### PR TITLE
LIMS-335: Set courier as 'DHL' for facility shipping

### DIFF
--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -248,7 +248,7 @@ define(['marionette', 'views/form',
 
         toggleFacilityCourier: function() {
             this.ui.facc.hide()
-            this.ui.courier.val('DHL - Facility')
+            this.ui.courier.val('DHL')
             this.ui.courierDetails.hide()
             this.ui.facilityCourier.show()
             this.model.courierDetailsRequired = false


### PR DESCRIPTION
JIRA ticket: [LIMS-335](https://jira.diamond.ac.uk/browse/LIMS-335)

Changes:

- Set courier as 'DHL' when requesting a Dewar dispatch on the facility's account in the case where the shipping terms haven't been accepted before the dispatch request. This makes it consistent with dispatches where the terms had been accepted earlier.

To test:

- Check that when a dispatch is requested the courier is always set to 'DHL'.