### PR TITLE
SCI-7442: Update big_ep panel to include all downstream processing

### DIFF
--- a/api/src/Database/Type/MySQL.php
+++ b/api/src/Database/Type/MySQL.php
@@ -421,6 +421,31 @@ class MySQL extends DatabaseParent implements DatabaseInterface
 
     }
 
+    // Union multiple queries that take the same arguments and return the same columns
+    // Query can optionally be wrapped, where :QUERY will be replaced with the inner query:
+    //  $wrapper = 'SELECT * FROM (:QUERY) GROUP BY id';
+    function union($queries, $args, $all=false, $wrapper=null) {
+        $nargs = sizeof($args);
+        $all_args = array();
+        $union_kw = $all ? 'UNION ALL' : 'UNION';
+        foreach ($queries as $i => &$query) {
+            $offset = $i * $nargs;
+            $query = preg_replace_callback('/\:(\d+)/', 
+                function($mat) use ($offset) {
+                    return ':'.(intval($mat[1]) + $offset);
+                }, 
+            $query);
+            $all_args = array_merge($all_args, $args);
+        }   
+
+        $union = implode("\n$union_kw\n", $queries);
+        if ($wrapper) {
+            $union = preg_replace('/:QUERY/', $union, $wrapper);
+        }
+
+        return $this->pq($union, $all_args);
+    }
+
     function set_explain($exp)
     {
 

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -718,8 +718,8 @@ class DC extends Page
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                 INNER JOIN blsession s ON s.sessionid = dcg.sessionid 
                 INNER JOIN proposal p ON p.proposalid = s.proposalid
-                INNER JOIN autoprocintegration api ON api.datacollectionid = dc.datacollectionid
-                INNER JOIN autoprocprogram app ON api.autoprocprogramid = app.autoprocprogramid
+                INNER JOIN processingjob pj ON pj.datacollectionid = dc.datacollectionid
+                INNER JOIN autoprocprogram app ON pj.processingjobid = app.processingjobid
                 WHERE $where", $ids);
 
             $db_status = array();
@@ -1254,7 +1254,7 @@ class DC extends Page
             $ap = array('Fast EP' => array('fast_ep', array('sad.mtz', 'sad_fa.pdb')),
                         'MrBUMP' => array('auto_mrbump', array('PostMRRefine.pdb', 'PostMRRefine.mtz')),
                         'Dimple' => array('fast_dp', array('dimple/final.pdb', 'dimple/final.mtz')),
-                        'Big EP' => array('shelxc', array('', ''))
+                        'Big EP' => array('big_ep', array('', ''))
                         );
             
             list($info) = $this->db->pq("SELECT dc.imageprefix as imp, dc.datacollectionnumber as run, dc.imagedirectory as dir, CONCAT(CONCAT(CONCAT(p.proposalcode, p.proposalnumber), '-'), s.visit_number) as vis
@@ -1264,7 +1264,6 @@ class DC extends Page
              INNER JOIN proposal p ON (p.proposalid = s.proposalid) 
              WHERE dc.datacollectionid=:1", array($id));
             
-            $this->db->close();
             $info['DIR'] = $this->ads($info['DIR']);
             $data = array();
             
@@ -1386,118 +1385,104 @@ class DC extends Page
 
                     # BigEP
                     } else if ($n == 'Big EP') {
-                        $this->_bigep_downstream($root, $data, $info);
+                        $this->_bigep_downstream($id, $root, $data, $info);
                     }
                    
                 }
                 
             }
-            
+            $this->db->close();
             $this->_output($data);
         }
 
 
