### PR TITLE
Gridinfo is now linked to dc and not dcg

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1609,7 +1609,7 @@ class DC extends Page
         function _grid_info() {
             $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked
                 FROM gridinfo g
-                INNER JOIN datacollection dc on dc.datacollectionid = g.datacollectionid
+                INNER JOIN datacollection dc on (dc.datacollectionid = g.datacollectionid) or (dc.datacollectiongroupid = g.datacollectiongroupid)
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid
                 WHERE g.datacollectionid = :1 ", array($this->arg('id')));
 

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1611,7 +1611,7 @@ class DC extends Page
                 FROM gridinfo g
                 INNER JOIN datacollection dc on (dc.datacollectionid = g.datacollectionid) or (dc.datacollectiongroupid = g.datacollectiongroupid)
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid
-                WHERE g.datacollectionid = :1 ", array($this->arg('id')));
+                WHERE dc.datacollectionid = :1 ", array($this->arg('id')));
 
             if (!sizeof($info)) $this->_output(array());
             else {

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -707,7 +707,7 @@ class DC extends Page
             $dct = $this->db->pq("SELECT dc.overlap, dc.blsampleid, dc.datacollectionid as id, dc.startimagenumber, dc.filetemplate, dc.imageprefix as imp, dc.datacollectionnumber as run, dc.imagedirectory as dir, s.visit_number, xrc.status as xrcstatus
                 FROM datacollection dc 
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
-                LEFT OUTER JOIN gridinfo gr ON gr.datacollectionid = dc.datacollectionid
+                LEFT OUTER JOIN gridinfo gr ON (gr.datacollectionid = dc.datacollectionid) OR (gr.datacollectiongroupid = dc.datacollectiongroupid)
                 LEFT OUTER JOIN xraycentringresult xrc ON xrc.gridinfoid = gr.gridinfoid
                 INNER JOIN blsession s ON s.sessionid = dcg.sessionid 
                 INNER JOIN proposal p ON p.proposalid = s.proposalid

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -340,7 +340,7 @@ class DC extends Page
             # Data collection group
             if ($this->has_arg('dcg') || $this->has_arg('PROCESSINGJOBID')) {
                 $count_field = 'dc.datacollectionid';
-                $fields = "count(distinct dca.datacollectionfileattachmentid) as dcac, count(distinct dcc.datacollectioncommentid) as dccc, 1 as dcc, smp.name as sample,smp.blsampleid, ses.visit_number as vn, dc.kappastart as kappa, dc.phistart as phi, dc.startimagenumber as si, dc.experimenttype as dct, dc.datacollectiongroupid as dcg, dc.runstatus, dc.beamsizeatsamplex as bsx, dc.beamsizeatsampley as bsy, dc.overlap, dc.flux, 1 as scon, 'a' as spos, 'a' as san, 'data' as type, dc.imageprefix as imp, dc.datacollectionnumber as run, dc.filetemplate, dc.datacollectionid as id, dc.numberofimages as ni, dc.imagedirectory as dir, dc.resolution, dc.exposuretime, dc.axisstart, dc.numberofimages as numimg, TO_CHAR(dc.starttime, 'DD-MM-YYYY HH24:MI:SS') as st, dc.transmission, dc.axisrange, dc.wavelength, dc.comments, 1 as epk, 1 as ein, dc.xtalsnapshotfullpath1 as x1, dc.xtalsnapshotfullpath2 as x2, dc.xtalsnapshotfullpath3 as x3, dc.xtalsnapshotfullpath4 as x4, dc.starttime as sta, dc.detectordistance as det, dc.xbeam, dc.ybeam, dc.chistart, 
+                $fields = "count(distinct dca.datacollectionfileattachmentid) as dcac, count(distinct dcc.datacollectioncommentid) as dccc, 1 as dcc, smp.name as sample,smp.blsampleid, ses.visit_number as vn, dc.kappastart as kappa, dc.phistart as phi, dc.startimagenumber as si, dcg.experimenttype as dct, dc.datacollectiongroupid as dcg, dc.runstatus, dc.beamsizeatsamplex as bsx, dc.beamsizeatsampley as bsy, dc.overlap, dc.flux, 1 as scon, 'a' as spos, 'a' as san, 'data' as type, dc.imageprefix as imp, dc.datacollectionnumber as run, dc.filetemplate, dc.datacollectionid as id, dc.numberofimages as ni, dc.imagedirectory as dir, dc.resolution, dc.exposuretime, dc.axisstart, dc.numberofimages as numimg, TO_CHAR(dc.starttime, 'DD-MM-YYYY HH24:MI:SS') as st, dc.transmission, dc.axisrange, dc.wavelength, dc.comments, 1 as epk, 1 as ein, dc.xtalsnapshotfullpath1 as x1, dc.xtalsnapshotfullpath2 as x2, dc.xtalsnapshotfullpath3 as x3, dc.xtalsnapshotfullpath4 as x4, dc.starttime as sta, dc.detectordistance as det, dc.xbeam, dc.ybeam, dc.chistart, 
                     dc.voltage,
                     dc.c2aperture,
                     dc.c2lens,
@@ -707,7 +707,7 @@ class DC extends Page
             $dct = $this->db->pq("SELECT dc.overlap, dc.blsampleid, dc.datacollectionid as id, dc.startimagenumber, dc.filetemplate, dc.imageprefix as imp, dc.datacollectionnumber as run, dc.imagedirectory as dir, s.visit_number, xrc.status as xrcstatus
                 FROM datacollection dc 
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
-                LEFT OUTER JOIN gridinfo gr ON gr.datacollectiongroupid = dc.datacollectiongroupid
+                LEFT OUTER JOIN gridinfo gr ON gr.datacollectionid = dc.datacollectionid
                 LEFT OUTER JOIN xraycentringresult xrc ON xrc.gridinfoid = gr.gridinfoid
                 INNER JOIN blsession s ON s.sessionid = dcg.sessionid 
                 INNER JOIN proposal p ON p.proposalid = s.proposalid
@@ -1609,9 +1609,9 @@ class DC extends Page
         function _grid_info() {
             $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked
                 FROM gridinfo g
-                INNER JOIN datacollection dc ON dc.datacollectiongroupid = g.datacollectiongroupid
+                INNER JOIN datacollection dc on dc.datacollectionid = g.datacollectionid
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid
-                WHERE dc.datacollectionid = :1 ", array($this->arg('id')));
+                WHERE g.datacollectionid = :1 ", array($this->arg('id')));
 
             if (!sizeof($info)) $this->_output(array());
             else {


### PR DESCRIPTION
To be coordinated with database (which has already been updated, but dont know if column has been populated)
This allows multiple grid scans to exist in a group => xray centring for example

I think this should suffice:
```
UPDATE GridInfo
INNER JOIN DataCollectionGroup ON DataCollectionGroup.datacollectiongroupid = GridInfo.datacollectiongroupid
INNER JOIN DataCollection ON DataCollection.datacollectiongroupid = DataCollectionGroup.datacollectiongroupid
SET GridInfo.datacollectionid = DataCollection.datacollectionid
WHERE GridInfo.datacollectionid IS NULL;
```