### PR TITLE
sci-9352: sort containers by name on shipment page

### DIFF
--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -126,6 +126,7 @@ define(['marionette',
             Backbone.Validation.bind(this);
             
             this.dewarcontent = new Containers()
+            this.dewarcontent.setSorting('NAME')
             this.dewarhistory = new DewarHistory()
             this.dewartracking = new DewarTracking()
             this.dewars = new Dewars(null, { id: this.model.get('SHIPPINGID') })


### PR DESCRIPTION
bltimestamp is the same for containers in the shipment, guess there is an update trigger @KarlLevik ? Sort by name on shipment page instead