-        function _bigep_downstream($root, &$data, $info) {
-            $sg_patterns = array('XDS' => 'xia2/3dii-run*',
-                                 'DIALS' => 'xia2/dials-run*');
-            
-            foreach ($sg_patterns as $name => $sgpt) {
-                $proc_paths = glob($root.$sgpt);
-                if (sizeof($proc_paths)) {
-                    foreach ($proc_paths as $i => $pth) {
-                        
-                        $dat = array('TYPE' => 'Big EP/'.$name.":".$i);
-                        
-                        # Read SHELXC logs
-                        $graph_patterns = array('CHISQ' => array('Chi-sq', 2),
-                                                'ISIGI' => array('<I/sig>', 2),
-                                                'DSIG' => array('<d"/sig>', 2),
-                                                'CC12' => array('CC(1/2)', 2),
-                                                'RESO' => array('Resl.', 3));
-                        $shx_logs = glob($pth.'/*_shelxc.log');
-                        if (sizeof($shx_logs)) {
-                            $shx_log = $shx_logs[0];
-                            if (file_exists($shx_log)) {
-                                $lst = explode("\n", file_get_contents($shx_log));
-                                $graphs = array();
-                                foreach ($lst as $l) {
-                                    foreach ($graph_patterns as $k => $gr) {
-                                        if (strpos($l, $gr[0]) == 1) {
-                                            $graphs[$k] = array_map('floatval', array_slice(preg_split('/\s+/', $l), $gr[1]));
-                                        }
-                                    }
-                                }
-                            }
-                            if ($graphs) {
-                                $dat['SHELXC']['PLOTS'][$name] = array();
+        function _bigep_downstream($id, $root, &$data, $info) {
+            $rows = $this->db->pq("SELECT app.autoProcProgramId, app.processingPrograms, app.processingJobId,
+                                             COALESCE(sel1.processingPrograms,
+                                             sel2.processingPrograms) as tabName,
+                                             appa.fileName, appa.filePath
+                                         FROM AutoProcProgramAttachment appa
+                                         INNER JOIN AutoProcProgram app ON app.autoProcProgramId = appa.autoProcProgramId
+                                         INNER JOIN ProcessingJob pj ON pj.processingJobId = app.processingJobId
+                                         LEFT OUTER JOIN (
+                                             SELECT
+                                                 pjp1.processingJobId,
+                                                 app1.autoprocprogramid,
+                                                 app1.processingPrograms
+                                             FROM
+                                                 AutoProcProgram app1
+                                             INNER JOIN ProcessingJobParameter pjp1 ON
+                                                 pjp1.parameterValue = app1.autoprocprogramid
+                                             INNER JOIN ProcessingJob pj1 ON
+                                                 pj1.processingJobId = pjp1.processingJobId
+                                             WHERE
+                                                 pjp1.parameterKey = 'ispyb_autoprocprogramid') sel1 ON
+                                             sel1.processingJobId = pj.processingJobId
+                                         LEFT OUTER JOIN (
+                                             SELECT
+                                                 pjp1.processingJobId,
+                                                 app.autoprocprogramid,
+                                                 app.processingPrograms
+                                             FROM
+                                                 AutoProcScaling aps
+                                             INNER JOIN ProcessingJobParameter pjp1 ON
+                                                 pjp1.parameterValue = aps.autoProcScalingId
+                                             INNER JOIN ProcessingJob pj1 ON
+                                                 pj1.processingJobId = pjp1.processingJobId
+                                             INNER JOIN AutoProc ap ON
+                                                 ap.autoProcId = aps.autoProcId
+                                             INNER JOIN AutoProcProgram app ON
+                                                 app.autoProcProgramId = ap.autoProcProgramId
+                                             WHERE
+                                                 pjp1.parameterKey = 'scaling_id') sel2 ON
+                                             sel2.processingJobId = pj.processingJobId
+                                         WHERE app.processingPrograms = 'big_ep'
+                                               AND pj.dataCollectionId = :1
+                                         ORDER BY
+                                               app.autoProcProgramId", array($id));
+            $dat = array('AID' => array());
+            foreach ($rows as $r) {
+                if (!array_key_exists($r['AUTOPROCPROGRAMID'], $dat['AID'])) {
+                    $idx = $r['AUTOPROCPROGRAMID'];
+                    $dat['AID'][$idx] = array('PROC' => array(), 'SETTINGS' => array());
+                    $dat['AID'][$idx]['TAG'] = strval(sizeof($dat['AID'])).": ".$r['TABNAME'];
+                }
+                $data_file = $r["FILEPATH"]."/".$r["FILENAME"];
+                if ($r["FILENAME"] == "big_ep_settings.json") {
+                    if (file_exists($data_file)) {
+                        $json_str = file_get_contents($data_file);
+                        $dat['AID'][$idx]['SETTINGS'] = json_decode($json_str, true);
+                    }
+                }
+                elseif ($r["FILENAME"] == "big_ep_model_ispyb.json") {
+                    if (file_exists($data_file)) {
+                        $json_str = file_get_contents($data_file);
+                        $json_data = json_decode($json_str, true);
+                        if (array_key_exists('pipeline', $json_data)) {
+                            $ppl = $json_data['pipeline'];
+                        } else {
+                            $ppl = basename(dirname($data_file));
+                        }
+                        foreach ( array('RESID' => array('total', 0),
+                            'FRAGM' => array('fragments', 0),
+                            'MAXLEN' => array('max', 0),
+                            'MAPCC' => array('mapcc', 2),
+                            'MAPRESOL' => array('mapcc_dmin', 2)) as $k => $v) {
+                            if (array_key_exists($v[0], $json_data)) {
+                                $dat['AID'][$idx]['PROC'][$ppl][$k] = number_format($json_data[$v[0]], $v[1]);
                             } else {
-                                continue;
+                                $dat['AID'][$idx]['PROC'][$ppl][$k] = null;
                             }
-                            foreach (array_keys($graph_patterns) as $k) {
-                                if ($k != 'RESO' and array_key_exists($k, $graphs)) {
-                                    $dat['SHELXC']['PLOTS'][$name][$k] = array();
-                                }
-                            }
-                            if (array_key_exists('RESO', $graphs)) {
-                                foreach ($graphs['RESO'] as $i => $r) {
-                                    foreach (array_keys($dat['SHELXC']['PLOTS'][$name]) as $k) {
-                                        if (array_key_exists($i, $graphs[$k])) {
-                                            array_push($dat['SHELXC']['PLOTS'][$name][$k], array(1.0/pow($r, 2), $graphs[$k][$i]));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        # Read model building results
-                        $bigep_patterns = array (
-                                'AUTOSHARP' => '/big_ep*/*/autoSHARP/',
-                                'AUTOBUILD' => '/big_ep*/*/AutoSol/',
-                                'CRANK2' => '/big_ep*/*/crank2/' 
-                        );
-                        preg_match('/\/xia2\/(3dii|dials)\-run\w*/', $pth, $sgmatch);
-                        $dtpt = 'big_ep/*'.$sgmatch[0];
-                        foreach ( array ('/processed',
-                                        '/tmp') as $loc ) {
-                            $settings_root = preg_replace ( '/' . $info ['VIS'] . '/', $info ['VIS'] . $loc, $info ['DIR'], 1 ) . $info ['IMP'] . '_' . $info ['RUN'] . '_' . '/' . $dtpt;
-                            $bigep_settings_glob = glob($settings_root.'/big_ep*/*/big_ep_settings.json');
-                            if (sizeof($bigep_settings_glob)) {
-                                preg_match('/\/big_ep\/(?P<tag>\w+)\/xia2\/(3dii|dials)\-run\w*/', $bigep_settings_glob[0], $tagmatch);
-                                $dat['TAG'] = $tagmatch['tag'];
-                                $bigep_settings_json = $bigep_settings_glob[0];
-                                $json_str = file_get_contents($bigep_settings_json);
-                                $dat['SETTINGS'][$name] = json_decode($json_str, true);
-                                break;
-                            }
-                        }
-                        foreach ( $bigep_patterns as $ppl => $pplpt ) {
-                            foreach ( array ('/processed', '/tmp' ) as $loc ) {
-                                $bigep_root = preg_replace ( '/' . $info ['VIS'] . '/', $info ['VIS'] . $loc, $info ['DIR'], 1 ) . $info ['IMP'] . '_' . $info ['RUN'] . '_' . '/' . $dtpt . $pplpt;
-                                $bigep_mdl_glob = glob($bigep_root.'big_ep_model_ispyb.json');
-                                if (sizeof($bigep_mdl_glob)) {
-                                    $bigep_mdl_json = $bigep_mdl_glob[0];
-                                    $json_str = file_get_contents($bigep_mdl_json);
-                                    $json_data = json_decode($json_str, true);
-                                    foreach ( array('RESID' => array('total', 0),
-                                                    'FRAGM' => array('fragments', 0),
-                                                   'MAXLEN' => array('max', 0),
-                                                    'MAPCC' => array('mapcc', 2),
-                                                 'MAPRESOL' => array('mapcc_dmin', 2)) as $k => $v) {
-                                        if (array_key_exists($v[0], $json_data)) {
-                                            $dat['PROC'][$name][$ppl][$k] = number_format($json_data[$v[0]], $v[1]);
-                                        } else {
-                                            $dat['PROC'][$name][$ppl][$k] = null;
-                                        }
-                                    }
-                                    break;
-                                }
-                            }
-                        }
-                        
-                        if (array_key_exists('PROC',$dat) && array_intersect(array_keys($dat['PROC']), array_keys($sg_patterns))) {
-                            array_push( $data, $dat );
                         }
                     }
                 }
+            }
+            if (!empty($dat['AID'])) {
+                foreach ($dat['AID'] as $idx => $v) {
+                    ksort($dat['AID'][$idx]['PROC'], SORT_NATURAL | SORT_FLAG_CASE);
+                }
+                $dat['TYPE'] =  'Big EP';
+                array_push( $data, $dat );
             }
         }
 

--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -27,9 +27,9 @@ class Download extends Page
                               'map' => '\d',
                               'validity' => '.*',
 
-                              'dt' => '\w+',
                               'ppl' => '\w+',
-
+                              'aid' => '\w+',
+            
                               'filetype' => '\w+',
                               'blsampleid' => '\d+',
                               'dcg' => '\d+',
@@ -42,7 +42,7 @@ class Download extends Page
                               );
 
 
-        public static $dispatch = array(array('/map(/pdb/:pdb)(/ty/:ty)(/dt/:dt)(/ppl/:ppl)(/id/:id)(/map/:map)', 'get', '_map'),
+        public static $dispatch = array(array('/map(/pdb/:pdb)(/ty/:ty)(/ppl/:ppl)(/aid/:aid)(/id/:id)(/map/:map)', 'get', '_map'),
                               array('/id/:id/aid/:aid(/log/:log)(/1)(/LogFiles/:LogFiles)(/archive/:archive)', 'get', '_auto_processing'),
                               array('/plots', 'get', '_auto_processing_plots'),
                               array('/ep/id/:id(/log/:log)', 'get', '_ep_mtz'),
@@ -51,7 +51,6 @@ class Download extends Page
                               array('/csv/visit/:visit', 'get', '_csv_report'),
                               array('/bl/visit/:visit/run/:run', 'get', '_blend_mtz'),
                               array('/sign', 'post', '_sign_url'),
-                              array('/bigep/id/:id/dt/:dt/ppl/:ppl(/log/:log)', 'get', '_bigep_mtz'),
                               array('/data/visit/:visit', 'get', '_download_visit'),
                               array('/attachments', 'get', '_get_attachments'),
                               array('/attachment/id/:id/aid/:aid', 'get', '_get_attachment'),
@@ -290,7 +289,7 @@ class Download extends Page
             $where = '';
 
             if ($this->has_arg('AUTOPROCPROGRAMID')) {
-                $where .= ' AND api.autoprocprogramid=:'.(sizeof($args)+1);
+                $where .= ' AND app.autoprocprogramid=:'.(sizeof($args)+1);
                 array_push($args, $this->arg('AUTOPROCPROGRAMID'));
             }
 
@@ -300,8 +299,8 @@ class Download extends Page
             }
 
             $rows = $this->db->pq("SELECT app.autoprocprogramid, appa.filename, appa.filepath, appa.filetype, appa.autoprocprogramattachmentid, dc.datacollectionid
-                FROM autoprocintegration api 
-                INNER JOIN autoprocprogram app ON api.autoprocprogramid = app.autoprocprogramid 
+                FROM autoprocprogram app
+                INNER JOIN processingjob pj on pj.processingjobid = app.processingjobid
                 INNER JOIN autoprocprogramattachment appa ON appa.autoprocprogramid = app.autoprocprogramid 
                 INNER JOIN datacollection dc ON dc.datacollectionid = api.datacollectionid
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
@@ -531,39 +530,6 @@ class Download extends Page
             $this->_mtzmap('MrBUMP');
         }
 
-        function _bigep_mtz() {
-            $bigep_patterns = array (
-                    'AUTOSHARP' => array( 'path' => 'big_ep*/*/autoSHARP/', 'log' => 'LISTautoSHARP.html'),
-                    'AUTOBUILD' => array( 'path' => 'big_ep*/*/AutoSol/', 'log' => 'phenix_autobuild.log'),
-                    'CRANK2' => array( 'path' => 'big_ep*/*/crank2/', 'log' => 'crank2.log')
-            );
-            $dt = strtoupper($this->arg('dt'));
-            $ppl = strtoupper($this->arg('ppl'));
-
-            $t = array();
-            $root_dirs = $this->_get_downstream_dir(array ('/processed', '/tmp'), 'big_ep/');
-            foreach ( $root_dirs as $loc ) {
-                $root_pattern = $loc . $dt . '/xia2/*/' . $bigep_patterns[$ppl]['path'];
-                $bigep_mdl_glob = glob($root_pattern);
-                if (sizeof($bigep_mdl_glob)) {
-                    $root = $bigep_mdl_glob[0];
-                    $bigep_mdl_json = $root.'big_ep_model_ispyb.json';
-                    if (file_exists($bigep_mdl_json)) {
-                        $json_str = file_get_contents($bigep_mdl_json);
-                        $json_data = json_decode($json_str, true);
-                        $mtz_pth = $this->_use_rel_path($bigep_patterns[$ppl]['path'], $json_data['mtz'], $root);
-                        $pdb_pth = $this->_use_rel_path($bigep_patterns[$ppl]['path'], $json_data['pdb'], $root);
-                        $t = array('files' => array($mtz_pth, $pdb_pth), 'log' => $root.$bigep_patterns[$ppl]['log']);
-                        $type = 'BigEP_'.$dt.'_'.$ppl;
-                        $this->_mtzmap_readfile($type, $t['files'], $t['log']);
-                        return;
-                    }
-                }
-            }
-            $this->_error('Cannot find Big EP model builing results file');
-        }
-
-
         function _mtzmap($type) {
             $types = array('MrBUMP' => array('root' => 'auto_mrbump/', 'files' => array('PostMRRefine.pdb', 'PostMRRefine.mtz'), 'log' => 'MRBUMP.log'),
                            'Dimple' => array('root' => 'fast_dp/dimple/', 'files' => array('final.pdb', 'final.mtz'), 'log' => 'screen.log'),
@@ -628,46 +594,34 @@ class Download extends Page
         # ------------------------------------------------------------------------
         # Return maps and pdbs for big_ep
         function _big_ep_map() {
-            $bigep_patterns = array (
-                    'AUTOSHARP' => 'big_ep*/*/autoSHARP/',
-                    'AUTOBUILD' => 'big_ep*/*/AutoSol/',
-                    'CRANK2' => 'big_ep*/*/crank2/'
+            $map_names = array('autoSHARP' => 'autoSHARP',
+                'AutoSol' => 'AutoSol',
+                'AutoBuild' => 'AutoSol',
+                'crank2' => 'Crank2',
+                'Crank2' => 'Crank2'
             );
-            $dt = strtoupper($this->arg('dt'));
-            $ppl = strtoupper($this->arg('ppl'));
+            $aid = $this->arg('aid');
+            $ppl = "%".$map_names[$this->arg('ppl')];
 
-            $root_dirs = $this->_get_downstream_dir(array ('/processed', '/tmp'), 'big_ep/');
-            foreach ( $root_dirs as $loc ) {
-                $root_pattern = $loc . $dt . '/xia2/*/' . $bigep_patterns[$ppl];
-                $bigep_mdl_glob = glob($root_pattern);
-                if (sizeof($bigep_mdl_glob)) {
-                    $root = $bigep_mdl_glob[0];
-                    $bigep_mdl_json = $root.'big_ep_model_ispyb.json';
-                    if (file_exists($bigep_mdl_json)) {
-                        $json_str = file_get_contents($bigep_mdl_json);
-                        $json_data = json_decode($json_str, true);
-
-                        if ($this->has_arg('pdb') && array_key_exists('pdb', $json_data)) {
-                            $out = $this->_use_rel_path($bigep_patterns[$ppl], $json_data['pdb'], $root);
-                        } elseif (array_key_exists('map', $json_data)) {
-                            $out = $this->_use_rel_path($bigep_patterns[$ppl], $json_data['map'], $root);
-                        } else {
-                            continue;
-                        }
-                        # Use relative path in case files were moved
-                        if (file_exists($out)) {
-                            break;
-                        } else {
-                            $pth_split = preg_split('`'.$bigep_patterns[$ppl].'`', $out);
-                            if (sizeof($pth_split)) {
-                                $pth_rel = array_pop($pth_split);
-                                $out = $root.$pth_rel;
-                                if (file_exists($out)) {
-                                    break;
-                                }
-                            }
-                        }
-                    }
+            $rows = $this->db->pq("SELECT appa.fileName, appa.filePath FROM AutoProcProgramAttachment appa
+                                         WHERE appa.autoProcProgramId = :1
+                                         AND appa.filePath LIKE :2
+                                         AND appa.fileName = :3", array($aid, $ppl, 'big_ep_model_ispyb.json'));
+            if (!sizeof($rows)) return;
+            else $row = $rows[0];
+            $this->db->close();
+            
+            $bigep_mdl_json = $row["FILEPATH"]."/".$row["FILENAME"];
+            if (file_exists($bigep_mdl_json)) {
+                $json_str = file_get_contents($bigep_mdl_json);
+                $json_data = json_decode($json_str, true);
+                
+                if ($this->has_arg('pdb') && array_key_exists('pdb', $json_data)) {
+                    $out = $json_data['pdb'];
+                } elseif (array_key_exists('map', $json_data)) {
+                    $out = $json_data['map'];
+                } else {
+                    continue;
                 }
             }
 

--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -298,14 +298,24 @@ class Download extends Page
                 array_push($args, $this->arg('AUTOPROCPROGRAMATTACHMENTID'));
             }
 
-            $rows = $this->db->pq("SELECT app.autoprocprogramid, appa.filename, appa.filepath, appa.filetype, appa.autoprocprogramattachmentid, dc.datacollectionid
-                FROM autoprocprogram app
-                INNER JOIN processingjob pj on pj.processingjobid = app.processingjobid
+            $rows = $this->db->union(array(
+                "SELECT app.autoprocprogramid, appa.filename, appa.filepath, appa.filetype, appa.autoprocprogramattachmentid, dc.datacollectionid
+                FROM autoprocintegration api 
+                INNER JOIN autoprocprogram app ON api.autoprocprogramid = app.autoprocprogramid 
                 INNER JOIN autoprocprogramattachment appa ON appa.autoprocprogramid = app.autoprocprogramid 
                 INNER JOIN datacollection dc ON dc.datacollectionid = api.datacollectionid
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                 INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-                WHERE s.proposalid=:1 $where", $args);
+                WHERE s.proposalid=:1 $where",
+                "SELECT app.autoprocprogramid, appa.filename, appa.filepath, appa.filetype, appa.autoprocprogramattachmentid, dc.datacollectionid
+                FROM autoprocprogram app
+                INNER JOIN processingjob pj on pj.processingjobid = app.processingjobid
+                INNER JOIN autoprocprogramattachment appa ON appa.autoprocprogramid = app.autoprocprogramid 
+                INNER JOIN datacollection dc ON dc.datacollectionid = pj.datacollectionid
+                INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
+                INNER JOIN blsession s ON s.sessionid = dcg.sessionid
+                WHERE s.proposalid=:1 $where"
+            ), $args);
 
             // exit();
             if ($this->has_arg('AUTOPROCPROGRAMATTACHMENTID')) {

--- a/api/src/Page/Image.php
+++ b/api/src/Page/Image.php
@@ -25,6 +25,7 @@ class Image extends Page
         public static $dispatch = array(array('/id/:id(/f/:f)(/n/:n)', 'get', '_xtal_image'),
                               array('/diff/id/:id(/f/:f)(/n/:n)', 'get', '_diffraction_image'),
                               array('/dimp/id/:id(/n/:n)', 'get', '_dimple_images'),
+                              array('/bigep/aid/:aid/ppl/:ppl', 'get', '_bigep_images'),
                               array('/di/id/:id(/thresh/:thresh)(/n/:n)', 'get', '_diffraction_viewer'),
                               array('/cam/bl/:bl(/n/:n)', 'get', '_forward_webcam'),
                               array('/oav/bl/:bl(/n/:n)', 'get', '_forward_oav'),
@@ -273,6 +274,33 @@ class Image extends Page
         }
         
 
+        # BigEP model images
+        function _bigep_images() {
+            
+            $img_names = array('autoSHARP' => 'autoSHARP_model.png',
+                'AutoSol' => 'AutoBuild_model.png',
+                'crank2' => 'crank2_model.png',
+                'AutoBuild' => 'AutoBuild_model.png',
+                'Crank2' => 'crank2_model.png'
+            );
+            $rows = $this->db->pq("SELECT appa.fileName, appa.filePath FROM AutoProcProgramAttachment appa
+                                         WHERE appa.autoProcProgramId = :1
+                                         AND appa.fileName = :2", array($this->arg('aid'), $img_names[$this->arg('ppl')]));
+            
+            if (!sizeof($rows)) return;
+            else $row = $rows[0];
+            $this->db->close();
+            
+            $im = $row['FILEPATH'] . '/' . $row['FILENAME'];
+            
+            if (file_exists($im)) {
+                $this->_browser_cache();
+                $this->app->contentType('image/png');
+                readfile($im);
+            }
+        }
+        
+        
         # ------------------------------------------------------------------------
         # Forward OAV to browser
         function _forward_oav() {

--- a/client/src/css/partials/_content.scss
+++ b/client/src/css/partials/_content.scss
@@ -697,24 +697,25 @@ ol.rounded {
              }
          }
 
-        .plot_shelx-XDS,
-        .plot_shelx-DIALS {
-            width: 45%;
-            height: 250px;
-            float: inherit;
-             
+        .bigep-images figure {
+            width: 15%;
+            float: left;
+            text-align: center;
+            font-family: sans-serif;
+            font-size: 1.5em;
+            margin: 0.5em;
+
             @media (max-width: $breakpoint-vsmall) {
-                height: 100px;
                 float: none;
-            }
-             
-            .legend {
-                > table {
-                    width: auto;
-                }
+                width: auto;
             }
         }
         
+        .bigep-images img {
+            width: 100%;
+            height: auto;
+        }
+
         .plot_dimple {
             width: 70%;
             float: right;

--- a/client/src/js/modules/dc/controller.js
+++ b/client/src/js/modules/dc/controller.js
@@ -87,7 +87,7 @@ define(['marionette', 'modules/dc/views/getdcview', 'modules/dc/views/imageviewe
       
       
     // Map / Model Viewer
-    mapmodelviewer: function(id, ty, dt, ppl) {
+    mapmodelviewer: function(id, aid, ty, ppl) {
         if (!ty) ty = 'dimple'
         var lookup = new ProposalLookup({ field: 'DATACOLLECTIONID', value: id })
         lookup.find({
@@ -99,7 +99,7 @@ define(['marionette', 'modules/dc/views/getdcview', 'modules/dc/views/imageviewe
                             {title: app.prop+'-'+dc.get('VN'), url: '/dc/visit/'+app.prop+'-'+dc.get('VN') },
                             { title: 'Map/Model Viewer' },
                             { title: dc.get('FILETEMPLATE') }])
-                        app.content.show(new MapModelViewer({ ty: ty, dt: dt, ppl: ppl, model: dc }))
+                        app.content.show(new MapModelViewer({ ty: ty, aid: aid, ppl: ppl, model: dc }))
                     },
                     error: function() {
                         app.bc.reset([bc, { title: 'Map/Model Viewer' }])

--- a/client/src/js/modules/dc/router.js
+++ b/client/src/js/modules/dc/router.js
@@ -6,7 +6,7 @@ define(['utils/lazyrouter'], function(LazyRouter) {
             'dc': 'dc_list',
             'dc(/visit/:visit)(/dcg/:dcg)(/page/:page)(/s/:search)(/ty/:ty)(/id/:id)(/pjid/:pjid)': 'dc_list',
             'dc/view/id/:id': 'di_viewer',
-            'dc/map/id/:id(/ty/:ty)(/dt/:dt)(/ppl/:ppl)': 'mapmodelviewer',
+            'dc/map/id/:id(/aid/:aid)(/ty/:ty)(/ppl/:ppl)': 'mapmodelviewer',
             'dc/rsv/id/:id': 'rsviewer',
             'dc/summary/visit/:visit': 'summary',
             'dc/apstatussummary/visit/:visit(/ty/:ty)': 'apstatussummary',

--- a/client/src/js/modules/dc/views/mapmodelview.js
+++ b/client/src/js/modules/dc/views/mapmodelview.js
@@ -60,8 +60,9 @@ define(['marionette',
           
             if (this.getOption('ty') == 'bigep') {
                 var map_url = app.apiurl+'/download/map/ty/'+this.getOption('ty')+
-                                         '/dt/'+this.getOption('dt')+'/ppl/'+this.getOption('ppl')+
+                                         '/ppl/'+this.getOption('ppl')+'/aid/'+this.getOption('aid')+
                                          '/id/'+this.model.get('ID')
+                console.log(map_url)
             } else {
                 var map_url = app.apiurl+'/download/map/ty/'+this.getOption('ty')+'/id/'+this.model.get('ID')
             }
@@ -139,7 +140,7 @@ define(['marionette',
         loadMapModel: function() {
             if (this.getOption('ty') == 'bigep') {
                 var pdb_url = app.apiurl+'/download/map/pdb/1/ty/'+this.getOption('ty')+
-                                         '/dt/'+this.getOption('dt')+'/ppl/'+this.getOption('ppl')+
+                                         '/ppl/'+this.getOption('ppl')+'/aid/'+this.getOption('aid')+
                                          '/id/'+this.model.get('ID')
             } else {
                 var pdb_url = app.apiurl+'/download/map/pdb/1/ty/'+this.getOption('ty')+'/id/'+this.model.get('ID')

--- a/client/src/js/templates/dc/dc_bigep.html
+++ b/client/src/js/templates/dc/dc_bigep.html
@@ -1,10 +1,13 @@
-<% if (typeof SETTINGS !== 'undefined') { %>
+<% _.each(AID, function(data, aid) { %>
+    <h2><%-data.TAG%></h2>
+    <% if (_.isEmpty(data.PROC)) { %>
+    <p>This processing task has failed</p>
+    <% } %>
+    <% if (!_.isEmpty(data.SETTINGS)) { %>
     <section class="bigep-settings">
-        <h2>Settings</h2>
         <table class="bepm_sets reflow">
             <thead>
                 <tr>
-                    <th>Processed</th>
                     <th>Anom. scatterer</th>
                     <th>Space group</th>
                     <th>Num. scatterers</th>
@@ -13,51 +16,51 @@
                     <th>Sequence</th>
                 </tr>
             </thead>
-            <% _.each(SETTINGS, function(ppl, key) { %>
-                <tr>
-                    <td><%-key%></td>
-                    <td><%-ppl.atom%></td>
-                    <td><%-ppl.spacegroup%></td>
-                    <td><%-ppl.nsites%></td>
-                    <td><%-ppl.dataset%></td>
-                    <td><%-ppl.compound%></td>
-                    <td><div class="bepm-seq seq"><%-ppl.sequence%></div></td>
-                </tr>
-            <% }) %>
+            <tr>
+                <td><%-data.SETTINGS.atom%></td>
+                <td><%-data.SETTINGS.spacegroup%></td>
+                <td><%-data.SETTINGS.nsites%></td>
+                <td><%-data.SETTINGS.dataset%></td>
+                <td><%-data.SETTINGS.compound%></td>
+                <td><div class="bepm-seq seq"><%-data.SETTINGS.sequence%></div></td>
+            </tr>
         </table>
     </section>
-<% } %>
-<% if (typeof SHELXC !== 'undefined') { %>
-    <% _.each(SHELXC.PLOTS, function(ppl, key) { %>
-        <section class="bigep-stats clearfix">
-            <h2><%-key%></h2>
-            <% if (typeof PROC !== 'undefined' && PROC.hasOwnProperty(key)) { %>
-            <section class="bigep-models clearfix">
-                <table class="bepm_stats bepm_stats2 reflow">
-                    <thead>
-                        <tr>
-                            <th>Pipeline</th>
-                            <th>Resid. / Frag / Max. Frag.</th>
-                            <th>Best MapCC (Resol.)</th>
-                            <th>&nbsp;</th>
-                        </tr>
-                    </thead>
-                    <% _.each(PROC[key], function(val, prop) { %>
+    <% } %>
+    <% if (!_.isEmpty(data.PROC)) { %>
+    <section class="bigep-stats clearfix">
+        <section class="bigep-models clearfix">
+                <p class="r downloads">
+                <a id="<%-aid%>-bigep-files>" class="apattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
+                </p>
+            <table class="bepm_stats bepm_stats2 reflow">
+                <thead>
                     <tr>
-                        <td><%-prop%></td>
-                        <td><%-val.RESID%> / <%-val.FRAGM%> / <%-val.MAXLEN%></td>
-                        <td><%-val.MAPCC%> (<%-val.MAPRESOL%>)</td>
-                        <td>
-                            <a class="view button" href="/dc/map/id/<%-DCID%>/ty/bigep/dt/<%-TAG%>/ppl/<%-prop%>"><i class="fa fa-search"></i> Map / Model Viewer</a> 
-                            <a class="dll button" href="<%-APIURL%>/download/bigep/id/<%-DCID%>/dt/<%-TAG%>/ppl/<%-prop%>"><i class="fa fa-download"></i> PDB/MTZ file</a> 
-                            <a class="view button logf" href="<%-APIURL%>/download/bigep/id/<%-DCID%>/dt/<%-TAG%>/ppl/<%-prop%>/log/1"><i class="fa fa-search"></i> Log file</a>
-                        </td>
+                        <th>Pipeline</th>
+                        <th>Resid. / Frag / Max. Frag.</th>
+                        <th>Best MapCC (Resol.)</th>
+                        <th>&nbsp;</th>
                     </tr>
-                    <% }) %>
-                </table>
-            </section>
-            <% } %>
-            <div class="plot_shelx-<%-key%>"></div>
+                </thead>
+                <% _.each(data.PROC, function(val, prop) { %>
+                <tr>
+                    <td><%-prop%></td>
+                    <td><%-val.RESID%> / <%-val.FRAGM%> / <%-val.MAXLEN%></td>
+                    <td><%-val.MAPCC%> (<%-val.MAPRESOL%>)</td>
+                </tr>
+                <% }) %>
+            </table>
         </section>
-    <% }) %>
-<% } %>
+        <section class="bigep-images">
+            <% _.each(data.PROC, function(val, prop) { %>
+                <figure>
+                <a href="/dc/map/id/<%-DCID%>/aid/<%-aid%>/ty/bigep/ppl/<%-prop%>" title="<%-prop%> model">
+                <img id="<%-aid%><%-prop%>-thumb" class="bigep-thumb" alt="<%-prop%> model" />
+                </a>
+                <figcaption><%-prop%></figcaption>
+                </figure>
+            <% }) %>
+        </section>
+    </section>
+    <% } %>
+<% }) %>


### PR DESCRIPTION
From irakli:

> Updated BigEP panel that reads information from ProcessingJob and AutoProc tables and displays snapshots of the built models.
This change requires replacement of BigEP entries in config.php with
"Big EP" => array('big_ep/', '', '', 'big_ep')

Unions results from autoproc integration and processingjob so will work with both.
Also add unions for autoproc messages so messages can be read for jobs that arent auto proc integration