### PR TITLE
LIMS-467: Display warning when requesting a dispatch for a dewar on i24

### DIFF
--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -167,7 +167,7 @@ define(['marionette', 'views/form',
                 const history = self.history.at(0)
                 const location = history ? history.get('STORAGELOCATION') : null
                 const historyComment = history ? history.get('COMMENTS') : null
-                const restrictedLocations = ['i03', 'i04', 'i04-1', 'i024']
+                const restrictedLocations = ['i03', 'i04', 'i04-1', 'i24']
 
                 if (location) {
                     self.ui.loc.val(location)

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -1,5 +1,5 @@
 <h1>Request Dewar Dispatch</h1>
-<div id="help" class="content dispatch-state tw-hidden md:tw-flex tw-my-4 tw-p-4 tw-bg-content-inactive tw-rounded tw-flex tw-justify-between">
+<div id="help" class="content dispatch-state tw-hidden md:tw-flex tw-my-4 tw-p-4 tw-bg-content-inactive tw-rounded tw-flex tw-justify-between" data-testid="dispatch-warning">
   Please note, dewars are not topped up with LN2 after a return is requested.
 </div>
 


### PR DESCRIPTION
Ticket: [LIMS-467](https://jira.diamond.ac.uk/browse/LIMS-467)

* When requesting dispatch of a dewar, those on the beamline should display a warning
* Fixes typo of 'i024' to 'i24'
* Add data-testid tag for Selenium test