### PR TITLE
LIMS-342: Move MCA peak labels when window resizes

### DIFF
--- a/client/src/js/modules/dc/views/mcaplot.js
+++ b/client/src/js/modules/dc/views/mcaplot.js
@@ -10,7 +10,7 @@ define(['marionette', 'modules/dc/models/mca', 'utils',
     modelEvents: { 'change': 'render' },
                                                
     initialize: function(options) {
-        this.$el.css('opactiy', 0)
+        this.$el.css('opacity', 0)
         this.model = new MCAModel({ id: options.id })
         var self = this
         this.model.fetch().done(function() { console.log(self.model) })
@@ -24,6 +24,7 @@ define(['marionette', 'modules/dc/models/mca', 'utils',
         var pl = $.plot(this.$el, data, { grid: { borderWidth: 0 }, yaxis: { max: m.get('MAX')*1.1 } })
         var max = m.get('MAX')
         var plot_x_max = pl.getAxes().xaxis.datamax
+        var plot_width = this.$el.width()
         
         $.each(m.get('ELEMENTS'), function(e,d) {
             var inten = e[e.length-1] ==  'K' ? [1,0.2] : [0.9,0.1,0.5,0.05,0.05]
@@ -33,11 +34,13 @@ define(['marionette', 'modules/dc/models/mca', 'utils',
             $.each(d[0], function(i,en) {
                 if (inten[i] > 0.1 & mp > 0.01) {
                     var o = pl.pointOffset({ x: en*1000-(plot_x_max*0.03), y: max*inten[i]*mp+(0.18*max)});
-                    self.$el.append('<div class="annote" style="left:' + (o.left + 4) + 'px;top:' + o.top + 'px;">'+e+'<sub>'+elines[i]+'</sub></div>');
+                    if (o.left > 0) {
+                        self.$el.append('<div class="annote" style="left:' + (100*o.left/plot_width) + '%;top:' + o.top + 'px;">'+e+'<sub>'+elines[i]+'</sub></div>');
+                    }
                 }
             })
         })
-        this.$el.css('opactiy', 1)
+        this.$el.css('opacity', 1)
         this.plot = pl
     },
             


### PR DESCRIPTION
Ticket: [LIMS-342](https://jira.diamond.ac.uk/browse/LIMS-342)

If the browser window is resized, the peak labels (eg "Se-K") on an MCA spectrum should move with the peaks themselves.
Also fix typo on "opacity".