### PR TITLE
return a default value if rotationaxis is not set

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -374,7 +374,7 @@ class DC extends Page
                     d.numberofpixelsx as detectornumberofpixelsx,
                     d.numberofpixelsy as detectornumberofpixelsy,
                     ses.archived,
-                    dc.rotationaxis
+                    IFNULL(dc.rotationaxis, 'Omega') as rotationaxis
                     ";
                 $groupby = 'GROUP BY smp.name,smp.blsampleid,ses.visit_number,dc.kappastart,dc.phistart, dc.startimagenumber, dc.experimenttype, dc.datacollectiongroupid, dc.runstatus, dc.beamsizeatsamplex, dc.beamsizeatsampley, dc.overlap, dc.flux, dc.imageprefix, dc.datacollectionnumber, dc.filetemplate, dc.datacollectionid, dc.numberofimages, dc.imagedirectory, dc.resolution, dc.exposuretime, dc.axisstart, dc.numberofimages, TO_CHAR(dc.starttime, \'DD-MM-YYYY HH24:MI:SS\'), dc.transmission, dc.axisrange, dc.wavelength, dc.comments, dc.xtalsnapshotfullpath1, dc.xtalsnapshotfullpath2, dc.xtalsnapshotfullpath3, dc.xtalsnapshotfullpath4, dc.starttime, dc.detectordistance, dc.xbeam, dc.ybeam, dc.chistart';
                 // $this->db->set_debug(True);
@@ -424,7 +424,7 @@ class DC extends Page
                     max(d.numberofpixelsx) as detectornumberofpixelsx,
                     max(d.numberofpixelsy) as detectornumberofpixelsy,
                     max(ses.archived) as archived,
-                    max(dc.rotationaxis) as rotationaxis";
+                    IFNULL(max(dc.rotationaxis), 'Omega') as rotationaxis";
                 $groupby = "GROUP BY dc.datacollectiongroupid";
             }
 


### PR DESCRIPTION
With https://github.com/DiamondLightSource/SynchWeb/pull/103 we removed hardcoded omega axis, however some beamlines are not actually populating rotationaxis so need to set a default