### PR TITLE
[LIMS-130]Fix: optional local contact for dispatch

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -46,7 +46,7 @@ class Shipment extends Page
                               'DEWARREGISTRYID' => '\d+',
 
                               'BARCODE' => '([\w-])+',
-                              'LOCATION' => '[\w|\s|-]*',
+                              'LOCATION' => '[\w|\s|-]+',
                               'NEXTLOCATION' => '\w+|^(?![\s\S])',
                               'STATUS' => '[\w|\s|-]+',
 
@@ -60,7 +60,7 @@ class Shipment extends Page
                               'FAMILYNAME' => '.*',
                               'GIVENNAME' => '.*',
                               'LABNAME' => '.*',
-                              'LOCALCONTACT' => '[\w|\s+|-]*',
+                              'LOCALCONTACT' => '[\w|\s+|-]+',
                               'NEXTLOCALCONTACT' => '\w+|^(?![\s\S])',
                               'PHONENUMBER' => '.*',
                               'VISIT' => '\w+\d+-\d+',
@@ -824,7 +824,7 @@ class Shipment extends Page
             // If no location specified (i.e. deleted), then read from dewar transport history.
             // If no dewar transport history fall back to dewar location
             // We still update history based on provided location to record action from user
-            $dewar_location = $this->arg('LOCATION');
+            $dewar_location = $this->has_arg('LOCATION)') ? $this->arg('LOCATION') : "";
 
             if (empty($dewar_location)) {
               // What was the last history entry for this dewar?
@@ -860,10 +860,11 @@ class Shipment extends Page
 
             // If a local contact is given, try to find their email address
             // First try LDAP, if unsuccessful look at the ISPyB person record for a matching staff user
-            if ($this->args['LOCALCONTACT']) {
-                $this->args['LCEMAIL'] = $this->_get_email_fn($this->arg('LOCALCONTACT'));
+            $local_contact = $this->has_arg('LOCALCONTACT') ? $this->args['LOCALCONTACT'] : '';
+            if ($local_contact) {
+                $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
                 if (!$this->args['LCEMAIL']) {
-                    $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($this->args['LOCALCONTACT']);
+                    $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
                 }
             }
 
@@ -874,7 +875,8 @@ class Shipment extends Page
             $email->data = $data;
 
             $recpts = $dispatch_email.', '.$this->arg('EMAILADDRESS');
-            if ($this->args['LCEMAIL']) $recpts .= ', '.$this->args['LCEMAIL'];
+            $local_contact_email = $this->has_arg('LCEMAIL') ? $this->args['LCEMAIL'] : '';
+            if ($local_contact_email) $recpts .= ', '.$local_contact_email;
 
             $email->send($recpts);
 

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -890,6 +890,9 @@ class Shipment extends Page
             if (!array_key_exists('FACILITYCODE', $data)) $data['FACILITYCODE'] = '';
             if (!array_key_exists('AWBNUMBER', $data)) $data['AWBNUMBER'] = '';
             if (!array_key_exists('DELIVERYAGENT_AGENTCODE', $data)) $data['DELIVERYAGENT_AGENTCODE'] = '';
+            if (!array_key_exists('LOCATION', $data)) $data['LOCATION'] = $dewar_location;
+            if (!array_key_exists('LOCALCONTACT', $data)) $data['LOCALCONTACT'] = $local_contact;
+            if (!array_key_exists('LCEMAIL', $data)) $data['LCEMAIL'] = '';
             $email->data = $data;
 
             $recpts = $dispatch_email.', '.$this->arg('EMAILADDRESS');

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -46,7 +46,7 @@ class Shipment extends Page
                               'DEWARREGISTRYID' => '\d+',
 
                               'BARCODE' => '([\w-])+',
-                              'LOCATION' => '[\w|\s|-]+',
+                              'LOCATION' => '[\w|\s|-]*',
                               'NEXTLOCATION' => '\w+|^(?![\s\S])',
                               'STATUS' => '[\w|\s|-]+',
 
@@ -60,7 +60,7 @@ class Shipment extends Page
                               'FAMILYNAME' => '.*',
                               'GIVENNAME' => '.*',
                               'LABNAME' => '.*',
-                              'LOCALCONTACT' => '[\w|\s+|-]+',
+                              'LOCALCONTACT' => '[\w|\s+|-]*',
                               'NEXTLOCALCONTACT' => '\w+|^(?![\s\S])',
                               'PHONENUMBER' => '.*',
                               'VISIT' => '\w+\d+-\d+',
@@ -858,12 +858,13 @@ class Shipment extends Page
             $subject_line = '*** Dispatch requested for Dewar '.$dew['BARCODE'].' from '.$dispatch_from_location.' - Pickup Date: '.$this->args['DELIVERYAGENT_SHIPPINGDATE'].' ***';
             $email = new Email('dewar-dispatch', $subject_line);
 
-            $this->args['LCEMAIL'] = $this->_get_email_fn($this->arg('LOCALCONTACT'));
-
-            // LDAP email search does not always provide a match
-            // So look at the ISPyB person record for a matching staff user
-            if (!$this->args['LCEMAIL'] && $this->args['LOCALCONTACT']) {
-              $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($this->args['LOCALCONTACT']);
+            // If a local contact is given, try to find their email address
+            // First try LDAP, if unsuccessful look at the ISPyB person record for a matching staff user
+            if ($this->args['LOCALCONTACT']) {
+                $this->args['LCEMAIL'] = $this->_get_email_fn($this->arg('LOCALCONTACT'));
+                if (!$this->args['LCEMAIL']) {
+                    $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($this->args['LOCALCONTACT']);
+                }
             }
 
             $data = $this->args;

--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -11,7 +11,7 @@ define(['backbone'], function(Backbone) {
         },
 
         LOCATION: {
-            required: true,
+            required: false,
             pattern: 'wwsdash'
         },
 
@@ -21,7 +21,7 @@ define(['backbone'], function(Backbone) {
         },
 
         LOCALCONTACT: {
-            required: true,
+            required: false,
             pattern: 'wwsdash'
         },
 

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -36,14 +36,14 @@
                 <label>Local Contact
                     <span class="small">Beamline local contact</span>
                 </label>
-                <input type="text" name="LOCALCONTACT" />
+                <input type="text" name="LOCALCONTACT" disabled="disabled"/>
             </li>
 
             <li>
                 <label>Dewar Location
                     <span class="small">Where the dewar currently is</span>
                 </label>
-                <input type="text" name="LOCATION" />
+                <input type="text" name="LOCATION"/>
             </li>
 
 


### PR DESCRIPTION
**JIRA ticket:** [LIMS-130](https://jira.diamond.ac.uk/browse/LIMS-130)

**Changes:**
- Make local contact and Dewar location optional fields of the Dewar dispatch form.
- Make the local contact field read-only

**To test:**
- Check that the form can be submitted both with and without the local contact and dewar location fields populated
- Check that the dispatch email(s) are sent correctly in all cases