### PR TITLE
Enable triggering Zocalo/AlphaFold on adding new protein sequence

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -105,9 +105,9 @@
 
     # This is used to trigger Zocalo recipes on adding new Protein sequences
     # Set to empty string to disable
-    $on_add_protein_sequence_recipes = array(
+    $zocalo_recipes_on_add_protein_sequence = array(
         'trigger-alphafold',
-    )
+    );
 
     # Paths
     # - These map files to physical locations on disk

--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -95,9 +95,19 @@
     # Crystal alignment programs
     $strat_align = array('XOalign', 'dials.align_crystal');
 
-    # Active MQ - Set to empty string to disable
-    $activemq_server = 'tcp://activemq.server.ac.uk';
-    $activemq_rp_queue = '/queue/zocolo.name';
+    # Zocalo message broker credentials - Set to empty string to disable
+    $zocalo_server = 'tcp://activemq.server.ac.uk';
+    $zocalo_username = 'foo';
+    $zocalo_password = 'bar';
+
+    # Primary Zocalo entry point for recipe submission
+    $zocalo_mx_reprocess_queue = '/queue/zocolo.name';
+
+    # This is used to trigger Zocalo recipes on adding new Protein sequences
+    # Set to empty string to disable
+    $on_add_protein_sequence_recipes = array(
+        'trigger-alphafold',
+    )
 
     # Paths
     # - These map files to physical locations on disk

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -896,4 +896,28 @@ class Page
             return $root;
         }
 
+        function _execute_recipe($recipe, $parameters) {
+            global
+            $zocalo_server,
+            $zocalo_username,
+            $zocalo_password,
+            $zocalo_mx_reprocess_queue;
+
+            if (isset($zocalo_server) && isset($zocalo_mx_reprocess_queue)) {
+                // Send job to processing queue
+                $message = array(
+                    'recipes' => array(
+                        $recipe,
+                    ),
+                    'parameters' => $parameters,
+                );
+
+                try {
+                    $queue = new Queue($zocalo_server, $zocalo_username, $zocalo_password);
+                    $queue->send($zocalo_mx_reprocess_queue, $message, true, $this->user->login);
+                } catch (Exception $e) {
+                    $this->_error($e->getMessage(), 500);
+                }
+            }
+        }
     }

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -2,6 +2,7 @@
 
 namespace SynchWeb;
 
+use Exception;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use ReflectionClass;
@@ -9,6 +10,8 @@ use Slim\Slim;
 use xmlrpc_client;
 use xmlrpcmsg;
 use xmlrpcval;
+
+use SynchWeb\Queue;
 
 class Page
 {
@@ -896,28 +899,47 @@ class Page
             return $root;
         }
 
