### PR TITLE
MXSW-1040: Distinct multi-xia2 tab names with sweep numbers

### DIFF
--- a/api/includes/pages/class.dc.php
+++ b/api/includes/pages/class.dc.php
@@ -915,7 +915,10 @@
         function _dc_auto_processing($id) {
             global $ap_types;
         
-            $rows = $this->db->pq('SELECT apss.cchalf, apss.ccanomalous, apss.anomalous, dc.xbeam, dc.ybeam, api.refinedxbeam, api.refinedybeam, app.autoprocprogramid,app.processingcommandline as type, apss.ntotalobservations as ntobs, apss.ntotaluniqueobservations as nuobs, apss.resolutionlimitlow as rlow, apss.resolutionlimithigh as rhigh, apss.scalingstatisticstype as shell, apss.rmeasalliplusiminus as rmeas, apss.rmerge, apss.completeness, apss.anomalouscompleteness as anomcompleteness, apss.anomalousmultiplicity as anommultiplicity, apss.multiplicity, apss.meanioversigi as isigi, ap.spacegroup as sg, ap.refinedcell_a as cell_a, ap.refinedcell_b as cell_b, ap.refinedcell_c as cell_c, ap.refinedcell_alpha as cell_al, ap.refinedcell_beta as cell_be, ap.refinedcell_gamma as cell_ga 
+            $nswps = '(SELECT COUNT(api1.autoprocintegrationid)
+                FROM autoprocintegration api1
+                WHERE api1.autoprocprogramid =  app.autoprocprogramid) as nswps';
+            $rows = $this->db->pq("SELECT apss.cchalf, apss.ccanomalous, apss.anomalous, dc.xbeam, dc.ybeam, api.refinedxbeam, api.refinedybeam, app.autoprocprogramid, $nswps, app.processingcommandline as type, apss.ntotalobservations as ntobs, apss.ntotaluniqueobservations as nuobs, apss.resolutionlimitlow as rlow, apss.resolutionlimithigh as rhigh, apss.scalingstatisticstype as shell, apss.rmeasalliplusiminus as rmeas, apss.rmerge, apss.completeness, apss.anomalouscompleteness as anomcompleteness, apss.anomalousmultiplicity as anommultiplicity, apss.multiplicity, apss.meanioversigi as isigi, ap.spacegroup as sg, ap.refinedcell_a as cell_a, ap.refinedcell_b as cell_b, ap.refinedcell_c as cell_c, ap.refinedcell_alpha as cell_al, ap.refinedcell_beta as cell_be, ap.refinedcell_gamma as cell_ga 
                 FROM autoprocintegration api 
                 INNER JOIN autoprocscaling_has_int aph ON api.autoprocintegrationid = aph.autoprocintegrationid 
                 INNER JOIN autoprocscaling aps ON aph.autoprocscalingid = aps.autoprocscalingid 
@@ -923,7 +926,7 @@
                 INNER JOIN autoprocscalingstatistics apss ON apss.autoprocscalingid = aph.autoprocscalingid 
                 INNER JOIN autoprocprogram app ON api.autoprocprogramid = app.autoprocprogramid 
                 INNER JOIN datacollection dc ON api.datacollectionid = dc.datacollectionid
-                WHERE api.datacollectionid = :1 ORDER BY apss.scalingstatisticstype DESC', array($id));
+                WHERE api.datacollectionid = :1 ORDER BY apss.scalingstatisticstype DESC", array($id));
             
             $dts = array('cell_a', 'cell_b', 'cell_c', 'cell_al', 'cell_be', 'cell_ga');
             $dts2 = array('rlow', 'rhigh');
@@ -937,7 +940,11 @@
                     if ($k == 'TYPE') {
                         foreach ($ap_types as $id => $name) {
                             if (strpos($v, $id)) {
-                                $v = $name;
+                                if ($r['NSWPS'] > 1) {
+                                    $v = $r['NSWPS'].'xMulti'.$name;
+                                } else {
+                                    $v = $name;
+                                }
                                 break;
                             }
                         }


### PR DESCRIPTION
Label multi-xia2 auto processing tabs indicating number of integrated data sweeps e.g. 3xMultiXia2 3dii