### PR TITLE
LIMS-615: Add Migrate menu item to all villages with Lab Contacts menu item

### DIFF
--- a/client/src/js/modules/types/conexs/menu.js
+++ b/client/src/js/modules/types/conexs/menu.js
@@ -10,6 +10,7 @@ define([], function() {
             visits: 'Visits',
             contacts: 'Lab Contacts',
             conexs: 'Conexs Submission',
+            migrate: 'Migrate',
         },
 
         extra: {

--- a/client/src/js/modules/types/em/menu.js
+++ b/client/src/js/modules/types/em/menu.js
@@ -8,6 +8,7 @@ define([], function() {
             contacts: 'Lab Contacts',
             'dewars/registry': 'Registered Dewars',
             stats: 'Statistics',
+            migrate: 'Migrate',
         },
         extra: {
             //projects: 'Projects',

--- a/client/src/js/modules/types/genproc/menu.js
+++ b/client/src/js/modules/types/genproc/menu.js
@@ -9,6 +9,7 @@ define([], function() {
             dc: 'View All Data',
             visits: 'Visits',
             contacts: 'Lab Contacts',
+            migrate: 'Migrate',
         },
 
         extra: {

--- a/client/src/js/modules/types/pow/menu.js
+++ b/client/src/js/modules/types/pow/menu.js
@@ -10,6 +10,7 @@ define([], function() {
             proteins: 'Components',
             contacts: 'Lab Contacts',
             stats: 'Statistics',
+            migrate: 'Migrate',
         },
         
         extra: {

--- a/client/src/js/modules/types/saxs/menu.js
+++ b/client/src/js/modules/types/saxs/menu.js
@@ -11,6 +11,7 @@ define([], function() {
             proteins: 'Proteins',
             contacts: 'Lab Contacts',
             // stats: 'Statistics',
+            migrate: 'Migrate',
         },
         
         extra: {

--- a/client/src/js/modules/types/xpdf/menu.js
+++ b/client/src/js/modules/types/xpdf/menu.js
@@ -15,6 +15,7 @@ define([], function() {
             xsamples: 'Samples',
             phases: 'Phases',
             contacts: 'Lab Contacts',
+            migrate: 'Migrate',
         },
         
         extra: {


### PR DESCRIPTION
Ticket: [LIMS-615](https://jira.diamond.ac.uk/browse/LIMS-615)

* If a village has Lab Contacts in the main menu, then they are likely to want to migrate them to new proposals
* Add Migrate menu item (going directly to https://ispyb.diamond.ac.uk/migrate already works)