### PR TITLE
[LIMS-229]Improvement: Hide 'create air waybill' if not applicable

### DIFF
--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -19,7 +19,7 @@
             <a class="button send" href="#"><i class="fa fa-plane"></i> Mark as Sent</a>
         <% } %>
 
-        <% if (DHL_ENABLE) { %>
+        <% if (DHL_ENABLE && (DELIVERYAGENT_AGENTNAME.toLowerCase() == 'dhl' || !DELIVERYAGENT_AGENTNAME)) { %>
         <% if (DELIVERYAGENT_HAS_LABEL == '1') { %>
             <a class="button pdf" href="<%-APIURL%>/pdf/awb/sid/<%-SHIPPINGID%>"><i class="fa fa-print"></i> Print Airway Bill</a>
             <!-- <a class="button cancel" href="#"><i class="fa fa-truck"></i> Cancel Pickup</a> -->
@@ -29,7 +29,7 @@
         <% } else if (COUNTRY && COUNTRY !="United Kingdom" ) { %>
             <a class="button" href="#"><i class="fa fa-credit-card"></i> Create Airway Bill - Disabled</a>
         <% } else { %>
-            <a class="button awb" href="/shipments/awb/sid/<%-SHIPPINGID%>"><i class="fa fa-credit-card"></i> Create Airway Bill</a>
+            <a class="button awb" href="/shipments/awb/sid/<%-SHIPPINGID%>"><i class="fa fa-credit-card"></i> Create DHL Airway Bill</a>
         <% } %>
         <% } %>
 


### PR DESCRIPTION
**JIRA ticket:** [LIMS-229](https://jira.diamond.ac.uk/browse/LIMS-229)

**Changes:**

- Make the create air waybill button only be present on the shipping page if the shipment's courier is undefined or DHL.
- Change the text on the create air waybillbutton to read 'create DHL airway bill'

**To test:**

- Check that the button only appears under the right circumstances.