### PR TITLE
Support client zero-padding in sample name clone

### DIFF
--- a/client/src/js/modules/shipment/views/sampletable.js
+++ b/client/src/js/modules/shipment/views/sampletable.js
@@ -120,12 +120,14 @@ define(['marionette',
                 var name_base = this.model.get('NAME').replace(/\d+$/, '')
                 var name_regexp = new RegExp(name_base)
                 var similar = this.model.collection.filter(function(m) { return m.get('NAME').match(name_regexp) })
+                var no
                 if (similar.length) no = similar[similar.length-1].get('NAME').match(/\d+$/)
+                if (!no) no = []
 
-                if (no) no = no.length > 0 ? parseInt(no[0]) : 1
-                else no = 1
+                var no_pad = no.length > 0 ? no[0].length : 0
+                no = no.length > 0 ? parseInt(no[0]) : 1
 
-                newm.set('NAME', name_base+(no+1))
+                newm.set('NAME', name_base+((no+1).toString().padStart(no_pad, '0')))
                 newm.set('LOCATION', empty[0].get('LOCATION'))
 
                 empty[0].attributes = newm.attributes


### PR DESCRIPTION
If a sample name ends in a number that is zero-padded, preserve zero-padding when cloning it in the client.

For example, in the Shipments > [Shipment] > Add New Container view, when you click the Clone from First Sample button, if the name of the first sample is `Sample-01`, the generated sample names will be `Sample-02`, `Sample-03`, etc. instead of `Sample-2`, `Sample-3`, etc.