### PR TITLE
LIMS-211: Paginate detectors to avoid slow query timeouts

### DIFF
--- a/api/src/Page/Exp.php
+++ b/api/src/Page/Exp.php
@@ -167,6 +167,7 @@ class Exp extends Page
 
             $tot = $this->db->pq("SELECT count(d.detectorid) as tot
               FROM detector d
+              LEFT OUTER JOIN beamlinesetup bls ON bls.detectorid = d.detectorid
               WHERE $where", $args);
             $tot = intval($tot[0]['TOT']);
 

--- a/api/src/Page/Exp.php
+++ b/api/src/Page/Exp.php
@@ -178,10 +178,9 @@ class Exp extends Page
                 'd.detectorid ASC'
             );
 
-            $rows = $this->db->paginate("SELECT d.detectorid, d.detectortype, d.detectormanufacturer, d.detectorserialnumber, d.sensorthickness, d.detectormodel, d.detectorpixelsizehorizontal, d.detectorpixelsizevertical, d.detectordistancemin, d.detectordistancemax, d.density, d.composition, concat(d.detectormanufacturer,' ',d.detectormodel, ' (',d.detectortype,')') as description, d.detectormaxresolution, d.detectorminresolution, count(distinct dc.datacollectionid) as dcs, count(distinct bls.beamlinesetupid) as blsetups, (SELECT count(distinct dphd.detectorid) FROM DataCollectionPlan_has_Detector dphd WHERE dphd.detectorid = d.detectorid) as dps, CONCAT_WS(',',GROUP_CONCAT(distinct ses.beamlinename),GROUP_CONCAT(distinct bls.beamlinename)) as beamlines, d.numberofpixelsx, d.numberofpixelsy, d.detectorrollmin, d.detectorrollmax
+            $rows = $this->db->paginate("SELECT d.detectorid, d.detectortype, d.detectormanufacturer, d.detectorserialnumber, d.sensorthickness, d.detectormodel, d.detectorpixelsizehorizontal, d.detectorpixelsizevertical, d.detectordistancemin, d.detectordistancemax, d.density, d.composition, concat(d.detectormanufacturer,' ',d.detectormodel, ' (',d.detectortype,')') as description, d.detectormaxresolution, d.detectorminresolution, count(distinct dc.datacollectionid) as dcs, count(distinct bls.beamlinesetupid) as blsetups, (SELECT count(distinct dphd.detectorid) FROM DataCollectionPlan_has_Detector dphd WHERE dphd.detectorid = d.detectorid) as dps, GROUP_CONCAT(distinct bls.beamlinename) as beamlines, d.numberofpixelsx, d.numberofpixelsy, d.detectorrollmin, d.detectorrollmax
                 FROM detector d
                 LEFT OUTER JOIN datacollection dc ON dc.detectorid = d.detectorid
-                LEFT OUTER JOIN blsession ses ON ses.sessionid = dc.sessionid
                 LEFT OUTER JOIN beamlinesetup bls ON bls.detectorid = d.detectorid
                 WHERE $where
                 GROUP BY d.detectorid

--- a/client/src/js/collections/detectors.js
+++ b/client/src/js/collections/detectors.js
@@ -1,16 +1,23 @@
 define(['backbone.paginator', 'models/detector', 'utils/kvcollection'], function(PageableCollection, Detector ,KVCollection) {
-       
+
     return PageableCollection.extend(_.extend({}, KVCollection, {
         model: Detector,
-        mode: 'client',
+        mode: 'server',
         url: '/exp/detectors',
-                                          
-        state: {
-            pageSize: 15,
-        },
         
         keyAttribute: 'DESCRIPTION',
         valueAttribute: 'DETECTORID',
 
+        state: {
+            pageSize: 5,
+        },
+
+        parseState: function(r, q, state, options) {
+            return { totalRecords: r.total }
+        },
+
+        parseRecords: function(r, options) {
+            return r.data
+        },
     }))
 })


### PR DESCRIPTION
Ticket: [LIMS-211](https://jira.diamond.ac.uk/browse/LIMS-211)

- Mainly, paginate on the server in pages of 5 to speed up the query
- Other minor changes:
  - Use subqueries as this speeds up debugging
  - Remove unused dps2 result
  - Join DataCollection to BLSession to remove join to DataCollectionGroup
  - Use CONCAT_WS to avoid "i03i03" type results
