### PR TITLE
LIMS-610: Reprocessing limits to maximum of 15 datasets

### DIFF
--- a/client/src/js/collections/reprocessingimagesweeps.js
+++ b/client/src/js/collections/reprocessingimagesweeps.js
@@ -8,7 +8,7 @@ define(['backbone', 'backbone.paginator', 'models/reprocessingimagesweep'],
 
             
         state: {
-            pageSize: 15,
+            pageSize: 9999,
         },
 
 


### PR DESCRIPTION
Ticket: [LIMS-610](https://jira.diamond.ac.uk/browse/LIMS-610)

* Reprocessing multiple datasets together manually was artificially limited to 15 datasets
* Increase page size to 9999 to allow for more