### PR TITLE
Filter out sub samples with source!=manual for now

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -589,7 +589,7 @@ class Sample extends Page
               LEFT OUTER JOIN autoprocscalingstatistics apss ON apss.autoprocscalingid = aph.autoprocscalingid
               LEFT OUTER JOIN autoprocprogram app ON app.autoprocprogramid = ap.autoprocprogramid AND app.processingstatus = 1
 
-              WHERE p.proposalid=:1 $where
+              WHERE p.proposalid=:1 AND ss.source='manual' $where
               GROUP BY pr.acronym, s.name, dp.experimentkind, dp.preferredbeamsizex, dp.preferredbeamsizey, dp.exposuretime, dp.requiredresolution, s.location, ss.diffractionplanid, pr.proteinid, ss.blsubsampleid, ss.blsampleid, ss.comments, ss.positionid, po.posx, po.posy, po.posz
               $having
               ORDER BY ss.blsubsampleid", $args);
@@ -968,7 +968,7 @@ class Sample extends Page
 
                                   LEFT OUTER JOIN blsampleimage si ON b.blsampleid = si.blsampleid
 
-                                  LEFT OUTER JOIN blsubsample ss ON b.blsubsampleid = ss.blsubsampleid
+                                  LEFT OUTER JOIN blsubsample ss ON b.blsubsampleid = ss.blsubsampleid AND ss.source='manual'
                                   LEFT OUTER JOIN blsample ssp ON ss.blsampleid = ssp.blsampleid
                                   
                                   

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1361,7 +1361,7 @@ class Shipment extends Page
                 INNER JOIN shipping sh ON sh.shippingid = d.shippingid
                 INNER JOIN proposal p ON p.proposalid = sh.proposalid
                 LEFT OUTER JOIN blsample s ON s.containerid = c.containerid 
-                LEFT OUTER JOIN blsubsample ss ON s.blsampleid = ss.blsampleid
+                LEFT OUTER JOIN blsubsample ss ON s.blsampleid = ss.blsampleid AND ss.source='manual'
                 LEFT OUTER JOIN crystal cr ON cr.crystalid = s.crystalid
                 LEFT OUTER JOIN protein pr ON pr.proteinid = cr.proteinid
                 LEFT OUTER JOIN containerinspection ci ON ci.containerid = c.containerid AND ci.state = 'Completed'
@@ -1427,7 +1427,7 @@ class Shipment extends Page
                                   INNER JOIN shipping sh ON sh.shippingid = d.shippingid 
                                   INNER JOIN proposal p ON p.proposalid = sh.proposalid 
                                   LEFT OUTER JOIN blsample s ON s.containerid = c.containerid 
-                                  LEFT OUTER JOIN blsubsample ss ON s.blsampleid = ss.blsampleid
+                                  LEFT OUTER JOIN blsubsample ss ON s.blsampleid = ss.blsampleid AND ss.source='manual'
                                   LEFT OUTER JOIN crystal cr ON cr.crystalid = s.crystalid
                                   LEFT OUTER JOIN protein pr ON pr.proteinid = cr.proteinid
                                   LEFT OUTER JOIN containerinspection ci ON ci.containerid = c.containerid AND ci.state = 'Completed'
@@ -1510,7 +1510,7 @@ class Shipment extends Page
                   INNER JOIN shipping sh ON sh.shippingid = d.shippingid
                   INNER JOIN proposal p ON p.proposalid = sh.proposalid
                   INNER JOIN containerqueuesample cqs ON cqs.blsubsampleid = ss.blsubsampleid
-                  WHERE p.proposalid=:1 AND c.containerid=:2 AND cqs.containerqueueid IS NULL", array($this->proposalid, $this->arg('CONTAINERID')));
+                  WHERE p.proposalid=:1 AND c.containerid=:2 AND cqs.containerqueueid IS NULL AND ss.source='manual'", array($this->proposalid, $this->arg('CONTAINERID')));
 
                 foreach ($samples as $s) {
                     $this->db->pq("UPDATE containerqueuesample SET containerqueueid=:1 WHERE containerqueuesampleid=:2", array($qid, $s['CONTAINERQUEUESAMPLEID']));


### PR DESCRIPTION
We are now (in theory at least) storing sub-samples that have been generated by CHiMP, but we currently don't have any UI for these. 

Therefore, for now let's just modify the relevant queries so they only select sub samples submitted by humans, i.e. `blsubsample.source='manual'`. 

Note that 'manual' is the default value for the column, and all the historical rows in the table have this value.