### PR TITLE
[LIMS-231]Improvement: Update and move description on shipping label

### DIFF
--- a/api/assets/pdf/shipment_label.php
+++ b/api/assets/pdf/shipment_label.php
@@ -93,17 +93,13 @@
             <div class="right thirty ca">
                 <img src="assets/images/dls_logo.jpg" width="250px" />
 
-                <br />
-                <br />
-
-                <p class="bold">Frozen samples in Dry-Shipper for experiments at facility</p>
-                <br />
-                <p class="bold">Not restricted,<br />As per IATA special provision A152</p>
-
                 <img src="assets/images/arrow.png"  width="250px" />
 
                 <p class="bold">HANDLE WITH CARE</p>
                 <p class="bold">DO NOT DROP</p>
+
+                <br />
+                <p class="bold">Cryogenic dry shipper. Not restricted,<br/>ADR A346, IATA A152.</p>
 
                 <?php if ($d['AUTO'] > 0): ?>
                     <div class="notification">
@@ -188,17 +184,13 @@
             <div class="right thirty ca">
                 <img src="assets/images/dls_logo.jpg" width="250px" />
 
-                <br />
-                <br />
-
-                <p class="bold">Frozen samples in Dry-Shipper for experiments at DLS</p>
-                <br />
-                <p class="bold">Not restricted,<br />As per IATA special provision A152</p>
-
                 <img src="assets/images/arrow.png"  width="250px" />
 
                 <p class="bold">HANDLE WITH CARE</p>
                 <p class="bold">DO NOT DROP</p>
+
+                <br />
+                <p class="bold">Cryogenic dry shipper. Not restricted,<br/>ADR A346, IATA A152.</p>
             </div>
 
             <div class="ca pad">

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -52,7 +52,6 @@ define(['backbone',
 
             DESCRIPTION: {
                 required: true,
-                pattern: 'wwsdash',
             }
         }
     })


### PR DESCRIPTION
**JIRA ticket:**

**Changes:**

- Swap positions of 'This way up' and shipment description.
- Update the description to read 'Cryogenic dry shipper. Not restricted, ADR A346, IATA A152.'
- Change validation on package description field on the create air waybill page to allow the new description.

**To test:**

- Check that shipment labels are formatted as expected.
- Check that airway bills can be created using the new description.

**Note:** To update the description on airway bills, `$package_description` will need to be updated in `config.php`.