### PR TITLE
Add logical not in scan model validation

### DIFF
--- a/client/js/models/scanmodel.js
+++ b/client/js/models/scanmodel.js
@@ -45,7 +45,7 @@ define(['backbone'], function(Backbone) {
             },
             ARRAY: {
                 required: function() {
-                    return (this.get('START') || this.get('STOP') || this.get('STEP'))
+                    return !(this.get('START') || this.get('STOP') || this.get('STEP'))
                 },
                 pattern: 'array'
             },


### PR DESCRIPTION
Without the logical not, start:stop:step and array are either both required, or both can be empty. With the logical not, the correct behaviour is achieved: either start:stop:step or array are required.