### PR TITLE
LIMS-260: Validate samples before adding container to UDC queue

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -399,8 +399,6 @@ export default {
       try {
         this.displayQueueModal = false
         const validated = await this.$refs.containerForm.validate()
-        console.log(this.QUEUEFORUDC)
-        console.log(validated)
         if(!validated){
           this.containerQueueError = true
           this.$store.commit('notifications/addNotification', {


### PR DESCRIPTION
JIRA ticket: [LIMS-260](https://jira.diamond.ac.uk/browse/LIMS-260)

Changes:

- Make it so that a container cannot be added to the UDC queue from the container view page if the information in the samples table does not meet the criteria for adding to the UDC queue on the container add page.

To test:

- Check that a container cannot be added to the UDC queue if fields are missing in the samples table.