### PR TITLE
LIMS-608: Check a user is not null before checking if an admin

### DIFF
--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -439,7 +439,7 @@ class Page
 
         $action = $act ? 'LOGON' : 'LOGOFF';
 
-        if (Utils::ShouldLogUserActivityToDB($this->user))
+        if ($this->user && Utils::ShouldLogUserActivityToDB($this->user->loginId))
         {
             $com = 'ISPyB2: ' . ($com ? $com : $_SERVER['REQUEST_URI']);
             $chk = $this->db->pq("SELECT comments FROM adminactivity WHERE username LIKE :1", array($this->user->loginId));

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -407,7 +407,7 @@ class Page
     {
         $this->_parse_args();
         $this->_get_type();
-        $this->staff = is_null($this->user) ? False : $this->user->hasPermission($this->ty . '_admin');
+        $this->staff = $this->user->hasPermission($this->ty . '_admin');
 
         if (in_array($route->getName(), array('edge', 'mca')))
         {
@@ -439,7 +439,7 @@ class Page
 
         $action = $act ? 'LOGON' : 'LOGOFF';
 
-        if ($this->user && Utils::ShouldLogUserActivityToDB($this->user->loginId))
+        if (Utils::ShouldLogUserActivityToDB($this->user->loginId))
         {
             $com = 'ISPyB2: ' . ($com ? $com : $_SERVER['REQUEST_URI']);
             $chk = $this->db->pq("SELECT comments FROM adminactivity WHERE username LIKE :1", array($this->user->loginId));

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -407,7 +407,7 @@ class Page
     {
         $this->_parse_args();
         $this->_get_type();
-        $this->staff = $this->user->hasPermission($this->ty . '_admin');
+        $this->staff = is_null($this->user) ? False : $this->user->hasPermission($this->ty . '_admin');
 
         if (in_array($route->getName(), array('edge', 'mca')))
         {

--- a/api/src/Utils.php
+++ b/api/src/Utils.php
@@ -22,7 +22,7 @@ class Utils
         global $log_activity_to_ispyb;
         $log_activity = isset($log_activity_to_ispyb) ? $log_activity_to_ispyb : true;
 
-        return $loginId && $log_activity;
+        return $log_activity && $loginId;
     }
 
     public static function getValueOrDefault($value, $default = false)

--- a/api/tests/Controllers/AuthenticationControllerTest.php
+++ b/api/tests/Controllers/AuthenticationControllerTest.php
@@ -54,7 +54,8 @@ final class AuthenticationControllerTest extends TestCase
         $response = new \Slim\Http\Response();
         $this->slimStub->shouldReceive('response')->times(1)->andReturn($response);
         $authService = new AuthenticationController($this->slimStub, $this->dataLayerStub, false);
-        $this->assertNull($authService->getUser());
+        $this->expectExceptionMessage(AuthenticationController::ErrorUnderTestExceptionMessage);
+        $authService->getUser("Exit under test");
     }
 
     private function setupMockRequest(): \Slim\Http\Request
@@ -71,6 +72,7 @@ final class AuthenticationControllerTest extends TestCase
         $response = new \Slim\Http\Response();
         $this->slimStub->shouldReceive('response')->times(1)->andReturn($response);
         $authService = new AuthenticationController($this->slimStub, $this->dataLayerStub, false); // a bit of a hack - if the service uses exit() it is untestable as this will end the process prematurely
+        $this->expectExceptionMessage(AuthenticationController::ErrorUnderTestExceptionMessage);
         $authService->check();
 
         $this->assertContains('Content-Type: application/json', Output::$headers);
@@ -85,6 +87,7 @@ final class AuthenticationControllerTest extends TestCase
         $this->slimStub->shouldReceive('response')->times(1)->andReturn($response);
 
         $authService = new AuthenticationController($this->slimStub, $this->dataLayerStub, false);
+        $this->expectExceptionMessage(AuthenticationController::ErrorUnderTestExceptionMessage);
         $authService->validateAuthentication();
 
         $this->assertContains('Content-Type: application/json', Output::$headers);


### PR DESCRIPTION
Ticket: [LIMS-608](https://jira.diamond.ac.uk/browse/LIMS-608)

* A few specialist systems (eg dewar-logistics) authenticate via IP address, so user is null
* PHP7 is throwing errors when asking for permissions on null users