### PR TITLE
[LIMS-377] Patch: conditional logic changed for I/SigI == 2  

### DIFF
--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -102,8 +102,8 @@
                 <th>Resolution</th>
                 <th>Rmeas</th>
                 <th>I/sig(I)</th>
-                <%if (SHELLS.innerShell.RESISIGI != 0.00 && SHELLS.outerShell.RESISIGI != 0.00 && SHELLS.overall.RESISIGI != 0.00) { %>
-                <th>I/sig(I) == 2</th>
+                <%if (!(SHELLS.innerShell.RESISIGI === "0.00" &&  SHELLS.outerShell.RESISIGI === "0.00" && SHELLS.overall.RESISIGI === "0.00")) { %>
+                    <th>I/sig(I) == 2</th>
                 <% }%>
                 <th>CC Half</th>
                 <th>Completeness</th>
@@ -121,7 +121,7 @@
             <td><%-s.RHIGH%> - <%-s.RLOW%></td>
             <td><% print(TYPE == 'Fast DP' ? s.RMERGE : s.RMEAS)%></td>
             <td><%-s.ISIGI%></td>
-            <%if (s.RESISIGI != 0.00 && s.RESISIGI != 0.00 && s.RESISIGI != 0.00) { %>
+            <%if (!(SHELLS.innerShell.RESISIGI === "0.00" &&  SHELLS.outerShell.RESISIGI === "0.00" && SHELLS.overall.RESISIGI === "0.00")) { %>         
             <td><%-s.RESISIGI%></td>
             <% }%>
             <td><%-s.CCHALF%></td>


### PR DESCRIPTION
Ticket: [LIMS-377](https://jira.diamond.ac.uk/browse/LIMS-377)

Change: Patch where  I/SigI == 2  field logic has changed where value appears correctly in autoproc table. 

To test: check user journey is as expected. 