### PR TITLE
[LIMS-377] SynchWeb: Display resolution where I/SigI == 2 in frontend

### DIFF
--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -676,6 +676,7 @@ class Processing extends Page {
             apss.anomalousmultiplicity as anommultiplicity,
             apss.multiplicity,
             apss.meanioversigi as isigi,
+            apss.resioversigi2 as resisigi,
             ap.spacegroup as sg,
             ap.refinedcell_a as cell_a,
             ap.refinedcell_b as cell_b,
@@ -764,6 +765,11 @@ class Processing extends Page {
                     if ($key == 'ISIGI') {
                         $value = number_format($value, 1);
                     }
+
+                    if ($key == 'RESISIGI') {
+                        $value = number_format($value, 2);
+                    }
+
                     if ($key == 'RMERGE') {
                         $value = number_format($value, 3);
                     }

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -765,11 +765,9 @@ class Processing extends Page {
                     if ($key == 'ISIGI') {
                         $value = number_format($value, 1);
                     }
-
                     if ($key == 'RESISIGI') {
                         $value = number_format($value, 2);
                     }
-
                     if ($key == 'RMERGE') {
                         $value = number_format($value, 3);
                     }

--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -102,6 +102,9 @@
                 <th>Resolution</th>
                 <th>Rmeas</th>
                 <th>I/sig(I)</th>
+                <%if (SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00) { %>
+                <th>I/sig(I) == 2</th>
+                <% }%>
                 <th>CC Half</th>
                 <th>Completeness</th>
                 <th>Multiplicity</th>
@@ -118,6 +121,9 @@
             <td><%-s.RHIGH%> - <%-s.RLOW%></td>
             <td><% print(TYPE == 'Fast DP' ? s.RMERGE : s.RMEAS)%></td>
             <td><%-s.ISIGI%></td>
+            <%if (SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00) { %>
+            <td><%-s.RESISIGI%></td>
+            <% }%>
             <td><%-s.CCHALF%></td>
             <td><%-s.COMPLETENESS%></td>
             <td><%-s.MULTIPLICITY%></td>

--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -102,7 +102,7 @@
                 <th>Resolution</th>
                 <th>Rmeas</th>
                 <th>I/sig(I)</th>
-                <%if (SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00) { %>
+                <%if (SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.outerShell.RESISIGI != 0.00 && SHELLS.overall.RESISIGI != 0.00) { %>
                 <th>I/sig(I) == 2</th>
                 <% }%>
                 <th>CC Half</th>
@@ -121,7 +121,7 @@
             <td><%-s.RHIGH%> - <%-s.RLOW%></td>
             <td><% print(TYPE == 'Fast DP' ? s.RMERGE : s.RMEAS)%></td>
             <td><%-s.ISIGI%></td>
-            <%if (SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.innerShell.RESISIGI != 0.00) { %>
+            <%if (s.RESISIGI != 0.00 && s.RESISIGI != 0.00 && s.RESISIGI != 0.00) { %>
             <td><%-s.RESISIGI%></td>
             <% }%>
             <td><%-s.CCHALF%></td>


### PR DESCRIPTION
Ticket: [LIMS-377](https://jira.diamond.ac.uk/browse/LIMS-377)

Display resIOverSigI2 value in SynchWeb in dataset stats view, where it only shows when it is available in ISPYB.