### PR TITLE
[LIMS-228]Fix: Add account number to DHL quote request

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2468,9 +2468,18 @@ class Shipment extends Page
             if (!$this->has_arg('DEWARS')) $this->_error('No dewars specified');
             if (!is_array($this->arg('DEWARS'))) $this->_error('No dewars specified');
             
-            $ship = $this->db->pq("SELECT s.shippingid,s.sendinglabcontactid,s.returnlabcontactid, TO_CHAR(s.deliveryagent_shippingdate, 'YYYY-MM-DD') as deliveryagent_shippingdate, TO_CHAR(s.readybytime, 'HH24:MI') as readybytime
+            $ship = $this->db->pq(
+                "SELECT
+                 s.shippingid,
+                 s.sendinglabcontactid,
+                 s.returnlabcontactid,
+                 TO_CHAR(s.deliveryagent_shippingdate, 'YYYY-MM-DD') as deliveryagent_shippingdate,
+                 TO_CHAR(s.readybytime, 'HH24:MI') as readybytime,
+                 s.deliveryagent_agentcode
                 FROM shipping s 
-                WHERE s.proposalid = :1 AND s.shippingid = :2", array($this->proposalid,$this->arg('sid')));
+                WHERE s.proposalid = :1 AND s.shippingid = :2",
+                array($this->proposalid,$this->arg('sid'))
+            );
             if (!sizeof($ship)) $this->_error('No such shipment');
             $ship = $ship[0];
 
@@ -2523,6 +2532,8 @@ class Shipment extends Page
                     'date' => $ship['DELIVERYAGENT_SHIPPINGDATE'],
                     'declaredvalue' => $this->arg('DECLAREDVALUE'),
                     'readyby' => $ship['READYBYTIME'],
+
+                    'payment_account_number' => $ship['DELIVERYAGENT_AGENTCODE'],
 
                     'sender' => $this->has_arg('RETURN') ? $facility : $user,
                     'receiver' => $this->has_arg('RETURN') ? $user : $facility,

--- a/api/src/Shipment/Courier/DHL.php
+++ b/api/src/Shipment/Courier/DHL.php
@@ -350,6 +350,7 @@ class DHL
         $quote->BkgDetails->DimensionUnit = 'CM';
         $quote->BkgDetails->WeightUnit = 'KG';
         $quote->BkgDetails->PaymentCountryCode = $this->_country_codes[$options['receiver']['country']];
+        $quote->BkgDetails->PaymentAccountNumber = $options['payment_account_number'];
 
         $quote->From->CountryCode = $this->_country_codes[$options['sender']['country']];
         $quote->From->Postalcode = $options['sender']['postcode'];


### PR DESCRIPTION
**JIRA ticket:** [LIMS-228](https://jira.diamond.ac.uk/browse/LIMS-228)

**Changes:**

- Add the `deliveryAgent_agentCode` from the Shipping table to the DHL XML quote request as the `PaymentAccountNumber` element.

**To test:**

- Check that the quotes received are correct for a given account number