### PR TITLE
Add datacollection error log stats

### DIFF
--- a/client/src/js/modules/blstats/collections/errorlog.js
+++ b/client/src/js/modules/blstats/collections/errorlog.js
@@ -1,0 +1,19 @@
+define(['underscore', 'backbone', 'backbone.paginator'], function(_, Backbone, PageableCollection) {
+    
+  var Error = Backbone.Model.extend({
+      idAttribute: 'visit',
+      urlRoot: '/vstat/errors',
+  })
+    
+  return PageableCollection.extend({
+    model: Error,
+    mode: 'client',
+    url: '/vstat/errors',
+                                      
+    state: {
+      pageSize: 15,
+    },
+
+  })
+  
+})

--- a/client/src/js/modules/stats/views/errorlog.js
+++ b/client/src/js/modules/stats/views/errorlog.js
@@ -1,0 +1,78 @@
+define(['backbone', 'backgrid', 'marionette', 'views/table'], 
+    function(Backbone, Backgrid, Marionette, TableView) {
+
+    var PercentCell = Backgrid.Cell.extend({
+        render: function() {
+            console.log(this.column)
+            this.$el.text((this.model.get(
+                this.column.get('name'))/(this.column.get('total') 
+                    ? this.column.get('total')
+                    : this.model.get('total'))*100).toFixed(1)
+            )
+
+            return this
+        }
+    })
+
+    var MessagesCell = Backgrid.Cell.extend({
+        render: function() {
+            var columns = [
+                { name: 'message', label: 'Message', cell: 'string', editable: false },
+                { name: 'count', label: 'Count', cell: 'string', teditable: false },
+                { name: 'count', label: '%', cell: PercentCell, total: this.model.get('failed'), editable: false },
+            ]
+
+            var collection = new Backbone.Collection(this.model.get('messages'))
+            console.log('collection', collection, this.model)
+
+            var table = new TableView({ 
+                collection: collection, 
+                pages: false,
+                columns: columns, 
+                tableClass: 'messages', 
+                backgrid: { emptyText: 'No failure messages' } 
+            })
+
+            this.$el.html(table.render().$el)
+
+            return this
+        }
+    })
+
+    return Marionette.LayoutView.extend({
+        className: 'content',
+        template: _.template('<h1>Data Collection Errors</h1><div class="wrapper"></div>'),
+        regions: { wrap: '.wrapper' },
+
+        initialize: function(options) {
+            var columns = [
+                { name: 'type', label: 'DC Type', cell: 'string', editable: false },
+                { name: 'aborted', label: 'Aborted', cell: 'string', editable: false },
+                { name: 'aborted', label: '%', cell: PercentCell, editable: false },
+                { name: 'failed', label: 'Failed', cell: 'string', editable: false },
+                { name: 'failed', label: '%', cell: PercentCell, editable: false },
+                { name: 'total', label: 'Total', cell: 'string', editable: false },
+                { label: 'Messages', cell: MessagesCell, editable: false },
+            ]
+            
+            if (app.mobile()) {
+                _.each([], function(v) {
+                    columns[v].renderable = false
+                })
+            }
+            
+            this.table = new TableView({ 
+                collection: options.collection, 
+                columns: columns, 
+                tableClass: 'errors', 
+                loading: true, 
+                backgrid: { emptyText: 'No datacollection failures' } 
+            })
+        },
+                                          
+        onRender: function() {
+            this.wrap.show(this.table)
+        },
+    })
+
+})

--- a/client/src/js/modules/stats/views/errorlog.js
+++ b/client/src/js/modules/stats/views/errorlog.js
@@ -3,7 +3,6 @@ define(['backbone', 'backgrid', 'marionette', 'views/table'],
 
     var PercentCell = Backgrid.Cell.extend({
         render: function() {
-            console.log(this.column)
             this.$el.text((this.model.get(
                 this.column.get('name'))/(this.column.get('total') 
                     ? this.column.get('total')
@@ -14,6 +13,12 @@ define(['backbone', 'backgrid', 'marionette', 'views/table'],
         }
     })
 
+    var MessageCollection = Backbone.Collection.extend({
+        comparator: function(m) {
+            return -m.get('count')
+        },
+    })
+
     var MessagesCell = Backgrid.Cell.extend({
         render: function() {
             var columns = [
@@ -22,9 +27,7 @@ define(['backbone', 'backgrid', 'marionette', 'views/table'],
                 { name: 'count', label: '%', cell: PercentCell, total: this.model.get('failed'), editable: false },
             ]
 
-            var collection = new Backbone.Collection(this.model.get('messages'))
-            console.log('collection', collection, this.model)
-
+            var collection = new MessageCollection(this.model.get('messages'))
             var table = new TableView({ 
                 collection: collection, 
                 pages: false,

--- a/client/src/js/modules/types/gen/stats/views/visit.js
+++ b/client/src/js/modules/types/gen/stats/views/visit.js
@@ -7,9 +7,13 @@ define(['marionette',
         'modules/stats/views/hourlies',
         'modules/stats/views/ehc',
         'modules/stats/views/callout',
+
+        'modules/blstats/collections/errorlog',
+        'modules/stats/views/errorlog',
     
         'templates/types/gen/stats/visit.html'], function(Marionette, Faults, FaultListView,
         BreakdownView, DetailsView, PieView, HourliesView, EHCLogView, CalloutView,
+        ErrorLog, ErrorLogView,
         template) {
 
     return Marionette.LayoutView.extend({
@@ -23,6 +27,7 @@ define(['marionette',
             ehc: '.ehclogs',
             hrs: '.hrs',
             flt: '.faults',
+            errlog: '.errlog'
         },
         
         
@@ -39,6 +44,12 @@ define(['marionette',
             this.faults.fetch()
             
             this.flt.show(new FaultListView({ collection: this.faults, filters: false, search: false }))
+
+            this.errorlog = new ErrorLog()
+            this.errorlog.queryParams.visit = this.model.get('VISIT')
+            this.errorlog.fetch()
+
+            this.errlog.show(new ErrorLogView({ collection: this.errorlog }))
         },
     })
 

--- a/client/src/js/templates/types/gen/stats/visit.html
+++ b/client/src/js/templates/types/gen/stats/visit.html
@@ -18,6 +18,7 @@
             <div class="plot_container right hrs"></div>
         </div>
 
+        <div class="errlog"></div>
         <div class="faults"></div>
 
 


### PR DESCRIPTION
This adds a list of datacollection errors and the last line of the associate log to the visit stats view for none mx proposals