### PR TITLE
feature/i03-374

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1116,7 +1116,7 @@ class Sample extends Page
                 if (array_key_exists($this->arg('sort_by'), $cols)) $order = $cols[$this->arg('sort_by')].' '.$dir;
             }
             
-            $rows = $this->db->paginate("SELECT /*distinct*/ $extc pr.concentrationtypeid, ct.symbol as concentrationtype, pr.componenttypeid, cmt.name as componenttype, CASE WHEN sequence IS NULL THEN 'No' ELSE 'Yes' END as hasseq, pr.proteinid, CONCAT(p.proposalcode,p.proposalnumber) as prop, pr.name,pr.acronym,pr.molecularmass,pr.global, IF(pr.externalid IS NOT NULL, 1, 0) as external, pr.density, count(php.proteinid) as pdbs
+            $rows = $this->db->paginate("SELECT /*distinct*/ $extc pr.concentrationtypeid, ct.symbol as concentrationtype, pr.componenttypeid, cmt.name as componenttype, CASE WHEN sequence IS NULL THEN 'No' ELSE 'Yes' END as hasseq, pr.proteinid, CONCAT(p.proposalcode,p.proposalnumber) as prop, pr.name,pr.acronym,pr.molecularmass,pr.global, IF(pr.externalid IS NOT NULL, 1, 0) as external, HEX(pr.externalid) as externalid, pr.density, count(php.proteinid) as pdbs
               /*,  count(distinct b.blsampleid) as scount, count(distinct dc.datacollectionid) as dcount*/ 
                                   FROM protein pr
                                   LEFT OUTER JOIN concentrationtype ct ON ct.concentrationtypeid = pr.concentrationtypeid

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -120,7 +120,7 @@ class Sample extends Page
                               'nodata' => '\d',
                               'notcompleted' => '\d',
 
-                              'externalid' => '\d',
+                              'external' => '\d',
 
                               'COMPONENTLATTICEID' => '\d+',
 
@@ -1074,7 +1074,7 @@ class Sample extends Page
                 array_push($args, $this->arg('type'));
             }
 
-            if ($this->has_arg('externalid')) {
+            if ($this->has_arg('external')) {
                 $where .= ' AND pr.externalid IS NOT NULL';
             }
             
@@ -1184,7 +1184,7 @@ class Sample extends Page
                 $where = '(pr.proposalid=:1 OR pr.global=1)';
             }
 
-            if ($this->has_arg('externalid')) {
+            if ($this->has_arg('external')) {
                 $where .= ' AND pr.externalid IS NOT NULL';
             }
 

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -120,7 +120,10 @@ class Sample extends Page
                               'nodata' => '\d',
                               'notcompleted' => '\d',
 
+                               // external is a flag to indicate this protein/sample has a user office system id
+                               // whereas externalid is the actual reference
                               'external' => '\d',
+                              'EXTERNALID' => '\w+',
 
                               'COMPONENTLATTICEID' => '\d+',
 
@@ -1376,14 +1379,15 @@ class Sample extends Page
             $cmt = $this->has_arg('COMPONENTTYPEID') ? $this->arg('COMPONENTTYPEID') : null;
             $global = $this->has_arg('GLOBAL') ? $this->arg('GLOBAL') : null;
             $density = $this->has_arg('DENSITY') ? $this->arg('DENSITY') : null;
+            $externalid = $this->has_arg('EXTERNALID') ? $this->arg('EXTERNALID') : null;
             
             $chk = $this->db->pq("SELECT proteinid FROM protein
               WHERE proposalid=:1 AND acronym=:2", array($this->proposalid, $this->arg('ACRONYM')));
             if (sizeof($chk)) $this->_error('That protein acronym already exists in this proposal');
 
-            $this->db->pq('INSERT INTO protein (proteinid,proposalid,name,acronym,sequence,molecularmass,bltimestamp,concentrationtypeid,componenttypeid,global,density) 
-              VALUES (s_protein.nextval,:1,:2,:3,:4,:5,CURRENT_TIMESTAMP,:6,:7,:8,:9) RETURNING proteinid INTO :id',
-              array($this->proposalid, $name, $this->arg('ACRONYM'), $seq, $mass, $ct, $cmt, $global, $density));
+            $this->db->pq('INSERT INTO protein (proteinid,proposalid,name,acronym,sequence,molecularmass,bltimestamp,concentrationtypeid,componenttypeid,global,density, externalid)
+              VALUES (s_protein.nextval,:1,:2,:3,:4,:5,CURRENT_TIMESTAMP,:6,:7,:8,:9,UNHEX(:10)) RETURNING proteinid INTO :id',
+              array($this->proposalid, $name, $this->arg('ACRONYM'), $seq, $mass, $ct, $cmt, $global, $density, $externalid));
             
             $pid = $this->db->id();
             

--- a/client/src/js/modules/samples/controller.js
+++ b/client/src/js/modules/samples/controller.js
@@ -173,6 +173,35 @@ define(['marionette',
         app.content.show(GetView.ProteinAdd.get(app.type))
     },
 
+    proteinclone: function(pid) {
+        app.loading()
+
+        var title = GetView.ProteinList.title(app.type)
+        var pbc = { title: title+'s', url: '/'+title.toLowerCase()+'s' }
+
+        var lookup = new ProposalLookup({ field: 'PROTEINID', value: pid })
+        lookup.find({
+            success: function() {
+                var protein = new Protein({ PROTEINID: pid })
+                protein.fetch({
+                    success: function() {
+                        app.bc.reset([pbc, { title: 'Clone '+title }])
+                        app.content.show(GetView.ProteinAdd.get(app.type, { model: protein }))
+                    },
+                    error: function() {
+                        app.bc.reset([pbc])
+                        app.message({ title: 'No such '+title, message: 'The specified '+title+' could not be found'})
+                    },
+                })
+            },
+
+            error: function() {
+                app.bc.reset([pbc])
+                app.message({ title: 'No such '+title, message: 'The specified '+title+' could not be found'})
+            }
+        })
+    },
+
   }
        
        

--- a/client/src/js/modules/samples/router.js
+++ b/client/src/js/modules/samples/router.js
@@ -20,6 +20,7 @@ define(['marionette', 'modules/samples/controller'], function(Marionette, c) {
       'proteins(/s/:s)(/page/:page)': 'proteinlist',
       'proteins/pid/:pid': 'proteinview',
       'proteins/add': 'proteinadd',
+      'proteins/pid/:pid/clone': 'proteinclone',
 
       'phases(/s/:s)(/page/:page)': 'proteinlist',
       'phases/pid/:pid': 'proteinview',

--- a/client/src/js/modules/samples/views/proteinadd.js
+++ b/client/src/js/modules/samples/views/proteinadd.js
@@ -12,15 +12,29 @@ define(['marionette', 'views/form',
 
         templateHelpers: function() {
             return {
-                IS_STAFF: app.staff
+                IS_STAFF: app.staff,
+                IS_CLONE: this.clone
             }
         },
         
         createModel: function() {
-            this.model = new Protein()
+            if (this.model) {
+                console.log("Passed protein to clone")
+                // Set the passed protein id to null to indicate this will be a new instance
+                this.model.set('PROTEINID', null)
+            } else {
+                // Normal New / Add Protein use case
+                this.model = new Protein()
+            }
         },
         
         ui: {
+            name: 'input[name=NAME]',
+            acronym: 'input[name=ACRONYM]',
+            sequence: 'textarea[name=SEQUENCE]',
+            mass: 'input[name=MOLECULARMASS]',
+
+            // Why the ^ character, bug???
             exist: 'select[name^=existing_pdb]',
             pdbf: 'input[name=new_pdb]',
             type: 'select[name=COMPONENTTYPEID]',
@@ -28,13 +42,18 @@ define(['marionette', 'views/form',
         },
         
         initialize: function(options) {
+            // If this page has been created as a clone option we will have a valid this.model
+            if (this.model) this.clone = true
+
             this.types = new ComponentTypes()
             this.types.fetch().done(this.updateTypes.bind(this))
 
             this.concs = new ConcentrationTypes()
             this.concs.fetch().done(this.updateConcs.bind(this))
 
-            this.pdbs = new PDBs()
+            // Get the PDBs associated with this protein
+            if (this.clone) this.pdbs = new PDBs(null, {pid: this.model.get('PROTEINID')})
+            else this.pdbs = new PDBs()
             this.pdbs.fetch().done(this.updatePDBs.bind(this))
         },
 
@@ -44,14 +63,29 @@ define(['marionette', 'views/form',
 
         updateTypes: function() {
             this.ui.type.html(this.types.opts({ empty: true }))
+            // Set them with our cloned value if we have one
+            if (this.model.get('COMPONENTTYPEID')) this.ui.type.val(this.model.get('COMPONENTTYPEID'))
         },
 
         updateConcs: function() {
             this.ui.conc.html(this.concs.opts({ empty: true }))
+            // Set them with our cloned value if we have one
+            if (this.model.get('CONCENTRATIONTYPEID')) this.ui.conc.val(this.model.get('CONCENTRATIONTYPEID'))
         },
 
         success: function(model, response, options) {
             console.log('success from protadd', this.model)
+            let newProtein = this.model
+            // Now if we are cloning, associate any existing PDBs with this protein
+            if (this.clone) {
+                this.pdbs.each(function(model, index, list) {
+                    model.set('PROTEINID', newProtein.get('PROTEINID'))
+                    model.set('PROTEINHASPDBID', null)
+                    model.set('existing_pdb', model.get('PDBID'))
+                    model.set('PDBID', null)
+                    model.save(model.changedAttributes())
+                })
+            }
             app.trigger('proteins:view', model.get('PROTEINID'))
         },
 
@@ -67,6 +101,13 @@ define(['marionette', 'views/form',
             if (json.message) app.alert({ message: json.message })
             else app.alert({ message: 'Something went wrong registering that protein' })
         },
+        onRender: function() {
+            console.log(this.ui.pdbf)
+            this.ui.name.val(this.model.get('NAME'))
+            this.ui.acronym.val(this.model.get('ACRONYM'))
+            this.ui.sequence.val(this.model.get('SEQUENCE'))
+            this.ui.mass.val(this.model.get('MOLECULARMASS'))
+        }
     })
 
 })

--- a/client/src/js/modules/samples/views/proteinview.js
+++ b/client/src/js/modules/samples/views/proteinview.js
@@ -84,7 +84,8 @@ define(['marionette',
         onRender: function() {
             var self = this
             var edit = new Editable({ model: this.model, el: this.$el })
-            edit.create('NAME', 'text')
+            // If this is protein is not from user office, allow changing name
+            if (this.model.get('EXTERNAL') == 0) edit.create('NAME', 'text')
             edit.create('ACRONYM', 'text')
             edit.create('SEQUENCE', 'markdown')
             edit.create('MOLECULARMASS', 'text')

--- a/client/src/js/modules/shipment/views/container.js
+++ b/client/src/js/modules/shipment/views/container.js
@@ -91,7 +91,7 @@ define(['marionette',
             
             this.proteins = new DistinctProteins()
             if (app.valid_samples) {
-                this.proteins.queryParams.externalid = 1
+                this.proteins.queryParams.external = 1
             }
             this.proteins.fetch()
 

--- a/client/src/js/modules/shipment/views/containeradd.js
+++ b/client/src/js/modules/shipment/views/containeradd.js
@@ -199,7 +199,7 @@ define(['backbone',
 
 
         limitProteins: function() {
-            this.proteins.queryParams.externalid = this.ui.imager.val() ? 1 : null
+            this.proteins.queryParams.external = this.ui.imager.val() ? 1 : null
             this.proteins.fetch()
 
             this.users.queryParams.login = this.ui.imager.val() ? 1 : null
@@ -527,7 +527,7 @@ define(['backbone',
             this.proteins = new DistinctProteins()
             // If we want to only allow valid samples
             if (app.valid_samples) {
-                this.proteins.queryParams.externalid = 1
+                this.proteins.queryParams.external = 1
             }
             this.ready.push(this.proteins.fetch())
 

--- a/client/src/js/templates/samples/protein.html
+++ b/client/src/js/templates/samples/protein.html
@@ -2,6 +2,8 @@
 
 <p class="help">This page shows details for the selected protein and a list of samples which make use of it</p>
 
+<a class="button" href="/proteins/pid/<%-PROTEINID%>/clone">Clone Protein</a>
+
 <div class="form">
     <ul>
         <li>

--- a/client/src/js/templates/samples/protein.html
+++ b/client/src/js/templates/samples/protein.html
@@ -2,7 +2,10 @@
 
 <p class="help">This page shows details for the selected protein and a list of samples which make use of it</p>
 
-<a class="button" href="/proteins/pid/<%-PROTEINID%>/clone">Clone Protein</a>
+<!-- Only allow cloning for valid/approved proteins -->
+<% if (EXTERNAL == 1) { %>
+    <a class="button" href="/proteins/pid/<%-PROTEINID%>/clone">Clone Protein</a>
+<% } %>
 
 <div class="form">
     <ul>

--- a/client/src/js/templates/samples/proteinadd.html
+++ b/client/src/js/templates/samples/proteinadd.html
@@ -1,4 +1,8 @@
-<h1>Add Protein</h1>
+<h1>New Protein</h1>
+
+<% if (IS_CLONE) { %>
+    <p class="help">This is a clone of a protein</p>
+<% } %>
 
 <form method="post" id="add_protein" enctype="multipart/form-data">
     
@@ -9,7 +13,13 @@
                 <label>Name
                     <span class="small">Name of the protein</span>
                 </label>
-                <span class="name"><input type="text" name="NAME" /></span>
+                <span class="name">
+                    <% if (IS_CLONE) { %>
+                        <input type="text" name="NAME" disabled>
+                    <% } else { %>
+                        <input type="text" name="NAME" />
+                    <% } %>
+                </span>
             </li>
             
             <li>


### PR DESCRIPTION
Adds the ability to clone proteins if the protein has a valid user office id.
Reuses Add Protein view.
Also takes away ability to edit the name - as requested in ticket for valid samples only; so users can easily associate clones/variants with the same protein name.
Preserves PDB associations.