### PR TITLE
Update LDAP.php to support start_tls

### DIFF
--- a/api/src/Authentication/Type/LDAP.php
+++ b/api/src/Authentication/Type/LDAP.php
@@ -22,6 +22,7 @@ class LDAP extends AuthenticationParent implements AuthenticationInterface
         if ($conn) {
             // Tested against LDAP version 3 (could add support for older versions here)
             ldap_set_option($conn, LDAP_OPT_PROTOCOL_VERSION, 3);
+            ldap_start_tls($conn);
 
             try {
                 // testing with openldap indicates this call needs to use a correct


### PR DESCRIPTION
Add `ldap_start_tls` because my LDAP server requires a secure connection. This may break LDAP authentication with other LDAP configurations so perhaps it would be better to add start_tls = true/false to the config.php file and then do some sort of if/else switch in LDAP.php?