### PR TITLE
LIMS-213: Update regex to enable creating Block-4 containers

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -103,7 +103,7 @@ class Shipment extends Page
                               // Container fields
                               'DEWARID' => '\d+',
                               'CAPACITY' => '\d+',
-                              'CONTAINERTYPE' => '\w+',
+                              'CONTAINERTYPE' => '([\w-])+',
                               'NAME' => '([\w-])+',
                               'SCHEDULEID' => '\d+',
                               'SCREENID' => '\d+',


### PR DESCRIPTION
Ticket: [LIMS-213](https://jira.diamond.ac.uk/browse/LIMS-213)

Trying to create a container of type "Block-4" would fail because of the regex not expecting a hyphen.