### PR TITLE
LIMS-70: Remove references to DISTL

### DIFF
--- a/client/src/js/modules/dc/views/dc.js
+++ b/client/src/js/modules/dc/views/dc.js
@@ -137,7 +137,7 @@ define(['marionette',
       
     showDistl: function(e) {
       e.preventDefault()
-      app.dialog.show(new DialogView({ title: 'DISTL Plot', view: new DCDISTLView({ parent: this.model }), autoSize: true }))
+      app.dialog.show(new DialogView({ title: 'Per-image Analysis Plot', view: new DCDISTLView({ parent: this.model }), autoSize: true }))
     },
     
     loadStrategies: function(e) {

--- a/client/src/js/templates/dc/reprocess.html
+++ b/client/src/js/templates/dc/reprocess.html
@@ -1,5 +1,5 @@
 	<p class="help">
-		Select data sets to reintegrate by selecting a number of images in the DISTL plot. Provide unit cell parameters, space group, and high resolution cut off as needed.
+		Select data sets to reintegrate by selecting a number of images in the per-image analysis plot. Provide unit cell parameters, space group, and high resolution cut off as needed.
 	</p>
 
     <div class="ra">

--- a/client/src/js/templates/mc/datacollections.html
+++ b/client/src/js/templates/mc/datacollections.html
@@ -1,7 +1,7 @@
 <h1>Data Collections for <%-VISIT%></h1>
 
     <p class="help">Use this page to reintegrate multiple data collections together</p>
-    <p class="help">Select data sets to integrate by dragging accross the DISTL plot below. This selects which images of the data set to integrate</p>
+    <p class="help">Select data sets to integrate by dragging accross the per-image analysis plot below. This selects which images of the data set to integrate</p>
 
     <div class="filter filter-nohide">
     	<div class="srch"></div>

--- a/client/src/js/templates/types/sm/dc/dc.html
+++ b/client/src/js/templates/types/sm/dc/dc.html
@@ -12,7 +12,7 @@
     <div class="links">
         <a href="/dc/view/id/<%-ID%>"><i class="fa fa-picture-o fa-2x"></i> Images</a> 
         <a class="sn" href="#snapshots"><i class="fa fa-camera fa-2x"></i> Snapshots</a> 
-        <a class="dl" href="#distl"><i class="fa fa-bar-chart-o fa-2x"></i> DISTL</a> 
+        <a class="dl" href="#distl"><i class="fa fa-bar-chart-o fa-2x"></i> Per-image Analysis</a> 
     </div>
     
     <ul class="clearfix">

--- a/client/src/js/templates/vue/docs/data/index.html
+++ b/client/src/js/templates/vue/docs/data/index.html
@@ -10,7 +10,7 @@
 
     <p class="inset"><img alt="Viewing Data" src="/assets/images/doc/data/data_search_ap.png"> /></p>
 
-    <p>From this page you can view diffraction /assetsimages for each data collection, crystal snapshots, and DISTL plots. You can search through data collections using the search box on the right and filter data collections by type using the list of filters on the top</p>
+    <p>From this page you can view diffraction /assetsimages for each data collection, crystal snapshots, and per-image analysis plots. You can search through data collections using the search box on the right and filter data collections by type using the list of filters on the top</p>
 
     <p>Auto processing results from the Fast DP and XIA2 pipelines can be displayed by clicking the &quot;Auto Processing&quot; header. &quot;Downstream Processing&quot; shows results from the Fast EP and DIMPLE pipelines</p>
 


### PR DESCRIPTION
Ticket: [LIMS-70](https://jira.diamond.ac.uk/browse/LIMS-70)

Remove references to DISTL from a few places:

Most notably, in the title of the per-image analysis plots
In the help text on reprocessing and multicrystal reprocessing
From the links next to a SM data collection