### PR TITLE
Fix for LDAP authentication

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -37,8 +37,9 @@
 
 
     # ldap server, used for lookup and authentication (if using)
-    $ldap_server = 'altfed.cclrc.ac.uk';
-    $ldap_search = 'dc=fed,dc=cclrc,dc=ac,dc=uk';
+    # Update the ldap(s) prefix, hostname and search settings as required
+    $ldap_server = 'ldaps://ldap.example.com';
+    $ldap_search = 'ou=people,dc=example,dc=com';
 
     # Upload directory
     # - used for user image uploads

--- a/api/includes/class.auth-ldap.php
+++ b/api/includes/class.auth-ldap.php
@@ -10,16 +10,22 @@ class LDAPAuthentication extends AuthenticationBase implements Authentication {
 
     function authenticate($login, $password) {
         global $ldap_server;
+        global $ldap_search;
 
         $conn = ldap_connect($ldap_server);
 
         if ($conn) {
+            // Tested against LDAP version 3 (could add support for older versions here)
+            ldap_set_option($conn, LDAP_OPT_PROTOCOL_VERSION, 3);
+            
             try {
-                return ldap_bind($conn, $login, $password);
+                // testing with openldap indicates this call needs to use a correct
+                // DN syntax: "uid=<login>,ou=people,dc=example,dc=com"
+                return ldap_bind($conn, "uid=".$login.",".$ldap_search, $password);
 
-            // Coulnt bind
+            // Couldn't bind
             } catch (Exeption $e) {
-                return false
+                return false;
             }
         }
     }


### PR DESCRIPTION
Updates the api/includes/class.auth-ldap.php based on testing with openldap servers.

Main change is the ldap_bind call - concatenating the SynchWeb login value with the LDAP search string. 

Also updates api/config_sample.php with example values - showing the search syntax required.