### PR TITLE
[LIMS-212] Fix: Add endpoint to post comments without special permissions

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -74,6 +74,7 @@ class Proposal extends Page
 
                                         array('/visits(/:visit)', 'get', '_get_visits'),
                                         array('/visits/:visit', 'patch', '_update_visit'),
+                                        array('/visitscomm/:visit', 'patch', '_update_visit_comment'),
                                         array('/visits', 'post', '_add_visit'),
 
                                         array('/visits/users', 'get', '_get_visit_users'),
@@ -515,6 +516,33 @@ class Proposal extends Page
             }
 
             $this->_output(array('total' => sizeof($rows), 'data' => $rows));
+        }
+
+        # ------------------------------------------------------------------------
+        # Update visit comment
+        function _update_visit_comment() {
+            if (!$this->has_arg('visit')) $this->_error('No visit specified');
+            if (!$this->has_arg('prop')) $this->_error('No proposal specified');
+            if (!$this->has_arg('COMMENTS')) $this->_error('No comment specified');
+
+            $vis = $this->db->pq("SELECT s.sessionid, st.sessiontypeid, st.typename from blsession s
+            INNER JOIN proposal p ON p.proposalid = s.proposalid 
+            LEFT OUTER JOIN sessiontype st on st.sessionid = s.sessionid
+            WHERE p.proposalid = :1 AND CONCAT(CONCAT(CONCAT(p.proposalcode, p.proposalnumber), '-'), s.visit_number) LIKE :2", array($this->proposalid, $this->arg('visit')));
+        
+            if (!sizeof($vis)) $this->_error('No such visit');
+            $vis = $vis[0];
+            
+            $fields = array('COMMENTS');
+
+            foreach ($fields as $f) {
+                $fl = in_array($f, array('STARTDATE', 'ENDDATE')) ? "TO_DATE(:1, 'DD-MM-YYYY HH24:MI')" : ':1';
+                if ($this->has_arg($f)) {
+                    $this->db->pq("UPDATE blsession set $f=$fl where sessionid=:2", array($this->arg($f), $vis['SESSIONID']));
+                    $this->_output(array($f => $this->arg($f)));
+                }
+            }
+
         }
 
 

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -523,7 +523,6 @@ class Proposal extends Page
         function _update_visit_comment() {
             if (!$this->has_arg('visit')) $this->_error('No visit specified');
             if (!$this->has_arg('prop')) $this->_error('No proposal specified');
-            if (!$this->has_arg('COMMENTS')) $this->_error('No comment specified');
 
             $vis = $this->db->pq("SELECT s.sessionid, st.sessiontypeid, st.typename from blsession s
             INNER JOIN proposal p ON p.proposalid = s.proposalid 
@@ -532,15 +531,11 @@ class Proposal extends Page
         
             if (!sizeof($vis)) $this->_error('No such visit');
             $vis = $vis[0];
-            
-            $fields = array('COMMENTS');
+        
 
-            foreach ($fields as $f) {
-                $fl = in_array($f, array('STARTDATE', 'ENDDATE')) ? "TO_DATE(:1, 'DD-MM-YYYY HH24:MI')" : ':1';
-                if ($this->has_arg($f)) {
-                    $this->db->pq("UPDATE blsession set $f=$fl where sessionid=:2", array($this->arg($f), $vis['SESSIONID']));
-                    $this->_output(array($f => $this->arg($f)));
-                }
+            if ($this->has_arg('COMMENTS')) {
+                $this->db->pq("UPDATE blsession set comments=:1 where sessionid=:2", array($this->arg('COMMENTS'), $vis['SESSIONID']));
+                $this->_output(array('COMMENTS' => $this->arg('COMMENTS')));
             }
 
         }

--- a/client/src/js/modules/visits/views/visit_list.vue
+++ b/client/src/js/modules/visits/views/visit_list.vue
@@ -180,7 +180,7 @@ export default {
             visit.clicked = false;
 
             await this.$store.dispatch('updateDataToApi', {
-            url: '/proposal/visits/' + visit.VISIT + '?prop=' + visit.PROPOSAL + '&COMMENTS=' + visit.COMMENTS,
+            url: '/proposal/visitscomm/' + visit.VISIT + '?prop=' + visit.PROPOSAL + '&COMMENTS=' + visit.COMMENTS,
             type: 'PATCH',
             requestType: 'updating comment for visit'
             }).then(


### PR DESCRIPTION
Ticket: [LIMS-212](https://jira.diamond.ac.uk/browse/LIMS-212)

Changes:
Endpoint created in proposal.php where users can add comments to the visits without needing manage visit permissions. 

To test:
Check postman returns expected json
Check ISPYB records change
Check user journey is as expected. 