### PR TITLE
[LIMS-253]Fix: Null courier name breaks shipment page

### DIFF
--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -19,7 +19,7 @@
             <a class="button send" href="#"><i class="fa fa-plane"></i> Mark as Sent</a>
         <% } %>
 
-        <% if (!DELIVERYAGENT_AGENTNAME || DHL_ENABLE && (DELIVERYAGENT_AGENTNAME.toLowerCase() == 'dhl')) { %>
+        <% if (!DELIVERYAGENT_AGENTNAME || (DHL_ENABLE && DELIVERYAGENT_AGENTNAME.toLowerCase() == 'dhl')) { %>
         <% if (DELIVERYAGENT_HAS_LABEL == '1') { %>
             <a class="button pdf" href="<%-APIURL%>/pdf/awb/sid/<%-SHIPPINGID%>"><i class="fa fa-print"></i> Print Air Waybill</a>
             <!-- <a class="button cancel" href="#"><i class="fa fa-truck"></i> Cancel Pickup</a> -->


### PR DESCRIPTION
JIRA ticket: [LIMS-253](https://jira.diamond.ac.uk/browse/LIMS-253)

Currently when a shipment has `deliveryAgent_agentCode=null` in ispyb the shipment page can't be shown due to a JavaScript type error. This is because `DELIVERYAGENT_AGENTNAME.toLowerCase()` is called before checking if `DELIVERYAGENT_AGENTNAME` is null. This PR fixes this issue.