### PR TITLE
[LIMS-80]Feature: Tidy responsive scheduling questions

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -85,15 +85,13 @@ class Shipment extends Page
                               'DYNAMIC' => '1?',
                               'REMOTEORMAILIN' => '.*',
                               'SESSIONLENGTH' => '\w+',
-                              'ENERGY' => '\w+',
+                              'ENERGY' => '.*',
                               'MICROFOCUSBEAM' => '1?|Yes|No',
                               'SCHEDULINGRESTRICTIONS' => '.*',
                               'LASTMINUTEBEAMTIME' => '1?|Yes|No',
                               'DEWARGROUPING' => '.*',
                               'ENCLOSEDHARDDRIVE' => '1?|Yes|No',
                               'ENCLOSEDTOOLS' => '1?|Yes|No',
-
-                              'TESTBOOL' => '1?',
 
                               'COMMENTS' => '.*',
                               
@@ -1165,7 +1163,7 @@ class Shipment extends Page
             
             if (!sizeof($ship)) $this->_error('No such shipment');
             
-            $fields = array('SHIPPINGNAME','SAFETYLEVEL', 'DELIVERYAGENT_AGENTNAME', 'DELIVERYAGENT_AGENTCODE', 'DELIVERYAGENT_SHIPPINGDATE', 'DELIVERYAGENT_DELIVERYDATE', 'SENDINGLABCONTACTID', 'RETURNLABCONTACTID', 'READYBYTIME', 'CLOSETIME', 'PHYSICALLOCATION');
+            $fields = array('SHIPPINGNAME','SAFETYLEVEL', 'DELIVERYAGENT_AGENTNAME', 'DELIVERYAGENT_AGENTCODE', 'DELIVERYAGENT_SHIPPINGDATE', 'DELIVERYAGENT_DELIVERYDATE', 'SENDINGLABCONTACTID', 'RETURNLABCONTACTID', 'READYBYTIME', 'CLOSETIME', 'PHYSICALLOCATION', 'COMMENTS');
             foreach ($fields as $f) {
                 if ($this->has_arg($f)) {
                     $fl = ':1';

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -80,17 +80,20 @@ class Shipment extends Page
                               'SAFETYLEVEL' => '\w+',
                               'DEWARS' => '\d+',
                               //'FIRSTEXPERIMENTID' => '\w+\d+-\d+',
+
                               // Fields for responsive remote questions:
-                              'DYNAMIC' => '\w+',
+                              'DYNAMIC' => '1?',
                               'REMOTEORMAILIN' => '.*',
                               'SESSIONLENGTH' => '\w+',
                               'ENERGY' => '\w+',
-                              'MICROFOCUSBEAM' => '\w+',
+                              'MICROFOCUSBEAM' => '1?|Yes|No',
                               'SCHEDULINGRESTRICTIONS' => '.*',
-                              'LASTMINUTEBEAMTIME' => '\w+',
+                              'LASTMINUTEBEAMTIME' => '1?|Yes|No',
                               'DEWARGROUPING' => '.*',
-                              'ENCLOSEDHARDDRIVE' => '\w+',
-                              'ENCLOSEDTOOLS' => '\w+',
+                              'ENCLOSEDHARDDRIVE' => '1?|Yes|No',
+                              'ENCLOSEDTOOLS' => '1?|Yes|No',
+
+                              'TESTBOOL' => '1?',
 
                               'COMMENTS' => '.*',
                               
@@ -137,6 +140,20 @@ class Shipment extends Page
                               'currentuser' => '\d',
 
                               );
+        
+
+        var $extra_arg_list = array(
+            'DYNAMIC',
+            'REMOTEORMAILIN',
+            'SESSIONLENGTH',
+            'ENERGY',
+            'MICROFOCUSBEAM',
+            'SCHEDULINGRESTRICTIONS',
+            'LASTMINUTEBEAMTIME',
+            'DEWARGROUPING',
+            'ENCLOSEDHARDDRIVE',
+            'ENCLOSEDTOOLS'
+        );
         
 
         public static $dispatch = array(array('/shipments(/:sid)', 'get', '_get_shipments'),
@@ -228,6 +245,16 @@ class Shipment extends Page
         }
 
 
+        // Get the args that will be passsed into the 'extra' JSON column of the Shipping table
+        function _get_extra_args() {
+            $extra_args = array();
+            foreach($this->extra_arg_list as $arg) {
+                // if ($this->has_arg($arg)) {
+                $extra_args[$arg] = $this->arg($arg);
+                // }
+            }
+            return $extra_args;
+        }
         
         # ------------------------------------------------------------------------
         # List of shipments for a proposal
@@ -285,7 +312,7 @@ class Shipment extends Page
                 if (array_key_exists($this->arg('sort_by'), $cols)) $order = $cols[$this->arg('sort_by')].' '.$dir;
             }
 
