### PR TITLE
LIMS-464: Add config variable to allow ending of grid scan image scaling

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -48,9 +48,9 @@ $app->configureMode('development', function () use ($app) {
 });
 
 $app->get('/options', function () use ($app) {
-    global $motd, $authentication_type, $cas_url, $cas_sso, $package_description, $facility_courier_countries, $facility_courier_countries_nde, $dhl_enable, $dhl_link, $scale_grid, $preset_proposal, $timezone, $valid_components, $enabled_container_types;
+    global $motd, $authentication_type, $cas_url, $cas_sso, $package_description, $facility_courier_countries, $facility_courier_countries_nde, $dhl_enable, $dhl_link, $scale_grid, $scale_grid_end_date, $preset_proposal, $timezone, $valid_components, $enabled_container_types;
     $app->contentType('application/json');
-    $app->response()->body(json_encode(array('motd' => $motd, 'authentication_type' => $authentication_type, 'cas_url' => $cas_url, 'cas_sso' => $cas_sso, 'package_description' => $package_description, 'facility_courier_countries' => $facility_courier_countries, 'facility_courier_countries_nde' => $facility_courier_countries_nde, 'dhl_enable' => $dhl_enable, 'dhl_link' => $dhl_link, 'scale_grid' => $scale_grid, 'preset_proposal' => $preset_proposal, 'timezone' => $timezone, 'valid_components' => $valid_components, 'enabled_container_types' => $enabled_container_types)));
+    $app->response()->body(json_encode(array('motd' => $motd, 'authentication_type' => $authentication_type, 'cas_url' => $cas_url, 'cas_sso' => $cas_sso, 'package_description' => $package_description, 'facility_courier_countries' => $facility_courier_countries, 'facility_courier_countries_nde' => $facility_courier_countries_nde, 'dhl_enable' => $dhl_enable, 'dhl_link' => $dhl_link, 'scale_grid' => $scale_grid, 'scale_grid_end_date' => $scale_grid_end_date, 'preset_proposal' => $preset_proposal, 'timezone' => $timezone, 'valid_components' => $valid_components, 'enabled_container_types' => $enabled_container_types)));
 });
 
 // the following prevents unexpected effects when using objects as save handlers

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1394,7 +1394,7 @@ class DC extends Page {
         # ------------------------------------------------------------------------
         # Grid Scan Info
         function _grid_info() {
-            $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d%H%i%S') as rts
+            $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d') as startdate
                 FROM gridinfo g
                 INNER JOIN datacollection dc on (dc.datacollectionid = g.datacollectionid) or (dc.datacollectiongroupid = g.datacollectiongroupid)
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1394,7 +1394,7 @@ class DC extends Page {
         # ------------------------------------------------------------------------
         # Grid Scan Info
         function _grid_info() {
-            $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked
+            $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d%H%i%S') as rts
                 FROM gridinfo g
                 INNER JOIN datacollection dc on (dc.datacollectionid = g.datacollectionid) or (dc.datacollectiongroupid = g.datacollectiongroupid)
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -296,10 +296,10 @@ define(['jquery', 'marionette',
                 var w = bw*this.grid.get('STEPS_X')
                 var h = bh*this.grid.get('STEPS_Y')
 
-                var rts = this.grid.get('RTS')
-                var sged = app.options.get('scale_grid_end_date')
+                var start_date = this.grid.get('STARTDATE')
+                var scale_grid_end_date = app.options.get('scale_grid_end_date')
 
-                var scale_grid = (app.options.get('scale_grid').indexOf(this.getOption('BL')) > -1 && (rts < sged * 1e6 || sged == null))
+                var scale_grid = (app.options.get('scale_grid').indexOf(this.getOption('BL')) > -1 && (start_date < scale_grid_end_date || scale_grid_end_date == null))
                 console.log("scale_grid: "+scale_grid)
 
                 if (scale_grid) {

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -296,7 +296,13 @@ define(['jquery', 'marionette',
                 var w = bw*this.grid.get('STEPS_X')
                 var h = bh*this.grid.get('STEPS_Y')
 
-                if (app.options.get('scale_grid').indexOf(this.getOption('BL')) > -1) {
+                var rts = this.grid.get('RTS')
+                var sged = app.options.get('scale_grid_end_date')
+
+                var scale_grid = (app.options.get('scale_grid').indexOf(this.getOption('BL')) > -1 && (rts < sged * 1e6 || sged == null))
+                console.log("scale_grid: "+scale_grid)
+
+                if (scale_grid) {
                     var scalef = this.snapshot.width/1024
 
                     stx *= scalef


### PR DESCRIPTION
Ticket: [LIMS-464](https://jira.diamond.ac.uk/browse/LIMS-464)

* Requires new variable in config.php, formatted as eg:
$scale_grid_end_date = 20221231;

* This should be added as/when GDA fix the grid scan scaling on affected beamlines (listed as $scale_grid)
* If $scale_grid_end_date is not present, image scaling will continue as before