### PR TITLE
[LIMS-232]Improvement: Update DHL XML API

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -10,15 +10,10 @@
   "repositories": [
     {
       "type": "github",
-      "url": "https://github.com/stufisher/DHL-API.git"
-    },
-    {
-      "type": "path",
-      "url": "/app/packages/dhl-api"
+      "url": "https://github.com/mattprit/dhl-api.git"
     }
   ],
   "require": {
-    "alfallouji/dhl_api": "dev-master#8a1699a5",
     "apereo/phpcas": "1.3.8",
     "ezyang/htmlpurifier": "4.12.0",
     "firebase/php-jwt": "2.2.0",
@@ -30,7 +25,7 @@
     "stomp-php/stomp-php": "3.0.6",
     "symfony/http-foundation": "^2.8",
     "symfony/filesystem": "^2.8",
-    "mtcmedia/dhl-api": "dev-master"
+    "mtcmedia/dhl-api": "dev-master#472ed023"
   },
   "autoload": {
     "psr-4": {

--- a/api/composer.json
+++ b/api/composer.json
@@ -25,7 +25,7 @@
     "stomp-php/stomp-php": "3.0.6",
     "symfony/http-foundation": "^2.8",
     "symfony/filesystem": "^2.8",
-    "mtcmedia/dhl-api": "dev-master#472ed023"
+    "mtcmedia/dhl-api": "dev-master#9b4b6315"
   },
   "autoload": {
     "psr-4": {

--- a/api/composer.json
+++ b/api/composer.json
@@ -11,6 +11,10 @@
     {
       "type": "github",
       "url": "https://github.com/stufisher/DHL-API.git"
+    },
+    {
+      "type": "path",
+      "url": "/app/packages/dhl-api"
     }
   ],
   "require": {
@@ -25,7 +29,8 @@
     "slim/slim": "2.4.3",
     "stomp-php/stomp-php": "3.0.6",
     "symfony/http-foundation": "^2.8",
-    "symfony/filesystem": "^2.8"
+    "symfony/filesystem": "^2.8",
+    "mtcmedia/dhl-api": "dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/api/src/Shipment/Courier/DHL.php
+++ b/api/src/Shipment/Courier/DHL.php
@@ -151,7 +151,7 @@ class DHL
 
         $shipment->Consignee->CompanyName = $options['receiver']['company'];
 
-        $reciever_address_lines = explode(PHP_EOL, $options['receiver']['address']);
+        $reciever_address_lines = explode(PHP_EOL, rtrim($options['receiver']['address']));
         if (isset($reciever_address_lines[0])) $shipment->Consignee->addAddressLine1($reciever_address_lines[0]);
         if (isset($reciever_address_lines[1])) $shipment->Consignee->addAddressLine2($reciever_address_lines[1]);
         if (isset($reciever_address_lines[2])) $shipment->Consignee->addAddressLine3($reciever_address_lines[2]);
@@ -188,7 +188,7 @@ class DHL
         $shipment->Shipper->ShipperID = (string)rand(10000000, 9999999);
         $shipment->Shipper->CompanyName = $options['sender']['company'];
 
-        $shipper_address_lines = explode(PHP_EOL, $options['sender']['address']);
+        $shipper_address_lines = explode(PHP_EOL, rtrim($options['sender']['address']));
         if (isset($shipper_address_lines[0])) $shipment->Shipper->addAddressLine1($shipper_address_lines[0]);
         if (isset($shipper_address_lines[1])) $shipment->Shipper->addAddressLine2($shipper_address_lines[1]);
         if (isset($shipper_address_lines[2])) $shipment->Shipper->addAddressLine3($shipper_address_lines[2]);

--- a/api/src/Shipment/Courier/DHL.php
+++ b/api/src/Shipment/Courier/DHL.php
@@ -152,9 +152,9 @@ class DHL
         $shipment->Consignee->CompanyName = $options['receiver']['company'];
 
         $reciever_address_lines = explode(PHP_EOL, $options['receiver']['address']);
-        if ($reciever_address_lines[0]) $shipment->Consignee->addAddressLine1($reciever_address_lines[0]);
-        if ($reciever_address_lines[1]) $shipment->Consignee->addAddressLine2($reciever_address_lines[1]);
-        if ($reciever_address_lines[2]) $shipment->Consignee->addAddressLine3($reciever_address_lines[2]);
+        if (isset($reciever_address_lines[0])) $shipment->Consignee->addAddressLine1($reciever_address_lines[0]);
+        if (isset($reciever_address_lines[1])) $shipment->Consignee->addAddressLine2($reciever_address_lines[1]);
+        if (isset($reciever_address_lines[2])) $shipment->Consignee->addAddressLine3($reciever_address_lines[2]);
 
         $shipment->Consignee->City = $options['receiver']['city'];
         $shipment->Consignee->PostalCode = $options['receiver']['postcode'];
@@ -189,9 +189,9 @@ class DHL
         $shipment->Shipper->CompanyName = $options['sender']['company'];
 
         $shipper_address_lines = explode(PHP_EOL, $options['sender']['address']);
-        if ($shipper_address_lines[0]) $shipment->Shipper->addAddressLine1($shipper_address_lines[0]);
-        if ($shipper_address_lines[1]) $shipment->Shipper->addAddressLine2($shipper_address_lines[1]);
-        if ($shipper_address_lines[2]) $shipment->Shipper->addAddressLine3($shipper_address_lines[2]);
+        if (isset($shipper_address_lines[0])) $shipment->Shipper->addAddressLine1($shipper_address_lines[0]);
+        if (isset($shipper_address_lines[1])) $shipment->Shipper->addAddressLine2($shipper_address_lines[1]);
+        if (isset($shipper_address_lines[2])) $shipment->Shipper->addAddressLine3($shipper_address_lines[2]);
 
         $shipment->Shipper->City = $options['sender']['city'];
         $shipment->Shipper->PostalCode = $options['sender']['postcode'];

--- a/api/src/Shipment/Courier/DHL.php
+++ b/api/src/Shipment/Courier/DHL.php
@@ -142,7 +142,7 @@ class DHL
         $shipment->RequestedPickupTime = 'Y';
         $shipment->LanguageCode = 'en';
         $shipment->SoftwareName = 'Synchweb';
-        $shipment->SoftwareVersion = $synchweb_version;
+        $shipment->SoftwareVersion = (isset($synchweb_version)) ? $synchweb_version : '4.0';
         $shipment->Billing->ShippingPaymentType = $options['payee'];
         $shipment->Billing->ShipperAccountNumber = $options['accountnumber'];
         if ($options['payee'] != 'S') {

--- a/api/src/Shipment/Courier/DHL.php
+++ b/api/src/Shipment/Courier/DHL.php
@@ -2,21 +2,32 @@
 
 namespace SynchWeb\Shipment\Courier;
 
-use DHL\Client\Web as WebserviceClient;
-use DHL\Datatype\AM\PieceType;
-use DHL\Datatype\GB\Piece;
-use DHL\Entity\AM\GetQuote;
-use DHL\Entity\GB\BookPURequest;
-use DHL\Entity\GB\BookPUResponse;
-use DHL\Entity\GB\CancelPURequest;
-use DHL\Entity\GB\CancelPUResponse;
-use DHL\Entity\GB\KnownTrackingRequest as Tracking;
-use DHL\Entity\GB\ShipmentRequest;
-use DHL\Entity\GB\ShipmentResponse;
+// use DHL\Client\Web as WebserviceClient;
+use Mtc\Dhl\Client\Web;
+// use DHL\Datatype\AM\PieceType;
+use Mtc\Dhl\Datatype\AM\PieceType;
+// use DHL\Datatype\GB\Piece;
+use Mtc\Dhl\Datatype\EU\Piece;
+// use DHL\Entity\AM\GetQuote;
+use Mtc\Dhl\Entity\AM\GetQuote;
+// use DHL\Entity\GB\BookPURequest;
+use Mtc\Dhl\Entity\EU\BookPURequest;
+// use DHL\Entity\GB\BookPUResponse;
+use Mtc\Dhl\Entity\EU\BookPUResponse;
+// use DHL\Entity\GB\CancelPURequest;
+use Mtc\Dhl\Entity\EU\CancelPURequest;
+// use DHL\Entity\GB\CancelPUResponse;
+use Mtc\Dhl\Entity\EU\CancelPUResponse;
+// use DHL\Entity\GB\KnownTrackingRequest as Tracking;
+// use DHL\Entity\GB\ShipmentRequest;
+use Mtc\Dhl\Entity\EU\ShipmentRequest;
+// use DHL\Entity\GB\ShipmentResponse;
+use Mtc\Dhl\Entity\EU\ShipmentResponse;
+use Mtc\Dhl\Entity\EU\KnownTrackingRequest;
 
 class DHL
 {
-    public $log = false;
+    public $log = true;
     public $region = 'EU';
 
     public $_country_codes = array(
@@ -107,7 +118,7 @@ class DHL
     {
         if (!array_key_exists('AWB', $options)) return;
 
-        $request = new Tracking();
+        $request = new KnownTrackingRequest();
         $request->SiteID = $this->_user;
         $request->Password = $this->_password;
         $request->MessageReference = '12345678901234567890' . (string)time();
@@ -119,7 +130,7 @@ class DHL
 
         if ($this->log) file_put_contents('logs/trackingrequest_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['AWB'] . '.xml'), $request->toXML());
 
-        $client = new WebserviceClient($this->env);
+        $client = new Web($this->env);
         $xml = $client->call($request);
 
         if ($this->log) file_put_contents('logs/trackingresponse_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['AWB'] . '.xml'), $xml);
@@ -130,6 +141,8 @@ class DHL
 
     function create_awb($options)
     {
+        global $synchweb_version;
+
         $shipment = new ShipmentRequest();
         $shipment->SiteID = $this->_user;
         $shipment->Password = $this->_password;
@@ -139,21 +152,32 @@ class DHL
         $shipment->RegionCode = $this->region;
         $shipment->RequestedPickupTime = 'Y';
         $shipment->LanguageCode = 'en';
-        $shipment->PiecesEnabled = 'Y';
+        // $shipment->PiecesEnabled = 'Y';
+        $shipment->SoftwareName = 'Synchweb';
+        $shipment->SoftwareVersion = $synchweb_version;
         $shipment->Billing->ShippingPaymentType = $options['payee'];
         $shipment->Billing->ShipperAccountNumber = $options['accountnumber'];
         if ($options['payee'] != 'S') {
             $shipment->Billing->BillingAccountNumber = $options['accountnumber'];
         }
-        $shipment->Billing->DutyPaymentType = 'R';
 
-        $shipment->Dutiable->DeclaredValue = $options['declaredvalue'];
-        $shipment->Dutiable->DeclaredCurrency = 'GBP';
+
+        // International Only:
+        // $shipment->Billing->DutyPaymentType = 'R';
+        // $shipment->Dutiable->DeclaredValue = $options['declaredvalue'];
+        // $shipment->Dutiable->DeclaredCurrency = 'GBP';
 
         $shipment->Consignee->CompanyName = $options['receiver']['company'];
-        foreach (split("\n", $options['receiver']['address']) as $l) {
-            if ($l) $shipment->Consignee->addAddressLine($l);
-        }
+
+        // TODO: Fix this s.t. lines are added to AddressLine1,2,3
+        $address_lines = explode(PHP_EOL, $options['receiver']['address']);
+        if ($address_lines[0]) $shipment->Consignee->addAddressLine1($address_lines[0]);
+        if ($address_lines[1]) $shipment->Consignee->addAddressLine2($address_lines[1]);
+        if ($address_lines[2]) $shipment->Consignee->addAddressLine3($address_lines[2]);
+        // foreach (split("\n", $options['receiver']['address']) as $l) {
+        //     if ($l) $shipment->Consignee->addAddressLine1($l);
+        // }
+
         $shipment->Consignee->City = $options['receiver']['city'];
         $shipment->Consignee->PostalCode = $options['receiver']['postcode'];
         $shipment->Consignee->CountryName = $options['receiver']['country'];
@@ -162,22 +186,22 @@ class DHL
         $shipment->Consignee->Contact->PhoneNumber = $options['receiver']['phone'];
         $shipment->Consignee->Contact->Email = $options['receiver']['email'];
 
-        $shipment->ShipmentDetails->NumberOfPieces = sizeof($options['pieces']);
+        // $shipment->ShipmentDetails->NumberOfPieces = sizeof($options['pieces']);
         $shipment->ShipmentDetails->WeightUnit = 'K';
         $shipment->ShipmentDetails->GlobalProductCode = $options['service'];
         $shipment->ShipmentDetails->Date = array_key_exists('date', $options) ? $options['date'] : date('Y-m-d');
         $shipment->ShipmentDetails->Contents = $options['description'];
         $shipment->ShipmentDetails->DimensionUnit = 'C';
         $shipment->ShipmentDetails->CurrencyCode = 'GBP';
-        $shipment->ShipmentDetails->DoorTo = 'DD';
+        // $shipment->ShipmentDetails->DoorTo = 'DD';
         // $shipment->ShipmentDetails->IsDutiable = 'Y';
 
         if (array_key_exists('notification', $options)) $shipment->Notification->EmailAddress = $options['notification'];
         if (array_key_exists('message', $options)) $shipment->Notification->Message = $options['message'];
 
-        $weight = 0;
+        // $weight = 0;
         foreach ($options['pieces'] as $i => $d) {
-            $weight += $d['weight'];
+            // $weight += $d['weight'];
 
             $piece = new Piece();
             $piece->PieceID = ($i + 1);
@@ -188,13 +212,20 @@ class DHL
             $shipment->ShipmentDetails->addPiece($piece);
         }
 
-        $shipment->ShipmentDetails->Weight = $weight;
+        // $shipment->ShipmentDetails->Weight = $weight;
 
         $shipment->Shipper->ShipperID = (string)rand(10000000, 9999999);
         $shipment->Shipper->CompanyName = $options['sender']['company'];
-        foreach (split("\n", $options['sender']['address']) as $l) {
-            if ($l) $shipment->Shipper->addAddressLine($l);
-        }
+
+        // TODO: Fix this s.t. lines are added to AddressLine1,2,3
+        $address_lines = explode(PHP_EOL, $options['sender']['address']);
+        if ($address_lines[0]) $shipment->Shipper->addAddressLine1($address_lines[0]);
+        if ($address_lines[1]) $shipment->Shipper->addAddressLine2($address_lines[1]);
+        if ($address_lines[2]) $shipment->Shipper->addAddressLine3($address_lines[2]);
+        // foreach (split("\n", $options['sender']['address']) as $l) {
+        //     if ($l) $shipment->Shipper->addAddressLine1($l);
+        // }
+
         $shipment->Shipper->City = $options['sender']['city'];
         $shipment->Shipper->PostalCode = $options['sender']['postcode'];
         $shipment->Shipper->CountryCode = $this->_country_codes[$options['sender']['country']];
@@ -207,7 +238,7 @@ class DHL
 
         if ($this->log) file_put_contents('logs/shipmentrequest_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['sender']['name'] . '.xml'), $shipment->toXML());
 
-        $client = new WebserviceClient($this->env);
+        $client = new Web($this->env);
         $xml = $client->call($shipment);
 
         if ($this->log) file_put_contents('logs/shipmentresponse_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['sender']['name'] . '.xml'), $xml);
@@ -276,7 +307,7 @@ class DHL
 
         if ($this->log) file_put_contents('logs/pickuprequest_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['requestor']['name'] . '.xml'), $pickup->toXML());
 
-        $client = new WebserviceClient($this->env);
+        $client = new Web($this->env);
         $xml = $client->call($pickup);
 
         if ($this->log) file_put_contents('logs/pickupresponse_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['requestor']['name'] . '.xml'), $xml);
@@ -312,7 +343,7 @@ class DHL
 
         if ($this->log) file_put_contents('logs/cancelpickuprequest_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['confirmationnumber'] . '.xml'), $cancelpickup->toXML());
 
-        $client = new WebserviceClient($this->env);
+        $client = new Web($this->env);
         $xml = $client->call($cancelpickup);
 
         if ($this->log) file_put_contents('logs/cancelpickupresponse_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['confirmationnumber'] . '.xml'), $xml);
@@ -364,7 +395,7 @@ class DHL
 
         if ($this->log) file_put_contents('logs/quoterequest_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['sender']['city'] . '.xml'), $quote->toXML());
 
-        $client = new WebserviceClient($this->env);
+        $client = new Web($this->env);
         $xml = $client->call($quote);
 
         if ($this->log) file_put_contents('logs/quoteresponse_' . date('Ymd-Hi') . '_' . str_replace(' ', '_', $options['sender']['city'] . '.xml'), $xml);
@@ -382,6 +413,8 @@ class DHL
                 $del = explode('-', (string)$q->DeliveryDate);
 
                 $code = (string)$q->GlobalProductCode;
+
+                // Skip over medical express
                 if ($code == 'C') continue;
 
                 array_push($products, array(


### PR DESCRIPTION
**JIRA ticket:** [LIMS-232](https://jira.diamond.ac.uk/browse/LIMS-232)

**Changes:**

- Update `composer.json` to use a [fork](https://github.com/MattPrit/dhl-api) of the PHP library that makes DHL requests with the updated schema.
- Check if address lines are set before trying to set the elements of the DHL shipping request.

**To test:**

- Test that quote/shipping/pickup/tracking requests can be made successfully.

**Note:** Currently uses a fork on my GitHub account; the aim is to move over to https://github.com/mtcmedia/dhl-api once Synchweb has been updated to PHP7