### PR TITLE
LIMS-405: Cannot view samples in containers of type 'Block-4'

### DIFF
--- a/client/src/js/modules/shipment/components/container-view-wrapper.vue
+++ b/client/src/js/modules/shipment/components/container-view-wrapper.vue
@@ -113,7 +113,7 @@ export default {
       // This is the current logic to determine the plate type
       // Anything other than Box, Puck or PCRStrip
       // TODO - get container types from data base
-      let is_plate = ['box', 'puck', 'pcrstrip', null].indexOf(containerType) == -1 && containerType.indexOf('puck') == -1
+      let is_plate = ['box', 'puck', 'pcrstrip', 'block-4', null].indexOf(containerType) == -1 && containerType.indexOf('puck') == -1
 
       return is_plate
     },


### PR DESCRIPTION
Ticket: [LIMS-405](https://jira.diamond.ac.uk/browse/LIMS-405)

If an i23-style puck was created using the containerType 'block-4', it was displayed as a plate as it didn't match the list of non-plate container types. Adding 'block-4' to the list means the samples are displayed the same as a puck.