### PR TITLE
LIMS-572: Use micronsPerPixel preferably over pixelsPerMicron for grid scan snapshots

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1441,7 +1441,7 @@ class DC extends Page
     # Grid Scan Info
     function _grid_info()
     {
-        $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g.pixelspermicronx, g.pixelspermicrony, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d') as startdate
+        $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, IFNULL(g.micronsperpixelx,g.pixelspermicronx) as micronsperpixelx, IFNULL(g.micronsperpixely,g.pixelspermicrony) as micronsperpixely, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d') as startdate
                 FROM gridinfo g
                 INNER JOIN datacollection dc on (dc.datacollectionid = g.datacollectionid) or (dc.datacollectiongroupid = g.datacollectiongroupid)
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -286,8 +286,8 @@ define(['jquery', 'marionette',
         draw: function() {
             if (!this.ctx || !this.gridFetched) return
 
-            var bw = 1000*this.grid.get('DX_MM')/Math.abs(this.grid.get('PIXELSPERMICRONX'))
-            var bh = 1000*this.grid.get('DY_MM')/Math.abs(this.grid.get('PIXELSPERMICRONY'))
+            var bw = 1000*this.grid.get('DX_MM')/Math.abs(this.grid.get('MICRONSPERPIXELX'))
+            var bh = 1000*this.grid.get('DY_MM')/Math.abs(this.grid.get('MICRONSPERPIXELY'))
 
             this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
 


### PR DESCRIPTION
Ticket: [LIMS-572](https://jira.diamond.ac.uk/browse/LIMS-572)

- Need to gradually switch from using pixelsPerMicron to micronsPerPixel for grid scan snapshots
- This PR means we can use either, but will prefer pixelsPerMicron
- A later PR will remove the micronsPerPixel possibility once that column has been emptied