### PR TITLE
SCI-7442: Update big_ep pannel to include all downstream processing

### DIFF
--- a/api/src/Page/Image.php
+++ b/api/src/Page/Image.php
@@ -25,6 +25,7 @@ class Image extends Page
         public static $dispatch = array(array('/id/:id(/f/:f)(/n/:n)', 'get', '_xtal_image'),
                               array('/diff/id/:id(/f/:f)(/n/:n)', 'get', '_diffraction_image'),
                               array('/dimp/id/:id(/n/:n)', 'get', '_dimple_images'),
+                              array('/bigep/aid/:aid/ppl/:ppl', 'get', '_bigep_images'),
                               array('/di/id/:id(/thresh/:thresh)(/n/:n)', 'get', '_diffraction_viewer'),
                               array('/cam/bl/:bl(/n/:n)', 'get', '_forward_webcam'),
                               array('/oav/bl/:bl(/n/:n)', 'get', '_forward_oav'),
@@ -272,6 +273,33 @@ class Image extends Page
         }
         
 
+        # BigEP model images
+        function _bigep_images() {
+            
+            $img_names = array('autoSHARP' => 'autoSHARP_model.png',
+                'AutoSol' => 'AutoBuild_model.png',
+                'crank2' => 'crank2_model.png',
+                'AutoBuild' => 'AutoBuild_model.png',
+                'Crank2' => 'crank2_model.png'
+            );
+            $rows = $this->db->pq("SELECT appa.fileName, appa.filePath FROM AutoProcProgramAttachment appa
+                                         WHERE appa.autoProcProgramId = :1
+                                         AND appa.fileName = :2", array($this->arg('aid'), $img_names[$this->arg('ppl')]));
+            
+            if (!sizeof($rows)) return;
+            else $row = $rows[0];
+            $this->db->close();
+            
+            $im = $row['FILEPATH'] . '/' . $row['FILENAME'];
+            
+            if (file_exists($im)) {
+                $this->_browser_cache();
+                $this->app->contentType('image/png');
+                readfile($im);
+            }
+        }
+        
+        
         # ------------------------------------------------------------------------
         # Forward OAV to browser
         function _forward_oav() {

--- a/client/src/css/partials/_content.scss
+++ b/client/src/css/partials/_content.scss
@@ -697,24 +697,25 @@ ol.rounded {
              }
          }
 
-        .plot_shelx-XDS,
-        .plot_shelx-DIALS {
-            width: 45%;
-            height: 250px;
-            float: inherit;
-             
+        .bigep-images figure {
+            width: 15%;
+            float: left;
+            text-align: center;
+            font-family: sans-serif;
+            font-size: 1.5em;
+            margin: 0.5em;
+
             @media (max-width: $breakpoint-vsmall) {
-                height: 100px;
                 float: none;
-            }
-             
-            .legend {
-                > table {
-                    width: auto;
-                }
+                width: auto;
             }
         }
         
+        .bigep-images img {
+            width: 100%;
+            height: auto;
+        }
+
         .plot_dimple {
             width: 70%;
             float: right;

--- a/client/src/js/modules/dc/controller.js
+++ b/client/src/js/modules/dc/controller.js
@@ -87,7 +87,7 @@ define(['marionette', 'modules/dc/views/getdcview', 'modules/dc/views/imageviewe
       
       
     // Map / Model Viewer
-    mapmodelviewer: function(id, ty, dt, ppl) {
+    mapmodelviewer: function(id, aid, ty, ppl) {
         if (!ty) ty = 'dimple'
         var lookup = new ProposalLookup({ field: 'DATACOLLECTIONID', value: id })
         lookup.find({
@@ -99,7 +99,7 @@ define(['marionette', 'modules/dc/views/getdcview', 'modules/dc/views/imageviewe
                             {title: app.prop+'-'+dc.get('VN'), url: '/dc/visit/'+app.prop+'-'+dc.get('VN') },
                             { title: 'Map/Model Viewer' },
                             { title: dc.get('FILETEMPLATE') }])
-                        app.content.show(new MapModelViewer({ ty: ty, dt: dt, ppl: ppl, model: dc }))
+                        app.content.show(new MapModelViewer({ ty: ty, aid: aid, ppl: ppl, model: dc }))
                     },
                     error: function() {
                         app.bc.reset([bc, { title: 'Map/Model Viewer' }])

--- a/client/src/js/modules/dc/router.js
+++ b/client/src/js/modules/dc/router.js
@@ -6,7 +6,7 @@ define(['utils/lazyrouter'], function(LazyRouter) {
             'dc': 'dc_list',
             'dc(/visit/:visit)(/dcg/:dcg)(/page/:page)(/s/:search)(/ty/:ty)(/id/:id)(/pjid/:pjid)': 'dc_list',
             'dc/view/id/:id': 'di_viewer',
-            'dc/map/id/:id(/ty/:ty)(/dt/:dt)(/ppl/:ppl)': 'mapmodelviewer',
+            'dc/map/id/:id(/aid/:aid)(/ty/:ty)(/ppl/:ppl)': 'mapmodelviewer',
             'dc/rsv/id/:id': 'rsviewer',
             'dc/summary/visit/:visit': 'summary',
             'dc/apstatussummary/visit/:visit(/ty/:ty)': 'apstatussummary',

--- a/client/src/js/modules/dc/views/mapmodelview.js
+++ b/client/src/js/modules/dc/views/mapmodelview.js
@@ -60,8 +60,9 @@ define(['marionette',
           
             if (this.getOption('ty') == 'bigep') {
                 var map_url = app.apiurl+'/download/map/ty/'+this.getOption('ty')+
-                                         '/dt/'+this.getOption('dt')+'/ppl/'+this.getOption('ppl')+
+                                         '/ppl/'+this.getOption('ppl')+'/aid/'+this.getOption('aid')+
                                          '/id/'+this.model.get('ID')
+                console.log(map_url)
             } else {
                 var map_url = app.apiurl+'/download/map/ty/'+this.getOption('ty')+'/id/'+this.model.get('ID')
             }
@@ -139,7 +140,7 @@ define(['marionette',
         loadMapModel: function() {
             if (this.getOption('ty') == 'bigep') {
                 var pdb_url = app.apiurl+'/download/map/pdb/1/ty/'+this.getOption('ty')+
-                                         '/dt/'+this.getOption('dt')+'/ppl/'+this.getOption('ppl')+
+                                         '/ppl/'+this.getOption('ppl')+'/aid/'+this.getOption('aid')+
                                          '/id/'+this.model.get('ID')
             } else {
                 var pdb_url = app.apiurl+'/download/map/pdb/1/ty/'+this.getOption('ty')+'/id/'+this.model.get('ID')

--- a/client/src/js/templates/dc/dc_bigep.html
+++ b/client/src/js/templates/dc/dc_bigep.html
@@ -1,10 +1,13 @@
-<% if (typeof SETTINGS !== 'undefined') { %>
+<% _.each(AID, function(data, aid) { %>
+    <h2><%-data.TAG%></h2>
+    <% if (_.isEmpty(data.PROC)) { %>
+    <p>This processing task has failed</p>
+    <% } %>
+    <% if (!_.isEmpty(data.SETTINGS)) { %>
     <section class="bigep-settings">
-        <h2>Settings</h2>
         <table class="bepm_sets reflow">
             <thead>
                 <tr>
-                    <th>Processed</th>
                     <th>Anom. scatterer</th>
                     <th>Space group</th>
                     <th>Num. scatterers</th>
@@ -13,51 +16,51 @@
                     <th>Sequence</th>
                 </tr>
             </thead>
-            <% _.each(SETTINGS, function(ppl, key) { %>
-                <tr>
-                    <td><%-key%></td>
-                    <td><%-ppl.atom%></td>
-                    <td><%-ppl.spacegroup%></td>
-                    <td><%-ppl.nsites%></td>
-                    <td><%-ppl.dataset%></td>
-                    <td><%-ppl.compound%></td>
-                    <td><div class="bepm-seq seq"><%-ppl.sequence%></div></td>
-                </tr>
-            <% }) %>
+            <tr>
+                <td><%-data.SETTINGS.atom%></td>
+                <td><%-data.SETTINGS.spacegroup%></td>
+                <td><%-data.SETTINGS.nsites%></td>
+                <td><%-data.SETTINGS.dataset%></td>
+                <td><%-data.SETTINGS.compound%></td>
+                <td><div class="bepm-seq seq"><%-data.SETTINGS.sequence%></div></td>
+            </tr>
         </table>
     </section>
-<% } %>
-<% if (typeof SHELXC !== 'undefined') { %>
-    <% _.each(SHELXC.PLOTS, function(ppl, key) { %>
-        <section class="bigep-stats clearfix">
-            <h2><%-key%></h2>
-            <% if (typeof PROC !== 'undefined' && PROC.hasOwnProperty(key)) { %>
-            <section class="bigep-models clearfix">
-                <table class="bepm_stats bepm_stats2 reflow">
-                    <thead>
-                        <tr>
-                            <th>Pipeline</th>
-                            <th>Resid. / Frag / Max. Frag.</th>
-                            <th>Best MapCC (Resol.)</th>
-                            <th>&nbsp;</th>
-                        </tr>
-                    </thead>
-                    <% _.each(PROC[key], function(val, prop) { %>
+    <% } %>
+    <% if (!_.isEmpty(data.PROC)) { %>
+    <section class="bigep-stats clearfix">
+        <section class="bigep-models clearfix">
+                <p class="r downloads">
+                <a id="<%-aid%>-bigep-files>" class="apattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
+                </p>
+            <table class="bepm_stats bepm_stats2 reflow">
+                <thead>
                     <tr>
-                        <td><%-prop%></td>
-                        <td><%-val.RESID%> / <%-val.FRAGM%> / <%-val.MAXLEN%></td>
-                        <td><%-val.MAPCC%> (<%-val.MAPRESOL%>)</td>
-                        <td>
-                            <a class="view button" href="/dc/map/id/<%-DCID%>/ty/bigep/dt/<%-TAG%>/ppl/<%-prop%>"><i class="fa fa-search"></i> Map / Model Viewer</a> 
-                            <a class="dll button" href="<%-APIURL%>/download/bigep/id/<%-DCID%>/dt/<%-TAG%>/ppl/<%-prop%>"><i class="fa fa-download"></i> PDB/MTZ file</a> 
-                            <a class="view button logf" href="<%-APIURL%>/download/bigep/id/<%-DCID%>/dt/<%-TAG%>/ppl/<%-prop%>/log/1"><i class="fa fa-search"></i> Log file</a>
-                        </td>
+                        <th>Pipeline</th>
+                        <th>Resid. / Frag / Max. Frag.</th>
+                        <th>Best MapCC (Resol.)</th>
+                        <th>&nbsp;</th>
                     </tr>
-                    <% }) %>
-                </table>
-            </section>
-            <% } %>
-            <div class="plot_shelx-<%-key%>"></div>
+                </thead>
+                <% _.each(data.PROC, function(val, prop) { %>
+                <tr>
+                    <td><%-prop%></td>
+                    <td><%-val.RESID%> / <%-val.FRAGM%> / <%-val.MAXLEN%></td>
+                    <td><%-val.MAPCC%> (<%-val.MAPRESOL%>)</td>
+                </tr>
+                <% }) %>
+            </table>
         </section>
-    <% }) %>
-<% } %>
+        <section class="bigep-images">
+            <% _.each(data.PROC, function(val, prop) { %>
+                <figure>
+                <a href="/dc/map/id/<%-DCID%>/aid/<%-aid%>/ty/bigep/ppl/<%-prop%>" title="<%-prop%> model">
+                <img id="<%-aid%><%-prop%>-thumb" class="bigep-thumb" alt="<%-prop%> model" />
+                </a>
+                <figcaption><%-prop%></figcaption>
+                </figure>
+            <% }) %>
+        </section>
+    </section>
+    <% } %>
+<% }) %>


### PR DESCRIPTION
Updated BigEP panel that reads information from ProcessingJob and AutoProc tables and displays snapshots of the built models.
This change requires replacement of BigEP entries in config.php with
`"Big EP" => array('big_ep/', '', '', 'big_ep')`