### PR TITLE
url redirects for trailing slash and uppercase urls

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -67,6 +67,15 @@ function(Backbone, Marionette, _, $, HeaderView, SideBarView, DialogRegion, Logi
 
   app.parseQuery()
 
+  // Strip trailing forward slash sci-8800
+  if (location.href.endsWith('/')) {
+    location.href = location.href.replace(/\/+$/, '')
+  }
+
+  // Convert uppercase url to lowercase sci-8799
+  if (location.href.match(/[A-Z]/)) {
+    location.href = location.href.toLowerCase()
+  }
 
   // Allow the app to autoupdate itself when running
   app.checkForUpdate = function() {


### PR DESCRIPTION
This will remove any trailing slash and convert any uppercase characters to lowercase. I dont think we have any urls in synchweb with casing but need to check. Also if other sites populate visits in uppercase this may break things. Hopefully everyone uses lower case...