### PR TITLE
[LIMS-413]Improvement: Make dynamic editable

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2210,7 +2210,10 @@ class Shipment extends Page
                 $tools_enclosed = $this->arg('ENCLOSEDTOOLS') ? "Yes" : "No";
             }
 
-            $dynamic = $this->has_arg("DYNAMIC") ? "Yes" : "No";
+            $dynamic = null;
+            if ($this->has_arg('DYNAMIC')){
+                $dynamic = $this->arg("DYNAMIC") ? "Yes" : "No";
+            }
 
             $extra_array = array(
                 "ENCLOSEDHARDDRIVE"=> $hard_drive_enclosed,

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -83,7 +83,7 @@ class Shipment extends Page
                               //'FIRSTEXPERIMENTID' => '\w+\d+-\d+',
 
                               // Fields for responsive remote questions:
-                              'DYNAMIC' => '1?',
+                              'DYNAMIC' => '1?|Yes|No',
                               'REMOTEORMAILIN' => '.*',
                               'SESSIONLENGTH' => '\w+',
                               'ENERGY' => '.*',
@@ -2210,7 +2210,7 @@ class Shipment extends Page
                 $tools_enclosed = $this->arg('ENCLOSEDTOOLS') ? "Yes" : "No";
             }
 
-            $dynamic = $this->has_arg("DYNAMIC") ? $this->arg("DYNAMIC") : null;
+            $dynamic = $this->has_arg("DYNAMIC") ? "Yes" : "No";
 
             $extra_array = array(
                 "ENCLOSEDHARDDRIVE"=> $hard_drive_enclosed,

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -171,6 +171,22 @@ define(['marionette',
         refreshDewar: function() {
             this.fetchDewars(true)
         },
+
+        updateDynamic: function(){
+            dynamic = this.model.get('DYNAMIC')
+            dynamicSelectedValues = [true, 'Yes', 'yes', 'Y', 'y']
+            if (!dynamicSelectedValues.includes(dynamic)) {
+                this.$el.find(".remoteormailin").hide()
+                this.$el.find(".remoteform").hide()
+            } else {
+                industrial_codes = ['in', 'sw']
+                industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
+                if (industrial_visit) {
+                    this.$el.find(".remoteormailin").show()
+                }
+                this.$el.find(".remoteform").show()
+            }
+        },
         
         onRender: function() {
             if (app.proposal && app.proposal.get('ACTIVE') != '1') this.ui.add_dewar.hide()
@@ -198,6 +214,7 @@ define(['marionette',
 
             edit.create("ENCLOSEDHARDDRIVE", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("ENCLOSEDTOOLS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("DYNAMIC", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             industrial_codes = ['in', 'sw']
             industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
             if (!industrial_visit) {
@@ -212,6 +229,9 @@ define(['marionette',
             edit.create("SCHEDULINGRESTRICTIONS", 'text')
             edit.create("LASTMINUTEBEAMTIME", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("DEWARGROUPING", 'select', { data: {'Yes': 'Yes', 'No': 'No', 'Don\'t mind': 'Don\'t mind'}})
+
+            this.updateDynamic()
+            this.listenTo(this.model, "change:DYNAMIC", this.updateDynamic)
             
             var self = this
             this.contacts = new LabContacts(null, { state: { pageSize: 9999 } })

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -135,46 +135,57 @@
                 <span class="ENCLOSEDTOOLS"><%-ENCLOSEDTOOLS %></span>
             </li>
             <% } %>
-            
-
-            <% if (DYNAMIC) {%>
-            <% if (REMOTEORMAILIN) {%>
-            <li class="remoteormailin">
-                <span class="label">Remote or mail in</span>
-                <span class="REMOTEORMAILIN"><%-REMOTEORMAILIN %></span>
-            </li>
-            <% } %>
 
             <li>
-                <span class="label">Session length</span>
-                <span class="SESSIONLENGTH"><%-SESSIONLENGTH %></span>
+                <span class="label">Responsive Remote</span>
+                <span class="DYNAMIC"><%-DYNAMIC %></span>
             </li>
 
-            <li>
-                <span class="label">Energy/wavelength requirements</span>
-                <span class="ENERGY"><%-ENERGY %></span>
-            </li>
+                <%
+                DYNAMIC=(typeof DYNAMIC !== 'undefined')? DYNAMIC : 'No';
+                REMOTEORMAILIN=(typeof REMOTEORMAILIN !== 'undefined')? REMOTEORMAILIN : null;
+                SESSIONLENGTH=(typeof SESSIONLENGTH !== 'undefined')? SESSIONLENGTH : null;
+                ENERGY=(typeof ENERGY !== 'undefined')? ENERGY : null;
+                MICROFOCUSBEAM=(typeof MICROFOCUSBEAM !== 'undefined')? MICROFOCUSBEAM : null;
+                SCHEDULINGRESTRICTIONS=(typeof SCHEDULINGRESTRICTIONS !== 'undefined')? SCHEDULINGRESTRICTIONS : null;
+                LASTMINUTEBEAMTIME=(typeof LASTMINUTEBEAMTIME !== 'undefined')? LASTMINUTEBEAMTIME : null;
+                DEWARGROUPING=(typeof DEWARGROUPING !== 'undefined')? DEWARGROUPING : null;
+                %>
 
-            <li>
-                <span class="label">Microfocus beam requested</span>
-                <span class="MICROFOCUSBEAM"><%-MICROFOCUSBEAM %></span>
-            </li>
+                <li class="remoteormailin">
+                    <span class="label">Remote or mail in</span>
+                    <span class="REMOTEORMAILIN"><%-REMOTEORMAILIN %></span>
+                </li>
 
-            <li>
-                <span class="label">Scheduling restrictions</span>
-                <span class="SCHEDULINGRESTRICTIONS"><%-SCHEDULINGRESTRICTIONS %></span>
-            </li>
+                <li class="remoteform">
+                    <span class="label">Session length</span>
+                    <span class="SESSIONLENGTH"><%-SESSIONLENGTH %></span>
+                </li>
 
-            <li>
-                <span class="label">Consider for last-minute beamtime</span>
-                <span class="LASTMINUTEBEAMTIME"><%-LASTMINUTEBEAMTIME %></span>
-            </li>
+                <li class="remoteform">
+                    <span class="label">Energy/wavelength requirements</span>
+                    <span class="ENERGY"><%-ENERGY %></span>
+                </li>
 
-            <li>
-                <span class="label">Group Dewars</span>
-                <span class="DEWARGROUPING"><%-DEWARGROUPING %></span>
-            </li>
-            <% } %>
+                <li class="remoteform">
+                    <span class="label">Microfocus beam requested</span>
+                    <span class="MICROFOCUSBEAM"><%-MICROFOCUSBEAM %></span>
+                </li>
+
+                <li class="remoteform">
+                    <span class="label">Scheduling restrictions</span>
+                    <span class="SCHEDULINGRESTRICTIONS"><%-SCHEDULINGRESTRICTIONS %></span>
+                </li>
+
+                <li class="remoteform">
+                    <span class="label">Consider for last-minute beamtime</span>
+                    <span class="LASTMINUTEBEAMTIME"><%-LASTMINUTEBEAMTIME %></span>
+                </li>
+
+                <li class="remoteform">
+                    <span class="label">Group Dewars</span>
+                    <span class="DEWARGROUPING"><%-DEWARGROUPING %></span>
+                </li>
 
             <li>
                 <span class="label">Comments</span>


### PR DESCRIPTION
JIRA ticket: [LIMS-413](https://jira.diamond.ac.uk/browse/LIMS-413)

Changes:

- Allow `DYNAMIC` to be changed via the shipment page - i.e. allow users to change 'responsive remote' after a shipment has been created.
- Change the type of `DYNAMIC` to be a string `'Yes'`/`'No'` rather than a boolean.
- Allow responsive remote options (`REMOTEORMAILIN`, `SESSIONLENGTH`, `ENERGY`, `MICROFOCUSBEAM`, `SCHEDULINGRESTRICTIONS`, `LASTMINUTEBEAMTIME`, `DEWARGROUPING`) to be shown/hidden when the value of `DYNAMIC` is changed on the shipment page.

To test:

- Check that `DYNAMIC` and the remote options can be edited via the shipment page.