### PR TITLE
LIMS-75: Show more than 10 visits on the assign containers page

### DIFF
--- a/client/src/js/modules/assign/routes.js
+++ b/client/src/js/modules/assign/routes.js
@@ -56,7 +56,7 @@ const routes = [
                 props: {
                     mview: SelectVisitView,
                     options: {
-                        collection: new Visits(null, { queryParams: { next: 1 } })
+                        collection: new Visits(null, { queryParams: { next: 1 }, state: { pageSize: 9999 }})
                     },
                     breadcrumbs: [bc]
                 }


### PR DESCRIPTION
Ticket: [LIMS-75](https://jira.diamond.ac.uk/browse/LIMS-75)

On the page https://ispyb.diamond.ac.uk/assign, we load the next 10 visits for the current proposal, but if a proposal has more than 10 current/future visits, there is no way to get to the 11th onward. This PR ups the pageSize to 9999.