### PR TITLE
[LIMS-255] Fix: Allow dots in local contact

### DIFF
--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -22,7 +22,7 @@ define(['backbone'], function(Backbone) {
 
         LOCALCONTACT: {
             required: false,
-            pattern: 'wwsdash'
+            pattern: 'wwsddash'
         },
 
 

--- a/client/src/js/utils/validation.js
+++ b/client/src/js/utils/validation.js
@@ -2,6 +2,7 @@ define(['backbone', 'backbone-validation'], function(Backbone) {
 
     _.extend(Backbone.Validation.patterns, {
         wwsdash: /^(\w|\s|\-)+$/,
+        wwsddash: /^(\w|\s|\-|\.)+$/,
         wwsldash: /^(\w|\s|\-|\/)+$/,
         wwsbdash: /^(\w|\s|\-|\(|\))+$/,
         wwdash: /^(\w|\-)+$/,

--- a/client/src/js/utils/validation.js
+++ b/client/src/js/utils/validation.js
@@ -24,6 +24,7 @@ define(['backbone', 'backbone-validation'], function(Backbone) {
     _.extend(Backbone.Validation.messages, {
         required: 'This field is required',
         wwsdash: 'This field must contain only letters, numbers, spaces, underscores, and dashes',
+        wwsddash: 'This field must contain only letters, numbers, spaces, underscores, dots, and dashes',
         wwdash: 'This field must contain only letters, numbers, underscores, and dashes',
         edate: 'Please specify a valid date (european style)',
         word: 'This field must contain only letters and numbers',


### PR DESCRIPTION
**JIRA ticket: [LIMS-255](https://jira.diamond.ac.uk/browse/LIMS-255)**

**Changes:**

- Create new validation type for letters/numbers/spaces/underscores/dots/dashes
- Add help message for new validation type
- Use new validation type on visit local contact

**To test:**

- Check that the form can be submitted with a local contact with only letters and spaces
- Check that the form can be submitted with a local contact with a dot in (eg Dr. Anastasia Shilova, https://ispyb.diamond.ac.uk/dewars/dispatch/57805)
- Check the form cannot be submitted with invalid characters in the local contact field - may not be possible to test