### PR TITLE
R2.4.1 (Fix): Remove NumberOfPieces from DHL shipment request

### DIFF
--- a/api/src/Shipment/Courier/DHL.php
+++ b/api/src/Shipment/Courier/DHL.php
@@ -167,7 +167,6 @@ class DHL
 
         $shipment->Reference->ReferenceID = $options['shipperid'];
 
-        $shipment->ShipmentDetails->NumberOfPieces = sizeof($options['pieces']);
         $shipment->ShipmentDetails->WeightUnit = 'K';
         $shipment->ShipmentDetails->GlobalProductCode = $options['service'];
         $shipment->ShipmentDetails->Date = array_key_exists('date', $options) ? $options['date'] : date('Y-m-d');


### PR DESCRIPTION
This fixes an issue made when merging DHL changes into the R4.2.1 branch: NumberOfPieces was not removed from DHL shipment requests - this is required by the new version of the DHL XML API schema.