### PR TITLE
LIMS-270: Enable staff to see proposals from other villages

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -154,8 +154,9 @@ class Proposal extends Page
                             $bls = array_merge($bls, $this->_get_beamlines_from_type($ty));
                         }
                     }
-
-                    $where .= " AND s.beamlinename in ('".implode("','", $bls)."')";
+                    $where = " LEFT OUTER JOIN session_has_person shp ON shp.sessionid = s.sessionid  ".$where;
+                    $where .= " AND (shp.personid=:".(sizeof($args)+1)." OR s.beamlinename in ('".implode("','", $bls)."'))";
+                    array_push($args, $this->user->personid);
                 }
             } else {
                 $where = " INNER JOIN session_has_person shp ON shp.sessionid = s.sessionid  ".$where;


### PR DESCRIPTION
Ticket: [LIMS-270](https://jira.diamond.ac.uk/browse/LIMS-270)

If users go to the list of proposals, they get a list of all proposals they have a visit on. If staff go to the list of proposals, they get a list of all proposals for beamlines they are admin on. This fix gives staff an extra OR condition, for proposals on other beamlines.