### PR TITLE
Further beamline templates

### DIFF
--- a/client/src/js/app/store/modules/store.menus.js
+++ b/client/src/js/app/store/modules/store.menus.js
@@ -17,6 +17,7 @@ import I20Menu from 'modules/types/i20/menu.js'
 import I12Menu from 'modules/types/i12/menu.js'
 import I13Menu from 'modules/types/i13/menu.js'
 import B24Menu from 'modules/types/b24/menu.js'
+import EpsicMenu from 'modules/types/epsic/menu.js'
 
 const menuStore = {
     namespaced: true,
@@ -41,6 +42,7 @@ const menuStore = {
         'i12': I12Menu,
         'i13': I13Menu,
         'b24': B24Menu,
+        'epsic': EpsicMenu,
       }
     }),
 

--- a/client/src/js/app/store/modules/store.menus.js
+++ b/client/src/js/app/store/modules/store.menus.js
@@ -14,7 +14,9 @@ import I08Menu from 'modules/types/i08/menu.js'
 import I11Menu from 'modules/types/i11/menu.js'
 import K11Menu from 'modules/types/k11/menu.js'
 import I20Menu from 'modules/types/i20/menu.js'
-
+import I12Menu from 'modules/types/i12/menu.js'
+import I13Menu from 'modules/types/i13/menu.js'
+import B24Menu from 'modules/types/b24/menu.js'
 
 const menuStore = {
     namespaced: true,
@@ -36,6 +38,9 @@ const menuStore = {
         'i11': I11Menu,
         'k11': K11Menu,
         'i20': I20Menu,
+        'i12': I12Menu,
+        'i13': I13Menu,
+        'b24': B24Menu,
       }
     }),
 

--- a/client/src/js/modules/dc/components/dc-wrapper.vue
+++ b/client/src/js/modules/dc/components/dc-wrapper.vue
@@ -43,7 +43,9 @@ import I08DCList from 'modules/types/i08/dc/datacollections'
 import I11DCList from 'modules/types/i11/dc/datacollections'
 import K11DCList from 'modules/types/k11/dc/datacollections'
 import I20DCList from 'modules/types/i20/dc/datacollections'
-
+import I12DCList from 'modules/types/i12/dc/datacollections'
+import I13DCList from 'modules/types/i13/dc/datacollections'
+import B24DCList from 'modules/types/b24/dc/datacollections'
 
 import DCCol from 'collections/datacollections'
 import Proposal from 'models/proposal'
