### PR TITLE
LIMS-510: Display .lsa files from ANODE as preformatted logs

### DIFF
--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -471,7 +471,7 @@ class Download extends Page
             } elseif (in_array($path_ext, array('jpg', 'jpeg'))) {
                 $response->headers->set("Content-Type", "image/jpeg");
                 $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $saved_filename);
-            } elseif (in_array($path_ext, array('log', 'txt', 'error', 'LP', 'json'))) {
+            } elseif (in_array($path_ext, array('log', 'txt', 'error', 'LP', 'json', 'lsa'))) {
                 $response->headers->set("Content-Type", "text/plain");
                 $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE);
             } else {


### PR DESCRIPTION
Ticket: [LIMS-510](https://jira.diamond.ac.uk/browse/LIMS-510)

Add .lsa to the list of extensions to be served as plain text mime type (instead of octet-stream)
Means anode.lsa files (from ANODE) are presented as preformatted logs