### PR TITLE
draft: made sample_groups work for xpdf simple sample

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -2231,14 +2231,26 @@ class Sample extends Page
             array_push($args, $start);
             array_push($args, $end);
 
-            $rows = $this->db->paginate("SELECT bsg.blsamplegroupid, bsg.name, count(bshg.blsampleid) as samplegroupsamples, bshg.type, b.name as sample,  cr.crystalid, cr.name as crystal
+            /*$rows = $this->db->paginate("SELECT bsg.blsamplegroupid, bsg.name, count(bshg.blsampleid) as samplegroupsamples, bshg.type, b.name as sample,  cr.crystalid, cr.name as crystal
                 FROM blsample b
                 INNER JOIN blsamplegroup_has_blsample bshg ON bshg.blsampleid = b.blsampleid
                 INNER JOIN blsamplegroup bsg ON bshg.blsamplegroupid = bsg.blsamplegroupid
                 INNER JOIN crystal cr ON cr.crystalid = b.crystalid
-                WHERE $where
-                GROUP BY $group_by", $args);
-
+                WHERE $where", $args);
+                // GROUP BY $group_by", $args);
+            */
+            $rows = $this->db->paginate("SELECT bsg.blSampleGroupId, 
+                                                bsg.name, 
+                                                bshg.blSampleId as samplegroupsamples,
+                                                bshg.type, 
+                                                b.name as sample,  
+                                                cr.crystalId, 
+                                                cr.name as crystal 
+                                        FROM BLSample b 
+                                            INNER JOIN BLSampleGroup_has_BLSample bshg ON bshg.blSampleId = b.blSampleId 
+                                            INNER JOIN BLSampleGroup bsg ON bshg.blSampleGroupId = bsg.blSampleGroupId 
+                                            INNER JOIN Crystal cr ON cr.crystalId = b.crystalId  
+                                        WHERE $where", $args);
             $this->_output(array(
                 'total' => $tot,
                 'data' => $rows,

--- a/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
+++ b/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
@@ -307,20 +307,22 @@
             async fetchSampleGroupsAndAssignContainers() {
                 const existingSamples = new Set()
                 let lastCapillaryId = 0
+                let lastCapillaryGroupId = 0
 
                 const result = await this.$store.dispatch('fetchDataFromApi', {
                   url: '/sample/groups',
                 })
                 const sampleGroups = await this.$store.dispatch('fetchDataFromApi', {
-                  url: `/sample/groups?page=1&per_page=${result.total}`,
+                  url: `/sample/groups?page=1&per_page=9999`,
                 })
 
                 this.sampleGroups = sampleGroups.data
 
                 this.sampleGroups.forEach(sample => {
                     if (sample.TYPE === 'container' || sample.TYPE === 'capillary') {
-                        if (sample.BLSAMPLEGROUPID > lastCapillaryId) {
+                        if (parseInt(sample.BLSAMPLEGROUPID) > lastCapillaryGroupId) {
                             lastCapillaryId = sample.CRYSTALID
+                            lastCapillaryGroupId = parseInt(sample.BLSAMPLEGROUPID)
                         }
                         existingSamples.add(`${sample.CRYSTALID}:${sample.CRYSTAL}`)
                     }


### PR DESCRIPTION
for review! 
updated the sample_groups query to return data required for simple sample vue. Previously group by and count field limited the results: some groups returned with a type=sample and some groups had type=capillary. simple sample needs to see _all_ of the capillaries. 
The samplegroupsamples field in that query is definitely wrong, however - but maybe it can work if you conditionally add the  `count(bshg.blsampleid)` and the `GROUP BY $group_by"`? 