-            $rows = $this->db->paginate("SELECT s.deliveryagent_agentname, s.deliveryagent_agentcode, TO_CHAR(s.deliveryagent_shippingdate, 'DD-MM-YYYY') as deliveryagent_shippingdate, TO_CHAR(s.deliveryagent_deliverydate, 'DD-MM-YYYY') as deliveryagent_deliverydate, s.safetylevel, count(d.dewarid) as dcount,s.sendinglabcontactid, c.cardname as lcout, c2.cardname as lcret, s.returnlabcontactid, s.shippingid, s.shippingname, s.shippingstatus,TO_CHAR(s.creationdate, 'DD-MM-YYYY') as created, s.isstorageshipping, s.shippingtype, s.comments, s.deliveryagent_flightcode, IF(s.deliveryAgent_label IS NOT NULL, 1, 0) as deliveryagent_has_label, TO_CHAR(s.readybytime, 'HH24:MI') as readybytime, TO_CHAR(s.closetime, 'HH24:MI') as closetime, s.physicallocation, s.deliveryagent_pickupconfirmation, TO_CHAR(s.deliveryagent_readybytime, 'HH24:MI') as deliveryAgent_readybytime, TO_CHAR(s.deliveryAgent_callintime, 'HH24:MI') as deliveryAgent_callintime, CONCAT(p.proposalcode, p.proposalnumber) as prop, TO_CHAR(s.deliveryagent_flightcodetimestamp, 'HH24:MI DD-MM-YYYY') as deliveryagent_flightcodetimestamp, sum(d.weight) as weight, pe.givenname, pe.familyname, l.name as labname, l.address, l.city, l.postcode, l.country, CONCAT(p.proposalcode, p.proposalnumber) as prop, GROUP_CONCAT(IF(d.facilitycode, d.facilitycode, d.code)) as dewars, s.deliveryagent_productcode, IF(cta.couriertermsacceptedid,1,0) as termsaccepted, GROUP_CONCAT(d.deliveryagent_barcode) as deliveryagent_barcode, pe2.login as deliveryagent_flightcodeperson
+            $rows = $this->db->paginate("SELECT s.deliveryagent_agentname, s.deliveryagent_agentcode, TO_CHAR(s.deliveryagent_shippingdate, 'DD-MM-YYYY') as deliveryagent_shippingdate, TO_CHAR(s.deliveryagent_deliverydate, 'DD-MM-YYYY') as deliveryagent_deliverydate, s.safetylevel, count(d.dewarid) as dcount,s.sendinglabcontactid, c.cardname as lcout, c2.cardname as lcret, s.returnlabcontactid, s.shippingid, s.shippingname, s.shippingstatus,TO_CHAR(s.creationdate, 'DD-MM-YYYY') as created, s.isstorageshipping, s.shippingtype, s.comments, s.deliveryagent_flightcode, IF(s.deliveryAgent_label IS NOT NULL, 1, 0) as deliveryagent_has_label, TO_CHAR(s.readybytime, 'HH24:MI') as readybytime, TO_CHAR(s.closetime, 'HH24:MI') as closetime, s.physicallocation, s.deliveryagent_pickupconfirmation, TO_CHAR(s.deliveryagent_readybytime, 'HH24:MI') as deliveryAgent_readybytime, TO_CHAR(s.deliveryAgent_callintime, 'HH24:MI') as deliveryAgent_callintime, CONCAT(p.proposalcode, p.proposalnumber) as prop, TO_CHAR(s.deliveryagent_flightcodetimestamp, 'HH24:MI DD-MM-YYYY') as deliveryagent_flightcodetimestamp, sum(d.weight) as weight, pe.givenname, pe.familyname, l.name as labname, l.address, l.city, l.postcode, l.country, CONCAT(p.proposalcode, p.proposalnumber) as prop, GROUP_CONCAT(IF(d.facilitycode, d.facilitycode, d.code)) as dewars, s.deliveryagent_productcode, IF(cta.couriertermsacceptedid,1,0) as termsaccepted, GROUP_CONCAT(d.deliveryagent_barcode) as deliveryagent_barcode, pe2.login as deliveryagent_flightcodeperson, s.extra
               FROM proposal p 
               INNER JOIN shipping s ON p.proposalid = s.proposalid 
               LEFT OUTER JOIN labcontact c2 ON s.returnlabcontactid = c2.labcontactid 
@@ -301,25 +328,14 @@ class Shipment extends Page
 
             foreach ($rows as &$s) {
                 $s['DELIVERYAGENT_BARCODE'] = str_replace(',', ', ', $s['DELIVERYAGENT_BARCODE']);
-                $comments_json = json_decode($s['COMMENTS'], true);
-                if (!is_null($comments_json)) {
-                    $s = array_merge($s, $comments_json);
+                $extra_json = json_decode($s['EXTRA'], true);
+                if (is_null($extra_json)) {
+                    $extra_json = array();
+                    foreach($this->extra_arg_list as $arg) {
+                        $extra_json[$arg] = "";
+                    }
                 }
-                else {
-                    $dummy_json = array(
-                        "ENCLOSEDHARDDRIVE" => "",
-                        "ENCLOSEDTOOLS" => "",
-                        "DYNAMIC" => "",
-                        "REMOTEORMAILIN" => "",
-                        "SESSIONLENGTH" => "",
-                        "ENERGY" => "",
-                        "MICROFOCUSBEAM" => "",
-                        "SCHEDULINGRESTRICTIONS" => "",
-                        "LASTMINUTEBEAMTIME" => "",
-                        "DEWARGROUPING" => ""
-                    );
-                    $s = array_merge($s, $dummy_json);
-                }
+                $s = array_merge($s, $extra_json);
             }
             
             if ($this->has_arg('sid')) {
@@ -1171,31 +1187,17 @@ class Shipment extends Page
                 }
             }
 
-            $json_fields = array(
-                "ENCLOSEDHARDDRIVE",
-                "ENCLOSEDTOOLS",
-                "DYNAMIC",
-                "REMOTEORMAILIN",
-                "SESSIONLENGTH",
-                "ENERGY",
-                "MICROFOCUSBEAM",
-                "SCHEDULINGRESTRICTIONS",
-                "LASTMINUTEBEAMTIME",
-                "DEWARGROUPING",
-                "COMMENTS"
-            );
-            $comments = implode("-", $this->db->pq("SELECT s.comments FROM shipping s WHERE s.shippingid = :1", array($this->arg('sid')))[0]);
-            $comments_json = json_decode($comments, true);
-            if (!is_null($comments_json)) {
-                foreach ($json_fields as $jf) {
-                    if ($this->has_arg($jf)) {
-                        $comments_json[$jf] = $this->arg($jf);
-                        $this->db->pq("UPDATE shipping SET comments=:1 WHERE shippingid=:2", array(json_encode($comments_json), $this->arg('sid')));
-                        $this->_output(array($jf => $this->arg($jf)));
-                    }
+            foreach ($this->extra_arg_list as $extra_arg_name) {
+                if ($this->has_arg($extra_arg_name)) {
+                    $extra_arg_value = addslashes($this->arg($extra_arg_name));
+                    $shippingid = $this->arg('sid');
+                    $this->db->pq(
+                        "UPDATE shipping SET extra = JSON_SET(extra, '$.".$extra_arg_name."', '".$extra_arg_value."') WHERE shippingid=:1",
+                        array($shippingid)
+                    );
+                    $this->_output(array($extra_arg_name => $extra_arg_value));
                 }
             }
-
         }
         
         
@@ -2133,39 +2135,46 @@ class Shipment extends Page
             $ct = $this->has_arg('CLOSETIME') ? $this->arg('CLOSETIME') : null;
             $loc = $this->has_arg('PHYSICALLOCATION') ? $this->arg('PHYSICALLOCATION') : null;
             
-            $hard_drive_enclosed = $this->arg('ENCLOSEDHARDDRIVE') ? 'Yes': 'No';
-            $tools_enclosed = $this->arg('ENCLOSEDTOOLS') ? 'Yes': 'No';
+            $hard_drive_enclosed = $this->arg('ENCLOSEDHARDDRIVE') ? "Yes" : "No";
+            $tools_enclosed = $this->arg('ENCLOSEDTOOLS') ? "Yes" : "No";
 
-            $dynamic = $this->arg('DYNAMIC') ? $this->arg('DYNAMIC') : '';
-            $remote_or_mailin = $this->arg('REMOTEORMAILIN') ? $this->arg('REMOTEORMAILIN') : '';
-            $session_length = $this->has_arg('SESSIONLENGTH') ? $this->arg('SESSIONLENGTH'): '';
-            $energy_requirements = $this->has_arg('ENERGY') ? $this->arg('ENERGY'): '';
-            $microfocus_beam = $this->arg('MICROFOCUSBEAM') ? 'Yes': 'No';
-            $scheduling_restrictions = $this->arg('SCHEDULINGRESTRICTIONS') ? $this->arg('SCHEDULINGRESTRICTIONS') : 'None';
-            $last_minute_beamtime = $this->arg('LASTMINUTEBEAMTIME') ? 'Yes' : 'No';
-            $dewar_grouping = $this->has_arg('DEWARGROUPING') ? $this->arg('DEWARGROUPING') : '';
+            $dynamic = $this->arg("DYNAMIC");
 
-            $comments_json = json_encode(
-                array(
-                    "ENCLOSEDHARDDRIVE"=> $hard_drive_enclosed,
-                    "ENCLOSEDTOOLS" => $tools_enclosed,
-                    "DYNAMIC" => $dynamic,
+            $extra_array = array(
+                "ENCLOSEDHARDDRIVE"=> $hard_drive_enclosed,
+                "ENCLOSEDTOOLS" => $tools_enclosed,
+                "DYNAMIC" => $dynamic,
+            );
+
+            if ($dynamic) {
+                $remote_or_mailin = $this->has_arg('REMOTEORMAILIN') ? $this->arg('REMOTEORMAILIN') : '';
+                $session_length = $this->has_arg('SESSIONLENGTH') ? $this->arg('SESSIONLENGTH'): '';
+                $energy_requirements = $this->has_arg('ENERGY') ? $this->arg('ENERGY'): '';
+                $microfocus_beam = $this->arg('MICROFOCUSBEAM') ? "Yes" : "No";
+                $scheduling_restrictions = $this->arg('SCHEDULINGRESTRICTIONS') ? $this->arg('SCHEDULINGRESTRICTIONS') : "None";
+                $last_minute_beamtime = $this->arg('LASTMINUTEBEAMTIME') ? "Yes" : "No";
+                $dewar_grouping = $this->has_arg('DEWARGROUPING') ? $this->arg('DEWARGROUPING') : '';
+                $dynamic_options = array(
                     "REMOTEORMAILIN" => $remote_or_mailin,
                     "SESSIONLENGTH" => $session_length,
                     "ENERGY" => $energy_requirements,
                     "MICROFOCUSBEAM" => $microfocus_beam,
                     "SCHEDULINGRESTRICTIONS" => $scheduling_restrictions,
                     "LASTMINUTEBEAMTIME" => $last_minute_beamtime,
-                    "DEWARGROUPING" => $dewar_grouping,
-                    "COMMENTS" => $com
-                )
-            );
+                    "DEWARGROUPING" => $dewar_grouping
+                );
+                $extra_array = array_merge($extra_array, $dynamic_options);
+            }
+
+            $extra = json_encode($extra_array);
 
             $this->db->pq("INSERT INTO shipping (shippingid, proposalid, shippingname, deliveryagent_agentname, deliveryagent_agentcode, deliveryagent_shippingdate, deliveryagent_deliverydate, bltimestamp, creationdate, comments, sendinglabcontactid, returnlabcontactid, shippingstatus, safetylevel, readybytime, closetime, physicallocation) 
               VALUES (s_shipping.nextval,:1,:2,:3,:4,TO_DATE(:5,'DD-MM-YYYY'), TO_DATE(:6,'DD-MM-YYYY'),CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,:7,:8,:9,'opened',:10, :11, :12, :13) RETURNING shippingid INTO :id", 
-              array($this->proposalid, $this->arg('SHIPPINGNAME'), $an, $ac, $sd, $dd, $comments_json, $this->arg('SENDINGLABCONTACTID'), $this->arg('RETURNLABCONTACTID'), $this->arg('SAFETYLEVEL'), $rt, $ct, $loc));
-            
+              array($this->proposalid, $this->arg('SHIPPINGNAME'), $an, $ac, $sd, $dd, $com, $this->arg('SENDINGLABCONTACTID'), $this->arg('RETURNLABCONTACTID'), $this->arg('SAFETYLEVEL'), $rt, $ct, $loc));
+                        
             $sid = $this->db->id();
+
+            $this->db->pq("UPDATE shipping SET extra=:1 WHERE shippingid=:2", array($extra, $sid));
             
             if ($this->has_arg('DEWARS')) {
                 if ($this->arg('DEWARS') > 0) {

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -86,7 +86,7 @@ class Shipment extends Page
                               'SESSIONLENGTH' => '\w+',
                               'ENERGY' => '\w+',
                               'MICROFOCUSBEAM' => '\w+',
-                              'SCHEDULINGRESTRICTIONS' => '\w+',
+                              'SCHEDULINGRESTRICTIONS' => '.*',
                               'LASTMINUTEBEAMTIME' => '\w+',
                               'DEWARGROUPING' => '.*',
                               'ENCLOSEDHARDDRIVE' => '\w+',
@@ -2141,7 +2141,7 @@ class Shipment extends Page
             $session_length = $this->has_arg('SESSIONLENGTH') ? $this->arg('SESSIONLENGTH'): '';
             $energy_requirements = $this->has_arg('ENERGY') ? $this->arg('ENERGY'): '';
             $microfocus_beam = $this->arg('MICROFOCUSBEAM') ? 'Yes': 'No';
-            $scheduling_restrictions = $this->arg('SCHEDULINGRESTRICTIONS') ? 'Yes' : 'No';
+            $scheduling_restrictions = $this->arg('SCHEDULINGRESTRICTIONS') ? $this->arg('SCHEDULINGRESTRICTIONS') : 'None';
             $last_minute_beamtime = $this->arg('LASTMINUTEBEAMTIME') ? 'Yes' : 'No';
             $dewar_grouping = $this->has_arg('DEWARGROUPING') ? $this->arg('DEWARGROUPING') : '';
 

--- a/client/src/js/models/shipment.js
+++ b/client/src/js/models/shipment.js
@@ -1,9 +1,9 @@
-define(['backbone'], function(Backbone) {
-    
+define(['backbone'], function (Backbone) {
+
   return Backbone.Model.extend({
     idAttribute: 'SHIPPINGID',
     urlRoot: '/shipment/shipments',
-      
+
     /*
      Validators for shipment, used for both editables and new shipments
     */
@@ -12,25 +12,38 @@ define(['backbone'], function(Backbone) {
         required: true,
         pattern: 'wwsdash',
       },
-      
+
       'FCODES[]': {
         required: false,
         pattern: 'fcode',
       },
-      
+
+      SESSIONLENGTH: {
+        required: false,
+        pattern: 'number',
+        fn: function (value){
+          if (value != parseInt(value, 10)) {
+            return 'Session length must be a whole number of hours'
+          }
+          if (parseInt(value, 10) < 1) {
+            return 'Session length must be at least one hour'
+          }
+        }
+      },
+
       SENDINGLABCONTACTID: {
         required: true,
       },
-      
+
       RETURNLABCONTACTID: {
         required: true,
       },
-      
+
       DELIVERYAGENT_AGENTCODE: {
         required: false,
         pattern: 'wwdash'
       },
-      
+
       DELIVERYAGENT_AGENTNAME: {
         required: false,
         pattern: 'wwsdash'
@@ -60,7 +73,7 @@ define(['backbone'], function(Backbone) {
 
 
     },
-      
+
   })
-       
+
 })

--- a/client/src/js/models/shipment.js
+++ b/client/src/js/models/shipment.js
@@ -18,6 +18,10 @@ define(['backbone'], function (Backbone) {
         pattern: 'fcode',
       },
 
+      REMOTEORMAILIN: {
+        required: false,
+      },
+
       SESSIONLENGTH: {
         required: false,
         pattern: 'number',
@@ -48,7 +52,6 @@ define(['backbone'], function (Backbone) {
         required: false,
         pattern: 'wwsdash'
       },
-
 
       DELIVERYAGENT_SHIPPINGDATE: {
         required: false,

--- a/client/src/js/modules/shipment/controller.js
+++ b/client/src/js/modules/shipment/controller.js
@@ -102,18 +102,6 @@ define(['backbone',
             app.log('ship add view')
             app.bc.reset([bc, { title: 'Add New Shipment' }])
             app.content.show(new ShipmentAddView({comments: {}}))
-
-            // Get any comments to prefill from the server
-            // Backbone.ajax({
-            //     url: app.appurl+'/assets/js/shipment_comments.json',
-            //     dataType: 'json',
-            //     success: function(shipmentComments) {
-            //         app.content.show(new ShipmentAddView({comments: shipmentComments}))
-            //     },
-            //     error: function() {
-            //         app.content.show(new ShipmentAddView({comments: {}}))
-            //     }
-            // })
         }
     },
 

--- a/client/src/js/modules/shipment/controller.js
+++ b/client/src/js/modules/shipment/controller.js
@@ -101,18 +101,19 @@ define(['backbone',
         } else {
             app.log('ship add view')
             app.bc.reset([bc, { title: 'Add New Shipment' }])
+            app.content.show(new ShipmentAddView({comments: {}}))
 
             // Get any comments to prefill from the server
-            Backbone.ajax({
-                url: app.appurl+'/assets/js/shipment_comments.json',
-                dataType: 'json',
-                success: function(shipmentComments) {
-                    app.content.show(new ShipmentAddView({comments: shipmentComments}))
-                },
-                error: function() {
-                    app.content.show(new ShipmentAddView({comments: {}}))
-                }
-            })
+            // Backbone.ajax({
+            //     url: app.appurl+'/assets/js/shipment_comments.json',
+            //     dataType: 'json',
+            //     success: function(shipmentComments) {
+            //         app.content.show(new ShipmentAddView({comments: shipmentComments}))
+            //     },
+            //     error: function() {
+            //         app.content.show(new ShipmentAddView({comments: {}}))
+            //     }
+            // })
         }
     },
 

--- a/client/src/js/modules/shipment/routes.js
+++ b/client/src/js/modules/shipment/routes.js
@@ -181,20 +181,21 @@ const routes = [
             next('/403?url='+to.fullPath)
           } else {
             app.log('ship add view')
+            next()
 
             // Get any comments to prefill from the server
-            Backbone.ajax({
-                url: app.appurl+'/assets/js/shipment_comments.json',
-                dataType: 'json',
-                success: function(comments) {
-                  shipmentComments = comments
-                  next()
-                },
-                error: function() {
-                  console.log("Warning no comments found")
-                  next()
-                }
-            })
+            // Backbone.ajax({
+            //     url: app.appurl+'/assets/js/shipment_comments.json',
+            //     dataType: 'json',
+            //     success: function(comments) {
+            //       shipmentComments = comments
+            //       next()
+            //     },
+            //     error: function() {
+            //       console.log("Warning no comments found")
+            //       next()
+            //     }
+            // })
           }
         }
       },

--- a/client/src/js/modules/shipment/routes.js
+++ b/client/src/js/modules/shipment/routes.js
@@ -182,20 +182,6 @@ const routes = [
           } else {
             app.log('ship add view')
             next()
-
-            // Get any comments to prefill from the server
-            // Backbone.ajax({
-            //     url: app.appurl+'/assets/js/shipment_comments.json',
-            //     dataType: 'json',
-            //     success: function(comments) {
-            //       shipmentComments = comments
-            //       next()
-            //     },
-            //     error: function() {
-            //       console.log("Warning no comments found")
-            //       next()
-            //     }
-            // })
           }
         }
       },

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -199,7 +199,15 @@ define(['marionette',
             edit.create("ENCLOSEDHARDDRIVE", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("ENCLOSEDTOOLS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
 
-            edit.create("REMOTEORMAILIN", 'select', { data: {'Remote': 'Remote', 'Mail-in': 'Mail-in', 'Other': 'Other'}})
+            proposal_code = app.proposal.get('PROPOSALCODE')
+            industrial_codes = ['in', 'sw']
+            industrial_visit = industrial_codes.includes(proposal_code)
+            if (!industrial_visit) {
+                this.$el.find(".remoteormailin").hide()
+            } else {
+                edit.create("REMOTEORMAILIN", 'select', { data: {'Remote': 'Remote', 'Mail-in': 'Mail-in', 'Other': 'Other'}})
+            }
+
             edit.create("SESSIONLENGTH", 'text')
             edit.create("ENERGY", 'text')
             edit.create("MICROFOCUSBEAM", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -194,6 +194,18 @@ define(['marionette',
             edit.create('PHYSICALLOCATION', 'text')
             edit.create('READYBYTIME', 'time')
             edit.create('CLOSETIME', 'time')
+
+
+            edit.create("ENCLOSEDHARDDRIVE", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("ENCLOSEDTOOLS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            // app.prop
+            edit.create("REMOTEORMAILIN", 'select', { data: {'Remote': 'Remote', 'Mail-in': 'Mail-in'}})
+            edit.create("SESSIONLENGTH", 'text')
+            edit.create("ENERGY", 'text')
+            edit.create("MICROFOCUSBEAM", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("SCHEDULINGRESTRICTIONS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("LASTMINUTEBEAMTIME", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("DEWARGROUPING", 'select', { data: {'Yes': 'Yes', 'No': 'No', 'Don\'t mind': 'Don\'t mind'}})
             
             var self = this
             this.contacts = new LabContacts(null, { state: { pageSize: 9999 } })

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -198,12 +198,12 @@ define(['marionette',
 
             edit.create("ENCLOSEDHARDDRIVE", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("ENCLOSEDTOOLS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
-            // app.prop
-            edit.create("REMOTEORMAILIN", 'select', { data: {'Remote': 'Remote', 'Mail-in': 'Mail-in'}})
+
+            edit.create("REMOTEORMAILIN", 'select', { data: {'Remote': 'Remote', 'Mail-in': 'Mail-in', 'Other': 'Other'}})
             edit.create("SESSIONLENGTH", 'text')
             edit.create("ENERGY", 'text')
             edit.create("MICROFOCUSBEAM", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
-            edit.create("SCHEDULINGRESTRICTIONS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("SCHEDULINGRESTRICTIONS", 'text')
             edit.create("LASTMINUTEBEAMTIME", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("DEWARGROUPING", 'select', { data: {'Yes': 'Yes', 'No': 'No', 'Don\'t mind': 'Don\'t mind'}})
             

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -113,22 +113,23 @@ define(['marionette', 'views/form',
         updateDynamicSchedule: function() {
             // Added as a fix to allow dynamic sessions
             // An extra option for proposals with no sessions yet that are not automated
+            proposal_code = app.proposal.get('PROPOSALCODE')
+            industrial_codes = ['in', 'sw']
+            industrial_visit = industrial_codes.includes(proposal_code)
             if (this.ui.dynamic.is(':checked')) {
                 this.ui.first.html('<option value=""> - </option>')
                 this.ui.noexp.prop('checked', false)
                 var text = '' // this.getOption('comments').dynamic || ''
                 this.ui.comments.val(text)
                 this.$el.find(".remoteform").show()
-                proposal_code = app.proposal.get('PROPOSALCODE')
-                industrial_codes = ['in', 'sw']
-                if (proposal_code in industrial_codes) {
+                if (industrial_visit) {
                     this.$el.find(".remoteormailin").show()
                 }
             } else {
                 this.ui.first.html(this.visits.opts())
                 this.ui.comments.val('')
                 this.$el.find(".remoteform").hide()
-                if (app.prop.startsWith("in") || app.prop.startsWith("sw")) {
+                if (industrial_visit) {
                     this.$el.find(".remoteormailin").hide()
                 }
             }

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -102,7 +102,7 @@ define(['marionette', 'views/form',
                 this.ui.first.html('<option value=""> - </option>')
                 this.ui.dynamic.prop('checked', false)
 
-                var text = this.getOption('comments').automated || ''
+                var text = '' // this.getOption('comments').automated || ''
                 this.ui.comments.val(text)
             } else {
                 this.ui.first.html(this.visits.opts())    
@@ -116,10 +116,12 @@ define(['marionette', 'views/form',
             if (this.ui.dynamic.is(':checked')) {
                 this.ui.first.html('<option value=""> - </option>')
                 this.ui.noexp.prop('checked', false)
-                var text = this.getOption('comments').dynamic || ''
+                var text = '' // this.getOption('comments').dynamic || ''
                 this.ui.comments.val(text)
                 this.$el.find(".remoteform").show()
-                if (app.prop.startsWith("in") || app.prop.startsWith("sw")) {
+                proposal_code = app.proposal.get('PROPOSALCODE')
+                industrial_codes = ['in', 'sw']
+                if (proposal_code in industrial_codes) {
                     this.$el.find(".remoteormailin").show()
                 }
             } else {

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -119,10 +119,16 @@ define(['marionette', 'views/form',
                 var text = this.getOption('comments').dynamic || ''
                 this.ui.comments.val(text)
                 this.$el.find(".remoteform").show()
+                if (app.prop.startsWith("in") || app.prop.startsWith("sw")) {
+                    this.$el.find(".remoteormailin").show()
+                }
             } else {
                 this.ui.first.html(this.visits.opts())
                 this.ui.comments.val('')
                 this.$el.find(".remoteform").hide()
+                if (app.prop.startsWith("in") || app.prop.startsWith("sw")) {
+                    this.$el.find(".remoteormailin").hide()
+                }
             }
         },
 
@@ -147,6 +153,7 @@ define(['marionette', 'views/form',
             this.$el.find('li.d .floated').append(new FCodes({ collection: this.fcodes, dewars: this.dewars }).render().el)
 
             this.$el.find(".remoteform").hide()
+            this.$el.find(".remoteormailin").hide()
             
             this.checkFCodes()
         },

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -71,7 +71,7 @@ define(['marionette', 'views/form',
             first: 'select[name=FIRSTEXPERIMENTID]',
             name: 'input[name=SHIPPINGNAME]',
             noexp: 'input[name=noexp]',
-            dynamic: 'input[name=dynamic]', // A checkbox to indicate dynamic/remote mail-in scheduling
+            dynamic: 'input[name=DYNAMIC]', // A checkbox to indicate dynamic/remote mail-in scheduling
             comments: 'textarea[name=COMMENTS]', // We need this so we can prefill comments to aid users
         },
         
@@ -118,9 +118,11 @@ define(['marionette', 'views/form',
                 this.ui.noexp.prop('checked', false)
                 var text = this.getOption('comments').dynamic || ''
                 this.ui.comments.val(text)
+                this.$el.find(".remoteform").show()
             } else {
                 this.ui.first.html(this.visits.opts())
                 this.ui.comments.val('')
+                this.$el.find(".remoteform").hide()
             }
         },
 
@@ -143,6 +145,8 @@ define(['marionette', 'views/form',
 
             this.fcodes = new Backbone.Collection()
             this.$el.find('li.d .floated').append(new FCodes({ collection: this.fcodes, dewars: this.dewars }).render().el)
+
+            this.$el.find(".remoteform").hide()
             
             this.checkFCodes()
         },

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -101,14 +101,10 @@ define(['marionette', 'views/form',
             if (this.ui.noexp.is(':checked')) {
                 this.ui.first.html('<option value=""> - </option>')
                 this.ui.dynamic.prop('checked', false)
-
-                var text = '' // this.getOption('comments').automated || ''
-                this.ui.comments.val(text)
             } else {
-                this.ui.first.html(this.visits.opts())    
-                this.ui.comments.val('')
+                this.ui.first.html(this.visits.opts())
             }
-        },  
+        },
 
         updateDynamicSchedule: function() {
             // Added as a fix to allow dynamic sessions
@@ -119,15 +115,12 @@ define(['marionette', 'views/form',
             if (this.ui.dynamic.is(':checked')) {
                 this.ui.first.html('<option value=""> - </option>')
                 this.ui.noexp.prop('checked', false)
-                var text = '' // this.getOption('comments').dynamic || ''
-                this.ui.comments.val(text)
                 this.$el.find(".remoteform").show()
                 if (industrial_visit) {
                     this.$el.find(".remoteormailin").show()
                 }
             } else {
                 this.ui.first.html(this.visits.opts())
-                this.ui.comments.val('')
                 this.$el.find(".remoteform").hide()
                 if (industrial_visit) {
                     this.$el.find(".remoteormailin").hide()

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -117,9 +117,11 @@ define(['marionette', 'views/form',
                 this.ui.noexp.prop('checked', false)
                 this.$el.find(".remoteform").show()
                 if (industrial_visit) {
+                    this.model.validation.REMOTEORMAILIN.required = true
                     this.$el.find(".remoteormailin").show()
                 }
             } else {
+                this.model.validation.REMOTEORMAILIN.required = false
                 this.ui.first.html(this.visits.opts())
                 this.$el.find(".remoteform").hide()
                 if (industrial_visit) {

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -122,6 +122,72 @@
                 <span class="DELIVERYAGENT_DELIVERYDATE"><%-DELIVERYAGENT_DELIVERYDATE%></span>
             </li>
 
+            <% if (ENCLOSEDHARDDRIVE) {%>
+            <li>
+                <span class="label">Hard drive enclosed</span>
+                <span class="ENCLOSEDHARDDRIVE"><%-ENCLOSEDTOOLS %></span>
+            </li>
+            <% } %>
+
+            <% if (ENCLOSEDTOOLS) {%>
+            <li>
+                <span class="label">Tools enclosed</span>
+                <span class="ENCLOSEDTOOLS"><%-ENCLOSEDTOOLS %></span>
+            </li>
+            <% } %>
+            
+
+            <% if (DYNAMIC) {%>
+            <% if (REMOTEORMAILIN) { %>
+            <li>
+                <span class="label">Remote or mail in</span>
+                <span class="REMOTEORMAILIN"><%-REMOTEORMAILIN %></span>
+            </li>
+            <% } %>
+
+            <% if (SESSIONLENGTH) { %>
+            <li>
+                <span class="label">Session length</span>
+                <span class="SESSIONLENGTH"><%-SESSIONLENGTH %></span>
+            </li>
+            <% } %>
+
+            <% if (ENERGY) { %>
+            <li>
+                <span class="label">Energy/wavelength requirements</span>
+                <span class="ENERGY"><%-ENERGY %></span>
+            </li>
+            <% } %>
+
+            <% if (MICROFOCUSBEAM) { %>
+            <li>
+                <span class="label">Microfocus beam requested</span>
+                <span class="MICROFOCUSBEAM"><%-MICROFOCUSBEAM %></span>
+            </li>
+            <% } %>
+
+            <% if (SCHEDULINGRESTRICTIONS) { %>
+            <li>
+                <span class="label">Scheduling restrictions</span>
+                <span class="SCHEDULINGRESTRICTIONS"><%-SCHEDULINGRESTRICTIONS %></span>
+            </li>
+            <% } %>
+
+            <% if (LASTMINUTEBEAMTIME) { %>
+            <li>
+                <span class="label">Consider for last-minute beamtime</span>
+                <span class="LASTMINUTEBEAMTIME"><%-LASTMINUTEBEAMTIME %></span>
+            </li>
+            <% } %>
+
+            <% if (DEWARGROUPING) { %>
+            <li>
+                <span class="label">Group Dewars</span>
+                <span class="DEWARGROUPING"><%-DEWARGROUPING %></span>
+            </li>
+            <% } %>
+            <% } %>
+
             <li>
                 <span class="label">Comments</span>
                 <div class="COMMENTS text tw-inline-block tw-w-3/5"><%-COMMENTS%></div>

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -138,54 +138,42 @@
             
 
             <% if (DYNAMIC) {%>
-            <% if (REMOTEORMAILIN) { %>
+            <% if (REMOTEORMAILIN) {%>
             <li>
                 <span class="label">Remote or mail in</span>
                 <span class="REMOTEORMAILIN"><%-REMOTEORMAILIN %></span>
             </li>
             <% } %>
 
-            <% if (SESSIONLENGTH) { %>
             <li>
                 <span class="label">Session length</span>
                 <span class="SESSIONLENGTH"><%-SESSIONLENGTH %></span>
             </li>
-            <% } %>
 
-            <% if (ENERGY) { %>
             <li>
                 <span class="label">Energy/wavelength requirements</span>
                 <span class="ENERGY"><%-ENERGY %></span>
             </li>
-            <% } %>
 
-            <% if (MICROFOCUSBEAM) { %>
             <li>
                 <span class="label">Microfocus beam requested</span>
                 <span class="MICROFOCUSBEAM"><%-MICROFOCUSBEAM %></span>
             </li>
-            <% } %>
 
-            <% if (SCHEDULINGRESTRICTIONS) { %>
             <li>
                 <span class="label">Scheduling restrictions</span>
                 <span class="SCHEDULINGRESTRICTIONS"><%-SCHEDULINGRESTRICTIONS %></span>
             </li>
-            <% } %>
 
-            <% if (LASTMINUTEBEAMTIME) { %>
             <li>
                 <span class="label">Consider for last-minute beamtime</span>
                 <span class="LASTMINUTEBEAMTIME"><%-LASTMINUTEBEAMTIME %></span>
             </li>
-            <% } %>
 
-            <% if (DEWARGROUPING) { %>
             <li>
                 <span class="label">Group Dewars</span>
                 <span class="DEWARGROUPING"><%-DEWARGROUPING %></span>
             </li>
-            <% } %>
             <% } %>
 
             <li>

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -125,7 +125,7 @@
             <% if (ENCLOSEDHARDDRIVE) {%>
             <li>
                 <span class="label">Hard drive enclosed</span>
-                <span class="ENCLOSEDHARDDRIVE"><%-ENCLOSEDTOOLS %></span>
+                <span class="ENCLOSEDHARDDRIVE"><%-ENCLOSEDHARDDRIVE %></span>
             </li>
             <% } %>
 

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -139,7 +139,7 @@
 
             <% if (DYNAMIC) {%>
             <% if (REMOTEORMAILIN) {%>
-            <li>
+            <li class="remoteormailin">
                 <span class="label">Remote or mail in</span>
                 <span class="REMOTEORMAILIN"><%-REMOTEORMAILIN %></span>
             </li>

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -31,6 +31,17 @@
                     <!--<span class="fcodes"></span>-->
                 </div>
             </li>
+
+            <li>
+                <label>Safety Level
+                    <span class="small">The safety level of the shipment</span>
+                </label>
+                <select class="tw-h-6" name="SAFETYLEVEL" required>
+                    <option value="Green">Green</option>
+                    <option value="Yellow">Yellow</option>
+                    <option value="Red">Red</option>
+                </select>
+            </li>
             
             <li>
                 <!-- Small tweaks to the styling here using tailwind flexbox -->
@@ -43,20 +54,80 @@
                         <input type="checkbox" name="noexp"> Automated / Imager
                     </label>
                     <label class="secondary tw-mr-2">
-                        <input type="checkbox" name="dynamic"> Responsive Remote / Mail-in
+                        <input type="checkbox" name="DYNAMIC"> Responsive Remote / Mail-in
                     </label>
                 </div>
             </li>
 
-            <li>
-                <label>Safety Level
-                    <span class="small">The safety level of the shipment</span>
+            <li class="remoteform">
+                <label>Remote or mail-in (Industrial users only)
+                    <span class="small">Is this for remote data collection or mail-in service work?</span>
                 </label>
-                <select class="tw-h-6" name="SAFETYLEVEL" required>
-                    <option value="Green">Green</option>
-                    <option value="Yellow">Yellow</option>
-                    <option value="Red">Red</option>
+                <select name="REMOTEORMAILIN"> 
+                    <option value="N/A">N/A</option>
+                    <option value="Remote">Remote</option>
+                    <option value="Mail-in">Mail-in</option>
                 </select>
+            </li>
+
+            <li class="remoteform">
+                <label>Session length
+                    <span class="small">Requested beamline session length [hours]</span>
+                </label>
+                <input name="SESSIONLENGTH"/>
+            </li>
+
+            <li class="remoteform">
+                <label>Energy/Wavelength
+                    <span class="small">Specify any energy/Wavelength requirements [eV/&#8491]</span>
+                </label>
+                <input type="text" name="ENERGY"/>
+            </li>
+
+            <li class="remoteform">
+                <label>Microfocus beam
+                    <span class="small">Microfocus beam is required for this shipment (provide further information in additional comments)</span>
+                </label>
+                <input type="checkbox" name="MICROFOCUSBEAM"> 
+            </li>
+
+            <li class="remoteform">
+                <label>Scheduling restrictions for data collection
+                    <span class="small">Are there times in the two weeks after delivery when the people collecting data are unavailable, including weekends?:</span>
+                </label>
+                <input type="checkbox" name="SCHEDULINGRESTRICTIONS"> 
+            </li>
+
+            <li class="remoteform">
+                <label>Last-minute beam time
+                    <span class="small">This shipment should be considered for last-minute beam time</span>
+                </label>
+                <input type="checkbox" name="LASTMINUTEBEAMTIME"> 
+            </li>
+
+            <li class="remoteform">
+                <label>Dewar grouping
+                    <span class="small">Would you prefer your beam time for this dewar to be grouped with beam time for other dewars?:</span>
+                </label>
+                <select name="DEWARGROUPING"> 
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="Don't mind">Don't mind</option>
+                </select>
+            </li>
+
+            <li>
+                <label>Hard drive enclosed
+                    <span class="small">A hard drive is included with this shipment</span>
+                </label>
+                <input type="checkbox" name="ENCLOSEDHARDDRIVE"> 
+            </li>
+
+            <li>
+                <label>Tools enclosed
+                    <span class="small">Tools are included within this shipment</span>
+                </label>
+                <input type="checkbox" name="ENCLOSEDTOOLS"> 
             </li>
             
             <li>

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -59,14 +59,14 @@
                 </div>
             </li>
 
-            <li class="remoteform">
+            <li class="remoteormailin">
                 <label>Remote or mail-in (Industrial users only)
                     <span class="small">Is this for remote data collection or mail-in service work?</span>
                 </label>
-                <select name="REMOTEORMAILIN"> 
-                    <option value="N/A">N/A</option>
+                <select name="REMOTEORMAILIN">
                     <option value="Remote">Remote</option>
                     <option value="Mail-in">Mail-in</option>
+                    <option value="Other">Other</option>
                 </select>
             </li>
 
@@ -95,7 +95,7 @@
                 <label>Scheduling restrictions for data collection
                     <span class="small">Are there times in the two weeks after delivery when the people collecting data are unavailable, including weekends?:</span>
                 </label>
-                <input type="checkbox" name="SCHEDULINGRESTRICTIONS"> 
+                <input type="text" name="SCHEDULINGRESTRICTIONS" size="100"></textarea>
             </li>
 
             <li class="remoteform">

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -96,7 +96,7 @@
                 <label>Scheduling restrictions for data collection
                     <span class="small">Are there times in the two weeks after delivery when the people collecting data are unavailable, including weekends?:</span>
                 </label>
-                <input type="text" name="SCHEDULINGRESTRICTIONS" size="100"></textarea>
+                <textarea name="SCHEDULINGRESTRICTIONS"></textarea>
             </li>
 
             <li class="remoteform">

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -64,6 +64,7 @@
                     <span class="small">Is this for remote data collection or mail-in service work?</span>
                 </label>
                 <select name="REMOTEORMAILIN">
+                    <option value="" disabled selected>Please select</option>
                     <option value="Remote">Remote</option>
                     <option value="Mail-in">Mail-in</option>
                     <option value="Other">Other</option>


### PR DESCRIPTION
**JIRA ticket:** [LIMS-80](https://jira.diamond.ac.uk/browse/LIMS-80)

**Changes:**
- Remove use of shipments_comments.json - remove questions from within the comments field, replacing them with separate fields
- Add extra fields to the create shipment form, for all dynamically-scheduled remote visits: Session length, Energy/wavelength, Microfocus beam, Scheduling restrictions, Last minute beam time, Dewar grouping
- Add an extra field for industrial dynamically-scheduled remote visits: Remote or mail in?
- Add extra fields for all shipments: Tools enclosed?, Hard drive enclosed?
- Add extra rows to the shipment page corresponding to the new fields

**To test:**
- Check that the correct fields appear depending on the circumstances (dynamic scheduling, industrial visit, etc.)
- Check that the input for these fields appears correctly on the shipment page once submitted

**Note:** The input of the new fields is stored as JSON in the 'extra' column of the Shipping table in ISPyB