### PR TITLE
[LIMS-230]Improvement: Widen the address on shipping labels

### DIFF
--- a/api/assets/pdf/shipment_label.php
+++ b/api/assets/pdf/shipment_label.php
@@ -119,10 +119,7 @@
             </div>
 
             <div>
-                <div class="left large bold" style="width: 70px">TO:</div>
-                <div class="pad-left">
-                    <p class="large bold"><?php echo $ship['FACILITYADDRESS'] ?></p>
-                </div>
+                <p class="large bold" style="padding-left: 20"><?php echo $ship['FACILITYADDRESS'] ?></p>
             </div>
 
             <div class="pad" style="padding-top: 0">
@@ -207,16 +204,13 @@
             </div>
 
             <div>
-                <div class="left large bold" style="width: 70px">TO:</div>
-                <div class="pad-left">
-                    <p class="large bold">
-                        <?php echo ucfirst($ship['GIVENNAME2']) ?> <?php echo strtoupper($ship['FAMILYNAME2']) ?><br />
-                        <?php echo $ship['LABNAME2'] ?><br />
-                        <?php echo $ship['ADDRESS2'] ?><br />
-                        <span class="normal">Tel: <?php echo $ship['PHONENUMBER2'] ?></span><br />
-                        <span class="normal">Fax: <?php echo $ship['FAXNUMBER2'] ?></span><br />
-                    </p>
-                </div>
+                <p class="large bold" style="padding-left: 20">
+                    <?php echo ucfirst($ship['GIVENNAME2']) ?> <?php echo strtoupper($ship['FAMILYNAME2']) ?><br />
+                    <?php echo $ship['LABNAME2'] ?><br />
+                    <?php echo $ship['ADDRESS2'] ?><br />
+                    <span class="normal">Tel: <?php echo $ship['PHONENUMBER2'] ?></span><br />
+                    <span class="normal">Fax: <?php echo $ship['FAXNUMBER2'] ?></span><br />
+                </p>
             </div>
 
             <div class="pad" style="padding-top: 0">


### PR DESCRIPTION
**JIRA ticket:** [LIMS-230](https://jira.diamond.ac.uk/browse/LIMS-230)

**Changes:**

- Removed 'To:' from the outbound addresses in the shipping label template. This is to allow for more characters to fit on each address line, e.g. to let 'Harwell Science & Innovation Campus' fit without requiring multiple lines.

**To test:**

- Check that shipping labels are rendered correctly and that 'Harwell Science & Innovation Campus' can now fit on a single line.