### PR TITLE
[LIMS-138]Fix: Extend dropdown for first experiment in Shipment page

### DIFF
--- a/client/src/js/modules/shipment/views/dewars.js
+++ b/client/src/js/modules/shipment/views/dewars.js
@@ -113,7 +113,7 @@ define(['marionette', 'backbone',
             edit.create('TRACKINGNUMBERFROMSYNCHROTRON', 'text')
             edit.create('WEIGHT', 'text')
             
-            this.visits = new Visits(null, { queryParams: { next: 1 }, state: { pageSize: 5 } })
+            this.visits = new Visits(null, { queryParams: { next: 0 }, state: { pageSize: 9999 } })
             this.visits.fetch().done(function() {
                 self.ui.first.html(self.visits.opts({ empty: true }))
                 edit.create('FIRSTEXPERIMENTID', 'select', { data: self.visits.kv({ empty: true }) }, true)

--- a/client/src/js/modules/shipment/views/dewars.js
+++ b/client/src/js/modules/shipment/views/dewars.js
@@ -113,7 +113,7 @@ define(['marionette', 'backbone',
             edit.create('TRACKINGNUMBERFROMSYNCHROTRON', 'text')
             edit.create('WEIGHT', 'text')
             
-            this.visits = new Visits(null, { queryParams: { next: 0 }, state: { pageSize: 9999 } })
+            this.visits = new Visits(null, { queryParams: { next: 1 }, state: { pageSize: 9999 } })
             this.visits.fetch().done(function() {
                 self.ui.first.html(self.visits.opts({ empty: true }))
                 edit.create('FIRSTEXPERIMENTID', 'select', { data: self.visits.kv({ empty: true }) }, true)


### PR DESCRIPTION
**JIRA ticket:** [LIMS-138](https://jira.diamond.ac.uk/browse/LIMS-138)

**Changes:**

- Extend the first experiment dropdown on the shipment page so that it can show more than 5 visits

**To test:**

- Check that the first experiment dropdown can show more than 5 visits for proposals with a large number of visits