### PR TITLE
LIMS-87: When viewing a log file, dont interpret <I> as a HTML tag

### DIFF
--- a/client/src/js/views/log.js
+++ b/client/src/js/views/log.js
@@ -78,7 +78,7 @@ define(['marionette', 'views/dialog', 'utils'], function(Marionette, DialogView,
                     var dec = new TextDecoder('utf-8')
                     var text = dec.decode(this.response)
 
-                    if (mimeType.indexOf('text/plain') > -1) text = '<pre>'+text+'</pre>'
+                    if (mimeType.indexOf('text/plain') > -1) text = '<textarea readonly style="height:100%; width:100%">'+text+'</textarea>'
 
                     doc.open()
                     doc.write(sh+text)


### PR DESCRIPTION
**Jira ticket: [LIMS-87](https://jira.diamond.ac.uk/browse/LIMS-87)**

**Changes:**

- Use `<textarea>` instead of `<pre>` when displaying log files, otherwise intensities (eg `<I>`, `<I/sI>`) are interpreted as HTML and the rest of the log is in italics.

**To test:**

- Check plain text log files display correctly
- Check other log files display correctly
- Check log files download correctly