### PR TITLE
Declare provenance when sending messages into Zocalo

### DIFF
--- a/api/src/Queue.php
+++ b/api/src/Queue.php
@@ -27,7 +27,8 @@ class Queue
                 $queue,
                 json_encode($message, JSON_UNESCAPED_SLASHES),
                 array(
-                    'persistent' => ($persistent === true)
+                    'persistent' => ($persistent === true),
+                    'source' => 'synchweb'
                 )
             );
 


### PR DESCRIPTION
Currently when messages are submitted via `dlstbx.go` [we identify the sending user and host in the message headers](https://github.com/DiamondLightSource/python-dlstbx/blob/393eab8b7f105150533858d443bc9c87d667f7e9/src/dlstbx/cli/go.py#L148-L149) to aid debugging:
```python
        {
            "dlstbx.go.user": getpass.getuser(),
            "dlstbx.go.host": socket.gethostname(),
        }
```

It would be great if Synchweb could do the same. I obviously have no clue what interesting and relevant information you could pass on. I suppose the logged on user and the hostname as `synchweb.user` and `synchweb.host` would be most useful.

Unfortunately I have no idea about the Synchweb internal structure and where to get that information, and my PHP skills are way out of date. Which is why in this PR I only make an absolute minimal change.