### PR TITLE
LIMS-158: When filtering by 'Full collections', dont show single image data collections

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -106,7 +106,8 @@ class DC extends Page
                     $where = '';
                     if ($this->arg('t') == 'sc') $where = ' AND dc.overlap != 0';
                     else if ($this->arg('t') == 'gr') $where = ' AND dc.axisrange = 0';
-                    else if ($this->arg('t') == 'fc') $where = ' AND dc.overlap = 0 AND dc.axisrange > 0';
+                    else if ($this->arg('t') == 'fc') $where = ' AND dc.overlap = 0 AND dc.axisrange > 0 AND dc.numberOfImages > 1';
+
                     
                 } else if ($this->arg('t') == 'edge') {
                     $where2 = '';


### PR DESCRIPTION
**JIRA ticket: [LIMS-158](https://jira.diamond.ac.uk/browse/LIMS-158)**

**Changes:**

- If filter type is 'full collections', append 'and numberOfImages>1' to the SQL query

**To test:**

- Check that single image data collections no longer appear if 'Full collections' is selected
- Check that single image data collections still appear if 'Data collections' or no filter is selected