### PR TITLE
Revert jquery-editable from npm to local vendor library

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,6 @@
     "jquery": "^1.12.4",
     "jquery-color": "^3.0.0-alpha.1",
     "jquery-flot-resize": "^1.0.0",
-    "jquery-jeditable": "^2.0.10",
     "jquery-touchswipe": "^1.6.19",
     "jquery-ui-timepicker-addon": "^1.5.5",
     "jquery-ui.combobox": "^1.0.7",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -74,10 +74,12 @@ module.exports = {
       // Hence the vendor magnific-popup has a dependency on our utils/xhrimage
       'jquery.mp': 'vendor/jquery/jquery.magnific-popup',
 
-      // jeditable provided by NPM.
-      'jquery.editable': 'jquery-jeditable/dist/jquery.jeditable.min',
-      'jquery.editable.datepicker': 'jquery-jeditable/dist/jquery.jeditable.datepicker.min',
-  
+      // jeditable can be provided by NPM (but only for jQuery 3.x). Does not work with our legacy jquery.
+      // 'jquery.editable': 'jquery-jeditable/dist/jquery.jeditable.min',
+      // 'jquery.editable.datepicker': 'jquery-jeditable/dist/jquery.jeditable.datepicker.min',
+      'jquery.editable': 'vendor/jquery/jquery.jeditable.min',
+      'jquery.editable.datepicker': 'vendor/jquery/jquery.jeditable.datepicker',
+
       // Jquery.color plugin also NPM package
       'jquery.color': 'jquery-color',
 


### PR DESCRIPTION
 Fixes inline date editing which does not work with npm version.