### PR TITLE
Add missing .mtz and include .log file into mtz/pdb download archive

### DIFF
--- a/api/includes/pages/class.download.php
+++ b/api/includes/pages/class.download.php
@@ -262,8 +262,10 @@
                 } else {
                     if (!file_exists('/tmp/'.$this->arg('id').'_'.$type.'.tar.gz')) {
                         $a = new PharData('/tmp/'.$this->arg('id').'_'.$type.'.tar');
-                        $a->addFile($files[1], basename($files[1]));
-                        $a->addFile($files[1], basename($files[1]));
+                        foreach ($files as $f) {
+                            $a->addFile($f, basename($f));
+                        }
+                        $a->addFile($log_file, basename($log_file));
                         $a->compress(Phar::GZ);
 
                         unlink('/tmp/'.$this->arg('id').'_'.$type.'.tar');


### PR DESCRIPTION
Fixed duplicated .pdb file reference and included .log fine into archive for improved usability.