### PR TITLE
Fix Proposals breadcrumb: s/proposals/proposal/

### DIFF
--- a/client/src/js/modules/proposal/controller.js
+++ b/client/src/js/modules/proposal/controller.js
@@ -11,7 +11,7 @@ define(['underscore', 'marionette',
 ], function(_, Marionette, ProposalList, Proposals, Visits, VisitList, SAXSVisitList, GenVisitList) {
   var controller = {
     list: function(s, page) {
-      app.bc.reset([{ title: 'Proposals', url: '/proposals' }])
+      app.bc.reset([{ title: 'Proposals', url: '/proposal' }])
       app.loading()
       console.log('prop list')
         
@@ -24,7 +24,7 @@ define(['underscore', 'marionette',
     },
        
     visit_list: function(s, page) {
-        app.bc.reset([{ title: 'Proposals', url: '/proposals' },
+        app.bc.reset([{ title: 'Proposals', url: '/proposal' },
                       { title: 'Visits for '+app.prop }])
         app.loading()
         page = page ? parseInt(page) : 1


### PR DESCRIPTION
The Proposals breadcrumb link is broken since it links to `/proposals` when it should be `/proposal` (singular).