### PR TITLE
Fixed bug with camera feeds not stopping after widget closes

### DIFF
--- a/client/js/views/status.js
+++ b/client/js/views/status.js
@@ -26,30 +26,42 @@ define(['marionette',
         ui: {
             status: 'div.status',
         },
-        
+
+        // Handler for the camera feed timeout function
+        timeoutHandler: undefined,
+        // Duration to leave camera feeds visible (in milliseconds)
+        timeoutDuration: 10*60*1000,
+
         toggleView: function() {
-            this.ui.status.slideToggle()
+            var self = this
             
-            if (this.ui.status.is(':visible')) {
-                this.pvs.show(new PVView({ bl: this.getOption('bl') }))
-                var self = this
-                this.$el.find('.webcam img').each(function(i,w) {
-                    var url = app.apiurl+'/image/cam/bl/'+self.getOption('bl')+'/n/'+i
-                    utils.sign({
-                        url: url,
-                        callback: function(resp) {
-                            $(w).attr('src', url+'?token='+resp.token)        
-                        }
+            this.ui.status.slideToggle('fast', 'swing', function() {
+                if (self.ui.status.is(':visible')) {
+                    self.pvs.show(new PVView({ bl: self.getOption('bl') }))
+                    self.$el.find('.webcam img').each(function(i,w) {
+                        var url = app.apiurl+'/image/cam/bl/'+self.getOption('bl')+'/n/'+i
+                        utils.sign({
+                            url: url,
+                            callback: function(resp) {
+                                $(w).attr('src', url+'?token='+resp.token)
+                            }
+                        })
                     })
-                    // $(w).attr('src', app.apiurl+'/image/cam/bl/'+self.getOption('bl')+'/n/'+i+'?prop='+app.prop)
-                })
-                
-            } else {
-                this.pvs.empty()
-                this.$el.find('.webcam img').each(function(i,w) {
-                    $(this).attr('src', '')
-                })
-            }
+                    // Set Timeout for x mins to close it 
+                    self.timeoutHandler = setTimeout(function() {
+                        self.toggleView()
+                    }, self.timeoutDuration)
+                } else {
+                    // If this is called before the timeout then cancel the timer
+                    if (self.timeoutHandler) {
+                        clearTimeout(self.timeoutHandler)
+                    }
+                    self.pvs.empty()
+                    self.$el.find('.webcam img').each(function(i,w) {
+                        $(w).attr('src', '')
+                    })
+                }
+            })
         }
         
     })


### PR DESCRIPTION
This changes the logic within the status element of the main data collections/activity stream.

It waits until the animation (slideToggle) is complete before making the test to see if the element is visible. This fixes the bug where the camera feeds would be open, even if the webcam view was collapsed.