### PR TITLE
[LIMS-129]Fix: Fix Pilatus 12M resolution in image viewer

### DIFF
--- a/client/src/js/modules/dc/views/imageviewer.js
+++ b/client/src/js/modules/dc/views/imageviewer.js
@@ -95,7 +95,7 @@ define(['jquery', 'marionette',
             this.draw = _.debounce(this.draw, 10)
             this.readjust = _.debounce(this.readjust, 200)
             
-            // console.log(this.model)
+            console.log(this.model)
 
             this.n = options.n || 1
             this.img = new XHRImage()
@@ -718,14 +718,26 @@ define(['jquery', 'marionette',
         _xy_to_dist: function(x, y) {
             return Math.sqrt(Math.pow(Math.abs(x*this.ps/this.imscale-this.model.get('XBEAM')),2)+Math.pow(Math.abs(y*this.ps/this.imscale-this.model.get('YBEAM')),2))
         },
-          
+        
+        _xy_to_res: function(x, y) {
+            if (this.model.get('DETECTORMODEL') === "Pilatus 12M") {
+                x_mm = this.ps * x / this.imscale - this.model.get('XBEAM')
+                y_mm = this.ps * y / this.imscale - this.model.get('YBEAM')
+                r_det = 250
+                theta = Math.acos(r_det * Math.cos(y_mm / r_det) / Math.sqrt(r_det * r_det + x_mm * x_mm))
+                wavelength = this.model.get('WAVELENGTH')
+                res = wavelength / (2 * Math.sin(theta / 2))
+                return res
+            }
+            return this._dist_to_res(this._xy_to_dist(x,y))
+        },
           
         // Set cursor position and resolution
         _cursor: function(x, y) {
             var posx = (x/this.scalef)-(this.offsetx/this.scalef)
             var posy = (y/this.scalef)-(this.offsety/this.scalef)
           
-            var res = this._dist_to_res(this._xy_to_dist(posx,posy))
+            var res = this._xy_to_res(posx, posy)
     
             this.ui.resc.text(res.toFixed(2))
         },

--- a/client/src/js/modules/dc/views/imageviewer.js
+++ b/client/src/js/modules/dc/views/imageviewer.js
@@ -94,8 +94,6 @@ define(['jquery', 'marionette',
             this.onResize = _.debounce(this.onResize, 200)
             this.draw = _.debounce(this.draw, 10)
             this.readjust = _.debounce(this.readjust, 200)
-            
-            console.log(this.model)
 
             this.n = options.n || 1
             this.img = new XHRImage()


### PR DESCRIPTION
JIRA ticket: [LIMS-129](https://jira.diamond.ac.uk/browse/LIMS-129)

Changes:

- Change the formula used in calculating resolution on moving the cursor in the image viewer when the `DETECTORMODEL` is `"Pilatus 12M"`. This formula should produce more accurate values of resolution for the curved detector.

To test:

- Check that the values of resolution produced are now more accurate for the Pilatus 12M detector, i.e. consistent with the formulae linked in the JIRA ticket.