### PR TITLE
LIMS-324: Fix DYNAMIC arg in backend

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2209,7 +2209,7 @@ class Shipment extends Page
                 $tools_enclosed = $this->arg('ENCLOSEDTOOLS') ? "Yes" : "No";
             }
 
-            $dynamic = $this->has_arg("DYNAMIC") ? $this->has_arg("DYNAMIC") : null;
+            $dynamic = $this->has_arg("DYNAMIC") ? $this->arg("DYNAMIC") : null;
 
             $extra_array = array(
                 "ENCLOSEDHARDDRIVE"=> $hard_drive_enclosed,


### PR DESCRIPTION
JIRA ticket: [LIMS-324](https://jira.diamond.ac.uk/browse/LIMS-324)

Changes:
- Patch fix for issue introduced in https://github.com/DiamondLightSource/SynchWeb/pull/416. Shipping argument `DYNAMIC` would always be set to `true` when provided. This change fixes this issue.

To test:
- Check that shipments created with `DYNAMIC` set to `true/false` have the correct value added to the database.