### PR TITLE
fix regex expressions for PCRE2 (i.e. for PHP >= 7.3)

### DIFF
--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -35,7 +35,7 @@ class Page
                                       'sort_by' => '\w+',
                                       'order' => 'desc|asc',
                                       'ty' => '\w+',
-                                      's' => '[\w\s-]+',
+                                      's' => '[\w\s\-]+',
                                       'prop' => '\w+\d+',
                                       );
 

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -9,7 +9,7 @@ class DC extends Page
 {
         
 
-        public static $arg_list = array('id' => '\d+', 'ids' => '\d+', 'visit' => '\w+\d+-\d+', 's' => '[\w\d-\/]+', 't' => '\w+', 'value' => '.*', 'sid' => '\d+', 'aid' => '\d+', 'pjid' => '\d+', 'imp' => '\d', 'pid' => '\d+', 'h' => '\d\d', 'dmy' => '\d\d\d\d\d\d\d\d',
+        public static $arg_list = array('id' => '\d+', 'ids' => '\d+', 'visit' => '\w+\d+-\d+', 's' => '[\w\d\-\/]+', 't' => '\w+', 'value' => '.*', 'sid' => '\d+', 'aid' => '\d+', 'pjid' => '\d+', 'imp' => '\d', 'pid' => '\d+', 'h' => '\d\d', 'dmy' => '\d\d\d\d\d\d\d\d',
                               'ssid' => '\d+',
                               'dcg' => '\d+',
                               'a' => '\d+(.\d+)?',

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -62,7 +62,7 @@ class Sample extends Page
                               'DENSITY' => '\d+(.\d+)?',
                               'THEORETICALDENSITY' => '\d+(.\d+)?',
 
-                              'NAME' => '[\w\s-()]+',
+                              'NAME' => '[\w\s\-()]+',
                               'COMMENTS' => '.*',
                               'SPACEGROUP' => '(\w|\s|\-|\/)+|^$', // Any word character (inc spaces bars and slashes) or empty string
                               'CELL_A' => '\d+(.\d+)?',


### PR DESCRIPTION
If you want to host SynchWeb on a web server running PHP >= 7.3 where the underlying regex libraries have changed from PCRE to PCRE2 then you will need the changes in this PR.

You can [read](https://php.watch/versions/7.3/pcre2) about the differences between PCRE and PCRE2 and what affect it may have on regex code.

This [utility](https://regex101.com) is a good one for helping evaluate regex.

I have fixed a few of the problematic expressions while hopefully retaining the intended behavior.
