### PR TITLE
[LIMS-321]Fix: 

### DIFF
--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -191,7 +191,7 @@ define(['marionette', 'views/form',
 
             this.countries = new Countries()
             this.countries.state.pageSize = 9999
-            this.countries.fetch()
+            this.ready.push(this.countries.fetch())
         },
 
         updateLC: function() {

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -121,7 +121,6 @@ define(['marionette', 'views/form',
             this.$el.find('input[name=DELIVERYAGENT_SHIPPINGDATE]').val(today)
             this.$el.find('.facilityCourier').hide()
             
-            proposal_code = app.proposal.get('PROPOSALCODE')
             industrial_codes = ['in', 'sw']
             industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
             if (industrial_visit) {


### PR DESCRIPTION
JIRA ticket: [LIMS-321](https://jira.diamond.ac.uk/browse/LIMS-321)

Changes:

- Add the call to `countries.fetch` to the array awaited on rendering the dispatch view.

To test:

- Check that the country drop-down is now always populated with the complete list of countries, rather than just 'United Kingdom/other'

Note: It is not really possible to ensure that the list is *always* populated. When testing this change I added an artificial delay in the back end function `_get_countries`. Before this change the delay would result in the list of countries not being populated; after the change the list would be populated once the request returned.