### PR TITLE
LIMS-453: Email container owners when a dewar returns to the dewar store

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -516,13 +516,24 @@ class Shipment extends Page
 
                 if (sizeof($rows)) $dew['DC'] = $rows;
 
-                $cc = $dewar_complete_email ? $dewar_complete_email : null;
+                $cc = array($dewar_complete_email ? $dewar_complete_email : null);
+
+                $owners = $this->db->pq("SELECT p.emailaddress
+                    FROM Container c
+                    INNER JOIN Person p ON c.ownerId = p.personId
+                    WHERE c.dewarId = :1
+                    GROUP BY p.emailaddress", array($dew['DEWARID']));
+
+                foreach ($owners as $owner) {
+                    if ($owner['EMAILADDRESS'] != '') array_push($cc, $owner['EMAILADDRESS']);
+                }
+
                 // Log the event if debugging
                 if ($this->debug) error_log("Dewar " . $dew['DEWARID'] . " back from beamline...");
 
                 $email = new Email('storage-rack', '*** Visit finished, dewar awaiting instructions ***');
                 $email->data = $dew;
-                $email->send($dew['LCRETEMAIL'], $cc);
+                $email->send($dew['LCRETEMAIL'], implode(', ', $cc));
             }
 
             $this->_output(array('DEWARHISTORYID' => $dhid));


### PR DESCRIPTION
Ticket: [LIMS-453](https://jira.diamond.ac.uk/browse/LIMS-453)

Currently when dewars are returned to the Randex we send an email to the lab contact to say the dewar is ready for return or internal transfer. Feedback from users is that the current notifications aren't going to the right people, and that the people creating the samples don't get told once their samples are done. This PR adds all container "owners" to the CC list of the email.