### PR TITLE
Fix: Run selector not displaying for mobile devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,7 @@ sftp-config.json
 client/node_modules
 client/assets
 client/index.php
+client/dist
 
 api/config.php
+/api/vendor

--- a/client/src/js/modules/stats/views/beamline.js
+++ b/client/src/js/modules/stats/views/beamline.js
@@ -74,14 +74,11 @@ define(['marionette',
 
         },
 
-        popuateRuns: function() {
+        populateRuns: function() {
             this.ui.run.html(this.runs.opts())
 
-            var last
-            if (this.getOption('params')) {
-                var p = this.getOption('params')
-                if (p.run) last = p.run
-            } else last = this.runs.first().get('RUNID')
+            var params = this.getOption('params')
+            var last = params.run ? params.run : this.runs.first().get('RUNID')
 
             this.ui.run.val(last)
             this.changeRun()
@@ -152,7 +149,7 @@ define(['marionette',
 
         onRender: function() {
             this.first = true
-            $.when(this.ready).done(this.popuateRuns.bind(this))
+            $.when(this.ready).done(this.populateRuns.bind(this))
         },
 
         

--- a/client/src/js/templates/stats/beamline.html
+++ b/client/src/js/templates/stats/beamline.html
@@ -2,7 +2,7 @@
 
         <p class="help">This page shows statistics for the selected beamline. The plots below show each action and when they happened. Drag to zoom in on the plot. Click the refresh icon to reset the zoom level</p>
 
-        <div class="filter">
+        <div class="filter filter-nohide">
             <ul>
                 <li>Run: <select name="runid"></select></li>
             </ul>


### PR DESCRIPTION
#### What dies this PR do?
This PR fixes the issue with `beamline runs stats` drop-down selector not being visible on mobile devices