### PR TITLE
[LIMS-428]Feature: Dispatch Dewars using an external shipping service

### DIFF
--- a/api/assets/emails/html/dewar-dispatch.html
+++ b/api/assets/emails/html/dewar-dispatch.html
@@ -8,10 +8,17 @@
 		<table class="details" style="background: #f4f4f4; margin: 1%">
 			<tbody>
 				<?php if (isset($data['AWBURL'])): ?>
-				<tr>
-					<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
-					<td><?php echo $data['AWBURL'] ?></td>
-				</tr>
+					<?php if ($data['AWBURL']): ?>
+						<tr>
+							<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
+							<td><?php echo $data['AWBURL'] ?></td>
+						</tr>
+					<?php else: ?>
+						<tr>
+							<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
+							<td><?php echo nl2br("Shipping service could not book the shipment.\nPlease book a shipment for this Dewar using the details below.") ?></td>
+						</tr>
+					<?php endif; ?>
 				<?php endif; ?>
 
 				<tr>

--- a/api/assets/emails/html/dewar-dispatch.html
+++ b/api/assets/emails/html/dewar-dispatch.html
@@ -7,7 +7,7 @@
 
 		<table class="details" style="background: #f4f4f4; margin: 1%">
 			<tbody>
-				<?php if ($data['AWBURL']): ?>
+				<?php if (isset($data['AWBURL'])): ?>
 				<tr>
 					<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
 					<td><?php echo $data['AWBURL'] ?></td>

--- a/api/assets/emails/html/dewar-dispatch.html
+++ b/api/assets/emails/html/dewar-dispatch.html
@@ -7,6 +7,13 @@
 
 		<table class="details" style="background: #f4f4f4; margin: 1%">
 			<tbody>
+				<?php if ($data['AWBURL']): ?>
+				<tr>
+					<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
+					<td><?php echo $data['AWBURL'] ?></td>
+				</tr>
+				<?php endif; ?>
+
 				<tr>
 					<td style="padding: 1.5%; font-weight: bold">Visit</td>
 					<td><?php echo $data['VISIT'] ?></td>

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -1,0 +1,108 @@
+<?php
+
+
+namespace SynchWeb\Shipment;
+
+class ShippingService
+{
+    private $shipping_api_url;
+    private $headers;
+
+    function __construct()
+    {
+        global $shipping_service_url;
+        $this->shipping_api_url = $shipping_service_url;
+        $this->headers = array(
+            'Accept: application/json',
+            'Content-Type: application/json',
+        );
+    }
+
+
+    function _send_request($url, $type, $data, $expected_status_code)
+    {
+        $ch = curl_init($url);
+        curl_setopt_array(
+            $ch,
+            array(
+                CURLOPT_RETURNTRANSFER => TRUE,
+                CURLOPT_HTTPHEADER => $this->headers,
+                CURLOPT_TIMEOUT => 5
+            )
+        );
+        switch ($type) {
+            case "POST":
+                curl_setopt_array(
+                    $ch,
+                    array(
+                        CURLOPT_POST => TRUE,
+                        CURLOPT_POSTFIELDS => json_encode($data)
+                    )
+                );
+                break;
+            case "GET":
+                break;
+            case "PUT":
+                curl_setopt_array(
+                    $ch,
+                    array(
+                        CURLOPT_CUSTOMREQUEST => "PUT",
+                        CURLOPT_HTTPHEADER => array_merge($this->headers, array('Content-Length: ' . strlen(json_encode($data)))),
+                        CURLOPT_POSTFIELDS => json_encode($data),
+                    )
+                );
+                break;
+        }
+        $response = json_decode(curl_exec($ch), TRUE);
+        $status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($status_code != $expected_status_code) {
+            throw new \Exception(json_encode(array('status' => $status_code, 'content' => $response)));
+        }
+        return $response;
+    }
+
+
+    function create_shipment($shipment_data)
+    {
+        return $this->_send_request(
+            $this->shipping_api_url . '/shipments/',
+            "POST",
+            $shipment_data,
+            201
+        );
+    }
+
+
+    function get_shipment($external_id)
+    {
+        return $this->_send_request(
+            $this->shipping_api_url . '/shipments/external_id/' . $external_id,
+            "GET",
+            null,
+            200
+        );
+    }
+
+
+    function update_shipment($external_id, $shipment_data)
+    {
+        return $this->_send_request(
+            $this->shipping_api_url . '/shipments/external_id/' . $external_id,
+            "PUT",
+            $shipment_data,
+            204
+        );
+    }
+
+
+    function dispatch_shipment($shipment_id)
+    {
+        return $this->_send_request(
+            $this->shipping_api_url . '/shipments/' . $shipment_id . '/dispatch',
+            "POST",
+            array(),
+            201
+        );
+    }
+}


### PR DESCRIPTION
JIRA ticket: [LIMS-428](https://jira.diamond.ac.uk/browse/LIMS-428)

Changes:

- Add support for booking Dewar return shipments using an external shipping service.
- Add link to AWBs to dispatch request email if enabled.

To test:
Check that, on a dewar dispatch request, with facility shipping terms accepted:
- If the Dewar has not already been dispatched, a shipment is made and dispatched in the shipping service.
- If the Dewar has already been dispatched, the relevant shipment is updated and re-dispatched in the shipping service.
- A link to the air waybill is provided in the Dewar dispatch request email.