### PR TITLE
[I15_1-1203] fix xpdf reuse of containers

### DIFF
--- a/client/src/js/modules/types/xpdf/shipment/views/containeradd.js
+++ b/client/src/js/modules/types/xpdf/shipment/views/containeradd.js
@@ -93,8 +93,7 @@ define([
             e.preventDefault()
 
             this.model.set({
-                NAME: this.ui.name[0].value,
-                BARCODE: this.ui.registry[0].options[this.ui.registry[0].options.selectedIndex].innerText,
+                NAME: this.ui.registry[0].options[this.ui.registry[0].options.selectedIndex].innerText,
                 CONTAINERREGISTRYID: this.ui.registry[0].value
             })
 

--- a/client/src/js/templates/types/xpdf/shipment/containeradd.html
+++ b/client/src/js/templates/types/xpdf/shipment/containeradd.html
@@ -29,11 +29,6 @@
             <select name="CONTAINERTYPE"></select>
         </li>
         <li>
-            <label>Stage Name</label>
-            <input type="text" name="NAME" />
-        </li>
-
-        <li>
             <label>Registered Container</label>
             <select name="CONTAINERREGISTRYID"></select> <span class="message"></span>
         </li>

--- a/client/src/js/templates/types/xpdf/shipment/containerview.html
+++ b/client/src/js/templates/types/xpdf/shipment/containerview.html
@@ -25,10 +25,6 @@
             <span class="label">Stage Type</span>
             <span><%-CONTAINERTYPE%></span>
         </li>
-        <li>
-            <span class="label">Barcode</span>
-            <span class="BARCODE"><%-BARCODE%></span>
-        </li>
         <% if (EXPERIMENTTYPE) { %>
         <li>
             <span class="label">Experiment Type</span>


### PR DESCRIPTION
the XPDF pages incorrectly set the barcode on the model and Container.barcode is a unique column, therefore precluding reusing a barcode. This fixes this by: 
- not setting the barcode on the model when a container is added
- removing the stage name field from the container add page (use the registry name instead)
- removing the barcode field from the container view page