### PR TITLE
LIMS-225: Allow hyphens in user path when creating pucks

### DIFF
--- a/client/src/js/modules/types/mx/samples/tabbed-columns-view.vue
+++ b/client/src/js/modules/types/mx/samples/tabbed-columns-view.vue
@@ -72,7 +72,7 @@
         :ref="`sample_${sampleIndex}_user_path`"
         class-names="tw-px-2 tw-w-3/12"
         :name="`Sample ${sampleIndex + 1} User Path`"
-        :rules="sample['PROTEINID'] > -1 ? { regex: /^(\w+(\/\w+)?)$/ } : ''"
+        :rules="sample['PROTEINID'] > -1 ? { regex: /^((\w|\-)+(\/(\w|\-)+)?)$/ } : ''"
         :vid="`sample ${sampleIndex + 1} userpath`">
         <template v-slot="{ errors, inputChanged }">
           <base-input-text


### PR DESCRIPTION
**JIRA ticket: [LIMS-225](https://jira.diamond.ac.uk/browse/LIMS-225)**

**Changes:**

- Change regex validation on User Path field to allow hyphens before and after the forward slash

**To test:**

- Check the form can be submitted with hyphens in the User Path
- Check the sample can be edited to add hyphens to the User Path
- Check the Bulk Editor can put hyphens in the User Path