### PR TITLE
[LIMS-93]Fix: Change logic of dewar dispatch courier fields

### DIFF
--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -91,11 +91,13 @@ define(['marionette', 'views/form',
                 self.updateLC()
             })
 
-            if (this.shipping.get('DELIVERYAGENT_AGENTCODE')) {
+            if (this.shipping.get('TERMSACCEPTED') == 0) {
                 this.ui.courier.val(this.shipping.get('DELIVERYAGENT_AGENTNAME'))
                 this.ui.accountNumber.val(this.shipping.get('DELIVERYAGENT_AGENTCODE'))
-                this.ui.courier.attr('disabled', true)
-                this.ui.accountNumber.attr('disabled', true)
+                if (this.shipping.get('DELIVERYAGENT_AGENTNAME') && this.shipping.get('DELIVERYAGENT_AGENTCODE')) {
+                    this.ui.courier.attr('disabled', true)
+                    this.ui.accountNumber.attr('disabled', true)
+                }
                 this.model.shipmentHasAgentCode = true
             }
         },

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -108,14 +108,7 @@
 
             
             <li class="head">Courier Details</li>
-            <% if (SHIPPING.DELIVERYAGENT_AGENTCODE) { %>
-            <li>
-                <label>
-                    Use another account
-                    <span class="small">Use another courier account instead</span>
-                </label>
-                <input type="checkbox" name="USE_ANOTHER_COURIER_ACCOUNT" value="0" />
-            </li>
+            <% if (SHIPPING.TERMSACCEPTED == 0) { %>
             <li>
                 <label>Courier
                     <span class="small">Courier Name</span>
@@ -123,12 +116,20 @@
                 <input type="text" name="DELIVERYAGENT_AGENTNAME" />
             </li>
 
-
             <li>
                 <label>Account Number
                     <span class="small">Courier account number</span>
                 </label>
                 <input type="text" name="DELIVERYAGENT_AGENTCODE" />
+            </li>
+
+            <% if (SHIPPING.DELIVERYAGENT_AGENTNAME && SHIPPING.DELIVERYAGENT_AGENTCODE) { %>
+            <li>
+                <label>
+                    Use another account
+                    <span class="small">Use another courier account instead</span>
+                </label>
+                <input type="checkbox" name="USE_ANOTHER_COURIER_ACCOUNT" value="0" />
             </li>
             <% } %>
 
@@ -138,7 +139,13 @@
                 </label>
                 <input type="text" name="AWBNUMBER" />
             </li>
-
+            <% } else { %>
+            <li>
+                <label>Courier</label>
+                <span class="small">This dewar will be returned using the facility's courier account</span>
+            </li>
+            <% } %>
+    
 
             <li>
                 <label>Comments


### PR DESCRIPTION
**JIRA ticket:** [LIMS-93](https://jira.diamond.ac.uk/browse/LIMS-93)

**Changes:**

- Change logic of Dewar dispatch form such that: If the facility courier account is used, courier details fields are hidden. If the facility account is not used and courier details have been fully specified, then courier details fields are shown disabled by default, with the option for editing. If the facility account is not used but courier details are not fully specified, then the fields are enabled by default, with no option to disable.

**To test:**

- Check that, for each combination of provided courier account information, the correct fields are visible.