### PR TITLE
[LIMS-475]Fix: Persist SCHEDULINGRESTRICTIONS to database

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2228,7 +2228,7 @@ class Shipment extends Page
                 }
                 $scheduling_restrictions = null;
                 if ($this->has_arg('SCHEDULINGRESTRICTIONS')){
-                    $this->arg('SCHEDULINGRESTRICTIONS') ? $this->arg('SCHEDULINGRESTRICTIONS') : "None";
+                    $scheduling_restrictions = $this->arg('SCHEDULINGRESTRICTIONS') ? $this->arg('SCHEDULINGRESTRICTIONS') : "None";
                 }
                 $last_minute_beamtime = null;
                 if ($this->has_arg('LASTMINUTEBEAMTIME')){


### PR DESCRIPTION
JIRA ticket: [LIMS-475](https://jira.diamond.ac.uk/browse/LIMS-475)

Changes:

- Assign `SCHEDULINGRESTRICTIONS` to the `$scheduling_restrictions` vaiable

To test:

- Check that, when a 'dynamic' shipment is created with scheduling restrictions specified, the scheduling restrictions are persisted to the database.