### PR TITLE
Use facility_email rather than dispatch_email as shipper_contact_email

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -926,7 +926,7 @@ class Shipment extends Page
         global $facility_phone;
         global $facility_contact;
         global $shipping_service_url;
-        global $dispatch_email;
+        global $facility_email;
         if (!isset($shipping_service_url)) {
             $this->_error("Server could not send request to shipping service.");
         }
@@ -945,7 +945,7 @@ class Shipment extends Page
             "shipper_post_code" => $facility_postcode,
             "shipper_contact_name" => $facility_contact,
             "shipper_contact_phone_number" => $facility_phone,
-            "shipper_contact_email" => $dispatch_email,
+            "shipper_contact_email" => $facility_email,
             "shipment_reference" =>  $dispatch_info['VISIT'],
             "external_id" => (int) $dispatch_info['DEWARID']
         );


### PR DESCRIPTION
Changes:
- Use `$facility_email` rather than `$dispatch_email` as `shipper_contact_email` when making shipping service requests. this is because the shipping service expects only a single email address, whereas `$dispatch_email` can be a list of email addresses. Also, the facility email address is a more sensible email to be used as the shipper contact email from DHL's point of view.

To test:
- Check that a dispatch request can be successfully sent to the shipping service when `$dispatch_email` is a list of emails.