### PR TITLE
[LIMS-254] Fix: Add default country options of UK/Other

### DIFF
--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -106,7 +106,9 @@ define(['marionette', 'views/form',
         },
 
         populateCountries: function() {
-            this.ui.country.html(this.countries.opts())
+            if (this.countries.length > 0) {
+                this.ui.country.html(this.countries.opts())
+            }
         },
 
         initialize: function(options) {

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -92,7 +92,10 @@
                 <label>Laboratory Country
                     <span class="small">The contact's laboratory country</span>
                 </label>
-                <select name="COUNTRY"></select>
+                <select name="COUNTRY">
+                    <option value="United Kingdom">United Kingdom</option>
+                    <option value="Other">Other</option>
+                </select>
             </li>
 
              <li>


### PR DESCRIPTION
JIRA ticket: [LIMS-254](https://jira.diamond.ac.uk/browse/LIMS-254)

Changes:

    Add default countries of "United Kingdom" and "Other" on the dewar dispatch form
    Only overwrite those with full list of countries if such a list exists

To test:

    Check the dropdown still populates with full list of countries
    Check the dropdown has UK/Other options if countries URL is blocked (firefox -> F11 -> Network tab -> right click on countries -> Block URL
    Check the form can be submitted with United Kingdom, Other, Aruba