-        function _submit_zocalo_recipe($recipe, $parameters) {
-            global
-            $zocalo_server,
-            $zocalo_username,
-            $zocalo_password,
-            $zocalo_mx_reprocess_queue;
 
-            if (isset($zocalo_server) && isset($zocalo_mx_reprocess_queue)) {
+        function _submit_zocalo_recipe($recipe, $parameters, $error_code=500) {
+            global $zocalo_mx_reprocess_queue;
+
+            if (isset($zocalo_mx_reprocess_queue)) {
                 // Send job to processing queue
-                $message = array(
+                $zocalo_message = array(
                     'recipes' => array(
                         $recipe,
                     ),
                     'parameters' => $parameters,
                 );
+                $this->_send_zocalo_message($zocalo_mx_reprocess_queue, $zocalo_message, $error_code);
+            }
+        }
 
-                try {
-                    $queue = new Queue($zocalo_server, $zocalo_username, $zocalo_password);
-                    $queue->send($zocalo_mx_reprocess_queue, $message, true, $this->user->login);
-                } catch (Exception $e) {
-                    $this->_error($e->getMessage(), 500);
+
+        function _send_zocalo_message($zocalo_queue, $zocalo_message, $error_code=500) {
+            global
+            $zocalo_server,
+            $zocalo_username,
+            $zocalo_password;
+
+            if (empty($zocalo_server) || empty($zocalo_queue)) {
+                $message = 'Zocalo server or queue not specified.';
+                error_log($message);
+                if (isset($error_code)) {
+                    $this->_error($message, $error_code);
+                }
+            }
+
+            try {
+                error_log("Sending message"+$zocalo_message);
+                $queue = new Queue($zocalo_server, $zocalo_username, $zocalo_password);
+                $queue->send($zocalo_queue, $zocalo_message, true, $this->user->login);
+            } catch (Exception $e) {
+                $message = $e->getMessage();
+                error_log($message);
+                if (isset($error_code)) {
+                    $this->_error($message, $error_code);
                 }
             }
         }
-    }
+}

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -896,7 +896,7 @@ class Page
             return $root;
         }
 
-        function _execute_recipe($recipe, $parameters) {
+        function _submit_zocalo_recipe($recipe, $parameters) {
             global
             $zocalo_server,
             $zocalo_username,

--- a/api/src/Page/Process.php
+++ b/api/src/Page/Process.php
@@ -3,7 +3,6 @@
 namespace SynchWeb\Page;
 
 use SynchWeb\Page;
-use SynchWeb\Queue;
 
 class Process extends Page
 {
@@ -356,17 +355,7 @@ class Process extends Page
 
     function _enqueue()
     {
-        global $zocalo_server,
-               $zocalo_username,
-               $zocalo_password,
-               $zocalo_mx_reprocess_queue;
-
-        if (empty($zocalo_server) || empty($zocalo_mx_reprocess_queue)) {
-            $message = 'Zocalo server not specified.';
-
-            error_log($message);
-            $this->_error($message, 500);
-        }
+        global $zocalo_mx_reprocess_queue;
 
         if (!$this->has_arg('PROCESSINGJOBID')) $this->_error('No processing job specified');
 
@@ -385,19 +374,12 @@ class Process extends Page
         if (!sizeof($chk)) $this->_error('No such processing job');
 
         // Send job to processing queue
-
         $message = array(
             'parameters' => array(
                 'ispyb_process' => intval($this->arg('PROCESSINGJOBID')),
             )
         );
-
-        try {
-            $queue = new Queue($zocalo_server, $zocalo_username, $zocalo_password);
-            $queue->send($zocalo_mx_reprocess_queue, $message, true, $this->user->login);
-        } catch (Exception $e) {
-            $this->_error($e->getMessage(), 500);
-        }
+        $this->_send_zocalo_message($zocalo_mx_reprocess_queue, $message);
 
         $this->_output(new \stdClass);
     }

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -84,7 +84,7 @@ class Proposal extends Page
 
                                         array('/bls/:ty', 'get', '_get_beamlines'),
                                         array('/type', 'get', '_get_types'),
-                                        array('/lookup', 'get', '_lookup'),
+                                        array('/lookup', 'post', '_lookup'),
 
                                         array('/auto', 'get', '_auto_visit'),
                                         array('/auto', 'delete', '_close_auto_visit'),

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -84,7 +84,7 @@ class Proposal extends Page
 
                                         array('/bls/:ty', 'get', '_get_beamlines'),
                                         array('/type', 'get', '_get_types'),
-                                        array('/lookup', 'post', '_lookup'),
+                                        array('/lookup', 'get', '_lookup'),
 
                                         array('/auto', 'get', '_auto_visit'),
                                         array('/auto', 'delete', '_close_auto_visit'),

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1676,11 +1676,11 @@ class Sample extends Page
 
 
         function _on_add_protein_sequence($pid) {
-            global $on_add_protein_sequence_recipes;
-            if (!empty($on_add_protein_sequence_recipes)) {
+            global $zocalo_recipes_on_add_protein_sequence;
+            if (!empty($zocalo_recipes_on_add_protein_sequence)) {
                 $parameters = array('ispyb_protein_id' => $pid);
-                foreach($on_add_protein_sequence_recipes as $recipe){
-                    $this->_execute_recipe($recipe, $parameters);
+                foreach($zocalo_recipes_on_add_protein_sequence as $recipe){
+                    $this->_submit_zocalo_recipe($recipe, $parameters);
                 }
             }
         }

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1680,7 +1680,7 @@ class Sample extends Page
             if (!empty($zocalo_recipes_on_add_protein_sequence)) {
                 $parameters = array('ispyb_protein_id' => $pid);
                 foreach($zocalo_recipes_on_add_protein_sequence as $recipe){
-                    $this->_submit_zocalo_recipe($recipe, $parameters);
+                    $this->_submit_zocalo_recipe($recipe, $parameters, 500);
                 }
             }
         }

--- a/client/src/js/models/proplookup.js
+++ b/client/src/js/models/proplookup.js
@@ -16,7 +16,7 @@ define(['backbone'], function(Backbone) {
             var self = this
             this.fetch({
                 data: data,
-                type: 'GET',
+                type: 'POST',
 
                 success: function() {
                     app.cookie(self.get('PROP'), function() {

--- a/client/src/js/models/proplookup.js
+++ b/client/src/js/models/proplookup.js
@@ -16,7 +16,7 @@ define(['backbone'], function(Backbone) {
             var self = this
             this.fetch({
                 data: data,
-                type: 'POST',
+                type: 'GET',
 
                 success: function() {
                     app.cookie(self.get('PROP'), function() {


### PR DESCRIPTION
If a new protein is added with a sequence, or an existing protein is updated to add a sequence (where the sequence was previously NULL/empty), then submit Zocalo recipes defined by the `zocalo_recipes_on_add_protein_sequence` config variable.

Add a generic `_submit_zocalo_recipe()` function to the base `Page` class.
