### PR TITLE
[LIMS-259]Fix: Direct links to shipments fail

### DIFF
--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -198,10 +198,8 @@ define(['marionette',
 
             edit.create("ENCLOSEDHARDDRIVE", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("ENCLOSEDTOOLS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
-
-            proposal_code = app.proposal.get('PROPOSALCODE')
             industrial_codes = ['in', 'sw']
-            industrial_visit = industrial_codes.includes(proposal_code)
+            industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
             if (!industrial_visit) {
                 this.$el.find(".remoteormailin").hide()
             } else {

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -109,9 +109,8 @@ define(['marionette', 'views/form',
         updateDynamicSchedule: function() {
             // Added as a fix to allow dynamic sessions
             // An extra option for proposals with no sessions yet that are not automated
-            proposal_code = app.proposal.get('PROPOSALCODE')
             industrial_codes = ['in', 'sw']
-            industrial_visit = industrial_codes.includes(proposal_code)
+            industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
             if (this.ui.dynamic.is(':checked')) {
                 this.ui.first.html('<option value=""> - </option>')
                 this.ui.noexp.prop('checked', false)


### PR DESCRIPTION
JIRA ticket: [LIMS-259](https://jira.diamond.ac.uk/browse/LIMS-259)

Changes:

- Alter logic determining if a given visit is an industrial visit to use app.prop rather than app.proposal

To test:

- Check that shipment pages now load correctly from direct links