### PR TITLE
Change client page title from ISPyB to SynchWeb

### DIFF
--- a/client/src/js/views/header.js
+++ b/client/src/js/views/header.js
@@ -88,7 +88,7 @@ define(['marionette', 'backbone', 'templates/header.html'], function(Marionette,
         
         setTitle: function() {
             console.log('set title')
-            document.title = 'ISPyB » ' + this.bc.pluck('title').join(' » ')
+            document.title = 'SynchWeb » ' + this.bc.pluck('title').join(' » ')
         },
         
     })


### PR DESCRIPTION
While it's true that the underlying database schema is ISPyB, what the user really sees and uses is SynchWeb.  The API is a SynchWeb API, so SynchWeb is what a developer sees and uses as well.  To make this more clear, change ISPyB in the client page title to SynchWeb.

This may be a controversial change.  I think it's a good change to make, but I would understand if the maintainers do not agree.  If this PR is rejected, would you be willing, just for my own understanding, to very briefly explain the rationale behind keeping the ISPyB naming?  Thanks!