### PR TITLE
LIMS-217: Use pia_total_intensity as default PIA for VMXi grid scans

### DIFF
--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -88,6 +88,7 @@ define(['jquery', 'marionette',
             this.attachments = new Attachments()
             this.attachments.queryParams.id = this.getOption('ID')
             this.attachments.queryParams.filetype = 'pia'
+            this.attachments.setSorting('DATACOLLECTIONFILEATTACHMENTID', 1)
 
             this.hasSnapshot = false
             this.snapshot = new XHRImage()

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -88,7 +88,6 @@ define(['jquery', 'marionette',
             this.attachments = new Attachments()
             this.attachments.queryParams.id = this.getOption('ID')
             this.attachments.queryParams.filetype = 'pia'
-            this.attachments.setSorting('DATACOLLECTIONFILEATTACHMENTID', 1)
 
             this.hasSnapshot = false
             this.snapshot = new XHRImage()
@@ -213,11 +212,14 @@ define(['jquery', 'marionette',
 
         populatePIA: function() {
             var d = this.distl.get('data')
+            var defaultPIA = 'pia_total_intensity'
             if (d[0].length < 1) {
                 this.ui.ty.hide()
                 if (this.attachments.length) {
                     const heatMapsOptionsList = `${this.attachments.opts()} \n <option value=""> None </option>`
                     this.ui.ty2.html(heatMapsOptionsList).show()
+                    var a = this.attachments.findWhere({ 'NAME': defaultPIA })
+                    if (a) this.ui.ty2.val(a.get('DATACOLLECTIONFILEATTACHMENTID'))
                     this.loadAttachment()
                 }
             }


### PR DESCRIPTION
Ticket: [LIMS-217](https://jira.diamond.ac.uk/browse/LIMS-217)

- Per-image analysis (PIA) for VMXi grid scans is stored as data collection file attachments
- So by default they are listed in attachment id order, which leaves the most useful one (pia_total_intensity) last
- By reversing the ordering, get the most useful one first, which makes it the default one displayed