### PR TITLE
Allow dash in username

### DIFF
--- a/client/src/js/views/login.js
+++ b/client/src/js/views/login.js
@@ -14,7 +14,7 @@ define(['views/form',
         validation: {
             login: {
                 required: true,
-                pattern: 'word',
+                pattern: 'wwdash',
             },
 
             password: {


### PR DESCRIPTION
UNIX-like OSs allow a dash in the username, so allow a dash in the
username in the SynchWeb Login view.