### PR TITLE
LIMS-634: Dont fail sample validation on fields that aren't editable

### DIFF
--- a/client/src/js/modules/types/mx/samples/sample-table-mixin.js
+++ b/client/src/js/modules/types/mx/samples/sample-table-mixin.js
@@ -115,6 +115,7 @@ export default {
     // If the sample belongs to more than one group, we want to return the first matching name and how many other groups it belongs to
     ...createFieldsForSamples([
       'ABUNDANCE',
+      'ACRONYM',
       'ANOMALOUSSCATTERER',
       'BLSUBSAMPLEID',
       'CODE',

--- a/client/src/js/modules/types/mx/samples/sample-table-row.vue
+++ b/client/src/js/modules/types/mx/samples/sample-table-row.vue
@@ -14,7 +14,7 @@
       v-slot="{ errors }"
       class="tw-px-2 protein-column tw-py-1"
       tag="div"
-      :rules="canEditRow(sample['LOCATION'], editingRow) && !isContainerProcessing && !sampleHasDataCollection && sample['NAME'] && (!containerId || editingRow === sample['LOCATION']) ? 'required' : ''"
+      :rules="sample['NAME'] && (!containerId || editingRow === sample['LOCATION']) ? 'required' : ''"
       :name="`Sample ${sampleIndex + 1} Protein`"
       :vid="`sample ${sampleIndex + 1} protein`"
     >
@@ -40,12 +40,12 @@
           </span>
         </template>
       </combo-box>
-      <div
+      <base-input-text
         v-else
-        class="tw-text-center"
-      >
-        {{ sample['ACRONYM'] }}
-      </div>
+        disabled="true"
+        class="tw-w-full tw-text-center"
+        v-model="ACRONYM"
+      />
       <span>{{ errors[0] }}</span>
     </validation-provider>
 

--- a/client/src/js/modules/types/mx/samples/sample-table-row.vue
+++ b/client/src/js/modules/types/mx/samples/sample-table-row.vue
@@ -53,24 +53,18 @@
       v-slot="{ errors }"
       tag="div"
       class="name-column tw-py-1 tw-px-2"
-      :rules="canEditRow(sample['LOCATION'], editingRow) && !isContainerProcessing && !sampleHasDataCollection && sample['PROTEINID'] > -1 && (!containerId || editingRow === sample['LOCATION']) ? 'required|alpha_dash|max:25|' : ''"
+      :rules="sample['PROTEINID'] > -1 && (!containerId || editingRow === sample['LOCATION']) ? 'required|alpha_dash|max:25|' : ''"
       :name="`Sample ${sampleIndex + 1} Name`"
       :vid="`sample ${sampleIndex + 1} name`"
     >
       <base-input-text
-        v-if="canEditRow(sample['LOCATION'], editingRow) && !isContainerProcessing && !sampleHasDataCollection"
+        :disabled="!canEditRow(sample['LOCATION'], editingRow) || isContainerProcessing || sampleHasDataCollection"
         v-model.trim="NAME"
         input-class="tw-w-full tw-h-8"
         :error-message="errors[0]"
         :quiet="true"
         :error-class="errors[0] ? 'tw-text-xxs ferror' : ''"
       />
-      <p
-        v-else
-        class="tw-text-center"
-      >
-        {{ sample['NAME'] }}
-      </p>
     </validation-provider>
 
     <extended-validation-provider

--- a/client/src/js/modules/types/mx/samples/sample-table-row.vue
+++ b/client/src/js/modules/types/mx/samples/sample-table-row.vue
@@ -14,7 +14,7 @@
       v-slot="{ errors }"
       class="tw-px-2 protein-column tw-py-1"
       tag="div"
-      :rules="sample['NAME'] && (!containerId || editingRow === sample['LOCATION']) ? 'required' : ''"
+      :rules="canEditRow(sample['LOCATION'], editingRow) && !isContainerProcessing && !sampleHasDataCollection && sample['NAME'] && (!containerId || editingRow === sample['LOCATION']) ? 'required' : ''"
       :name="`Sample ${sampleIndex + 1} Protein`"
       :vid="`sample ${sampleIndex + 1} protein`"
     >
@@ -53,7 +53,7 @@
       v-slot="{ errors }"
       tag="div"
       class="name-column tw-py-1 tw-px-2"
-      :rules="sample['PROTEINID'] > -1 && (!containerId || editingRow === sample['LOCATION']) ? 'required|alpha_dash|max:25|' : ''"
+      :rules="canEditRow(sample['LOCATION'], editingRow) && !isContainerProcessing && !sampleHasDataCollection && sample['PROTEINID'] > -1 && (!containerId || editingRow === sample['LOCATION']) ? 'required|alpha_dash|max:25|' : ''"
       :name="`Sample ${sampleIndex + 1} Name`"
       :vid="`sample ${sampleIndex + 1} name`"
     >

--- a/client/src/js/modules/types/mx/samples/sample-table-row.vue
+++ b/client/src/js/modules/types/mx/samples/sample-table-row.vue
@@ -19,8 +19,8 @@
       :vid="`sample ${sampleIndex + 1} protein`"
     >
       <combo-box
-        v-if="canEditRow(sample['LOCATION'], editingRow) && !isContainerProcessing && !sampleHasDataCollection"
         v-model="PROTEINID"
+        :is-disabled="!canEditRow(sample['LOCATION'], editingRow) || isContainerProcessing || sampleHasDataCollection"
         :data="proteinsOptionsList"
         class="tw-w-full protein-select"
         text-field="ACRONYM"
@@ -40,12 +40,6 @@
           </span>
         </template>
       </combo-box>
-      <base-input-text
-        v-else
-        disabled="true"
-        class="tw-w-full tw-text-center"
-        v-model="ACRONYM"
-      />
       <span>{{ errors[0] }}</span>
     </validation-provider>
 


### PR DESCRIPTION
Ticket: [LIMS-634](https://jira.diamond.ac.uk/browse/LIMS-634)

* Protein acronym and Sample name fields are not editable when a sample is in a container that is processing or if data has been collected on a sample
* The input validation is still looking at the hidden editable (but empty) fields, so the validation fails
* Set the validation rules to only apply to these fields if these fields are editable
* There may be a better way to do this (https://vee-validate.logaretm.com/v2/guide/conditional-and-looping-inputs.html) but I was unable to get it to work