@@ -66,6 +68,9 @@ let dc_views = {
   i11: I11DCList,
   k11: K11DCList,
   i20: I20DCList,
+  i12: I12DCList,
+  i13: I13DCList,
+  b24: B24DCList,
 }
 
 export default {

--- a/client/src/js/modules/dc/components/dc-wrapper.vue
+++ b/client/src/js/modules/dc/components/dc-wrapper.vue
@@ -46,6 +46,7 @@ import I20DCList from 'modules/types/i20/dc/datacollections'
 import I12DCList from 'modules/types/i12/dc/datacollections'
 import I13DCList from 'modules/types/i13/dc/datacollections'
 import B24DCList from 'modules/types/b24/dc/datacollections'
+import EpsicDCList from 'modules/types/epsic/dc/datacollections'
 
 import DCCol from 'collections/datacollections'
 import Proposal from 'models/proposal'
@@ -71,6 +72,7 @@ let dc_views = {
   i12: I12DCList,
   i13: I13DCList,
   b24: B24DCList,
+  epsic: EpsicDCList,
 }
 
 export default {

--- a/client/src/js/modules/types/b24/dc/datacollections.js
+++ b/client/src/js/modules/types/b24/dc/datacollections.js
@@ -1,0 +1,32 @@
+/**
+ * The view of all data collections for B24
+ * Copied directly from XPDF for easier pattern following
+ * See dc-wrapper.vue for mapping file to templates
+ */
+define([
+    'modules/dc/datacollections',
+    'modules/types/gen/dc/dclist',
+    'modules/types/xpdf/dc/dc',
+    'templates/types/xpdf/dc/dclist.html',
+    ], function(
+    DataCollections,
+    DCList,
+    DCItemView,
+    template) {
+
+    var XpdfDCList = DCList.extend({
+        dcViews: {
+            data: DCItemView,
+        },
+        apStatus: true,
+    })
+
+    return DataCollections.extend({
+        dcListView: XpdfDCList,
+        template: template,
+        filters: false,
+        sampleChanger: false,
+
+    })
+
+})

--- a/client/src/js/modules/types/b24/menu.js
+++ b/client/src/js/modules/types/b24/menu.js
@@ -1,0 +1,23 @@
+/**
+ * The menu specification for b24 pages
+ */
+
+define([], function() {
+
+    return {
+        menu: {
+            dc: 'View All Data',
+            visits: 'Visits',
+            contacts: 'Lab Contacts',
+        },
+
+        extra: {
+
+        },
+
+        admin: {
+
+        },
+    }
+
+})

--- a/client/src/js/modules/types/epsic/dc/datacollections.js
+++ b/client/src/js/modules/types/epsic/dc/datacollections.js
@@ -1,0 +1,32 @@
+/**
+ * The view of all data collections for epsic
+ * Copied directly from XPDF for easier pattern following
+ * See dc-wrapper.vue for mapping file to templates
+ */
+define([
+    'modules/dc/datacollections',
+    'modules/types/gen/dc/dclist',
+    'modules/types/xpdf/dc/dc',
+    'templates/types/xpdf/dc/dclist.html',
+    ], function(
+    DataCollections,
+    DCList,
+    DCItemView,
+    template) {
+
+    var XpdfDCList = DCList.extend({
+        dcViews: {
+            data: DCItemView,
+        },
+        apStatus: true,
+    })
+
+    return DataCollections.extend({
+        dcListView: XpdfDCList,
+        template: template,
+        filters: false,
+        sampleChanger: false,
+
+    })
+
+})

--- a/client/src/js/modules/types/epsic/menu.js
+++ b/client/src/js/modules/types/epsic/menu.js
@@ -1,0 +1,23 @@
+/**
+ * The menu specification for epsic pages
+ */
+
+define([], function() {
+
+    return {
+        menu: {
+            dc: 'View All Data',
+            visits: 'Visits',
+            contacts: 'Lab Contacts',
+        },
+
+        extra: {
+
+        },
+
+        admin: {
+
+        },
+    }
+
+})

--- a/client/src/js/modules/types/i12/dc/datacollections.js
+++ b/client/src/js/modules/types/i12/dc/datacollections.js
@@ -1,0 +1,32 @@
+/**
+ * The view of all data collections for I12
+ * Copied directly from XPDF for easier pattern following
+ * See dc-wrapper.vue for mapping file to templates
+ */
+define([
+    'modules/dc/datacollections',
+    'modules/types/gen/dc/dclist',
+    'modules/types/xpdf/dc/dc',
+    'templates/types/xpdf/dc/dclist.html',
+    ], function(
+    DataCollections,
+    DCList,
+    DCItemView,
+    template) {
+
+    var XpdfDCList = DCList.extend({
+        dcViews: {
+            data: DCItemView,
+        },
+        apStatus: true,
+    })
+
+    return DataCollections.extend({
+        dcListView: XpdfDCList,
+        template: template,
+        filters: false,
+        sampleChanger: false,
+
+    })
+
+})

--- a/client/src/js/modules/types/i12/menu.js
+++ b/client/src/js/modules/types/i12/menu.js
@@ -1,0 +1,23 @@
+/**
+ * The menu specification for i12 pages
+ */
+
+define([], function() {
+
+    return {
+        menu: {
+            dc: 'View All Data',
+            visits: 'Visits',
+            contacts: 'Lab Contacts',
+        },
+
+        extra: {
+
+        },
+
+        admin: {
+
+        },
+    }
+
+})

--- a/client/src/js/modules/types/i13/dc/datacollections.js
+++ b/client/src/js/modules/types/i13/dc/datacollections.js
@@ -1,0 +1,32 @@
+/**
+ * The view of all data collections for I13
+ * Copied directly from XPDF for easier pattern following
+ * See dc-wrapper.vue for mapping file to templates
+ */
+define([
+    'modules/dc/datacollections',
+    'modules/types/gen/dc/dclist',
+    'modules/types/xpdf/dc/dc',
+    'templates/types/xpdf/dc/dclist.html',
+    ], function(
+    DataCollections,
+    DCList,
+    DCItemView,
+    template) {
+
+    var XpdfDCList = DCList.extend({
+        dcViews: {
+            data: DCItemView,
+        },
+        apStatus: true,
+    })
+
+    return DataCollections.extend({
+        dcListView: XpdfDCList,
+        template: template,
+        filters: false,
+        sampleChanger: false,
+
+    })
+
+})

--- a/client/src/js/modules/types/i13/menu.js
+++ b/client/src/js/modules/types/i13/menu.js
@@ -1,0 +1,23 @@
+/**
+ * The menu specification for i13 pages
+ */
+
+define([], function() {
+
+    return {
+        menu: {
+            dc: 'View All Data',
+            visits: 'Visits',
+            contacts: 'Lab Contacts',
+        },
+
+        extra: {
+
+        },
+
+        admin: {
+
+        },
+    }
+
+})


### PR DESCRIPTION
Addition of (trivial xpdf extension) templates for i12, i13 and b24.

Moves the authorisation from the tomo_admin group to the appropriate staff group.
Template shows the scan_params json field and autoprocessing areas of the DC.