### PR TITLE
Make Beamline Status view handle empty GDA log

### DIFF
--- a/api/src/Page/Status.php
+++ b/api/src/Page/Status.php
@@ -159,7 +159,7 @@ class Status extends Page
                 fseek($file, -2, SEEK_CUR);
             }
 
-            if($line < $num_lines)
+            if($line < $num_lines && sizeof($lines) != 0)
                 $lines[$line] = implode('', array_reverse($lines[$line]));
             
             if ($this->has_arg('p')) $lines = array_slice($lines,$pp*($this->arg('p')-1),$pp);


### PR DESCRIPTION
When accessing the Beamline Status view, if the GDA log file is empty, an `Undefined offset: 0` exception is thrown from the API.  Fix this so that an empty GDA log file is handled correctly.