### PR TITLE
Generate image bitmaps via dials-rest server

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -337,5 +337,7 @@
         'i03' => 'BL03I',
     );
 
-
+    # Dials server values
+    $dials_rest_url = "";
+    $dials_rest_jwt = "";
 ?>

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -996,11 +996,17 @@ class Page
     {
         $ch = curl_init();
 
+        curl_setopt($ch, CURLOPT_HEADER, array_key_exists('HEADER', $options) ? 1 : 0);
+        if (array_key_exists('HEADERS', $options)) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $options['HEADERS']);
+        }
         $headers = getallheaders();
         if (array_key_exists('Authorization', $headers) && array_key_exists('jwt', $options))
         {
             curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: ' . $headers['Authorization']));
         }
+        if (array_key_exists('POST', $options)) curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+        if (array_key_exists('FIELDS', $options)) curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($options['FIELDS']));
 
         $data = '';
         if ($options['data'])

--- a/api/src/Page/Image.php
+++ b/api/src/Page/Image.php
@@ -193,34 +193,52 @@ class Image extends Page
             }
 
             $im = $info['LOC'] . '/' . $info['FT'];
-            $out = '/tmp/'.$this->arg('id').'_'.$n.($this->has_arg('thresh')?'_th':'').'.jpg';
-
+            $out = '/tmp/' . $this->arg('id') . '_' . $n . ($this->has_arg('thresh') ? '_th' : '') . '.jpg';
             global $dials_rest_url, $dials_rest_jwt;
-            if (!file_exists($out) && !empty($dials_rest_url) && !empty($dials_rest_jwt)) {
-                $resp = $this->_curl(array(
-                    'url' => $dials_rest_url.'/export_bitmap/',
-                    'HEADERS' => array(
-                        'Content-Type: application/json',
-                        'accept: application/json',
-                        'Authorization: Bearer '.$dials_rest_jwt,
-                    ),
-                    'POST' => 1,
-                    'FIELDS' => array(
-                        'filename' => $im,
-                        'image_index' => $n,
-                        'binning' => 4,
-                        'display' => $this->has_arg('thresh') ? "threshold" : "image",
-                        'colour_scheme' => 'greyscale',
-                        'brightness' => $this->has_arg('thresh') ? 1000 : 10,
-                        'format' => 'png',
-                    )
-                ));
+            if (!file_exists($out)) {                
+                if (!empty($dials_rest_url) && !empty($dials_rest_jwt)) {
+                    $resp = $this->_curl(array(
+                        'url' => $dials_rest_url.'/export_bitmap/',
+                        'HEADERS' => array(
+                            'Content-Type: application/json',
+                            'accept: application/json',
+                            'Authorization: Bearer ' . $dials_rest_jwt,
+                        ),
+                        'POST' => 1,
+                        'FIELDS' => array(
+                            'filename' => $im,
+                            'image_index' => $n,
+                            'binning' => 4,
+                            'display' => $this->has_arg('thresh') ? "threshold" : "image",
+                            'colour_scheme' => 'greyscale',
+                            'brightness' => $this->has_arg('thresh') ? 1000 : 10,
+                            'format' => 'png',
+                        )
+                    ));
+                } else {
+                    $resp = $this->_curl(array(
+                        'url' => 'http://localhost:5000/dc/image',
+                        'jwt' => true,
+                        'data' => array(
+                            'dcid' => $this->arg('id'),
+                            'image' => $n,
+                            'binning' => 4,
+                            'threshold' => $this->has_arg('thresh') ? 1 : 0,
+                        )
+                    ));
+                }
 
                 if ($resp['code'] == 200) {
                     file_put_contents($out, $resp['content']);
+                } else if ($resp['code'] == 403) {
+                    error_log("Not authorised when asking for grid scan image. Has the JWT token expired?". PHP_EOL);
+                    $this->_error('Unauthroised in image service', 'Image server has had an error.');
+                } else {
+                    error_log("Gridscan failed to contact external service. " . $resp['code'] .  " - " . $resp['content'] . PHP_EOL);
+                    $this->_error('Not found', 'Image not provided by image service.');
                 }
             }
-
+            
             if (file_exists($out)) {
                 $this->_browser_cache();
                 $this->app->contentType('image/jpeg');
@@ -228,6 +246,7 @@ class Image extends Page
                 $this->app->response->headers->set("Content-length", $size);
                 readfile($out);
             } else {
+                error_log("Grid scan image file no longer exists and should do.");
                 $this->_error('Not found', 'That image is no longer available');
             }
         }


### PR DESCRIPTION
This change uses the new [dials-rest server](https://github.com/dials/dials-rest) to generate bitmaps rather than the legacy [flask-dataviewer](https://github.com/DiamondLightSource/flask-dataviewer).

Requires the variables `$dials_rest_url` and `$dials_rest_jwt` to be defined in `config.php`.