### PR TITLE
LIMS-612: Allow URL params in a different order

### DIFF
--- a/client/src/js/app/marionette-application.js
+++ b/client/src/js/app/marionette-application.js
@@ -163,7 +163,7 @@ var MarionetteApplication = (function () {
             }
             // Define user permission method - hooked into store
             application.user_can = function(perm) {
-                console.log("CHECK USER PERMISSIONS LIST " + JSON.stringify(store.getters.permissions))
+                console.log("CHECK USER PERMISSIONS LIST " + JSON.stringify(store.getters['user/permissions']))
                 console.log("CHECK USER PERMISSIONS FOR " + perm)
                 return store.getters['user/permissions'].indexOf(perm) > -1
             }

--- a/client/src/js/modules/dc/routes.js
+++ b/client/src/js/modules/dc/routes.js
@@ -100,6 +100,21 @@ let routes = [
     }),
   },
   {
+    path: '/dc(/visit/)?:visit([a-zA-Z]{2}[0-9]+-[0-9]+)?(/dcg/)?:dcg([0-9]+)?(/page/)?:page([0-9]+)?(/ty/)?:ty([a-zA-Z0-9_-]+)?(/s/)?:search([a-zA-z0-9_-]+)?(/id/)?:id([0-9]+)?(/pjid/)?:pjid([0-9]+)?(/sgid/)?:sgid([0-9]+)?',
+    name: 'dc-list',
+    component: DCWrapper,
+    props: route => ({
+        id: +route.params.id || null,
+        visit: route.params.visit || '',
+        dcg: +route.params.dcg || null,
+        page: +route.params.page || 1,
+        ty: route.params.ty || '',
+        search: route.params.search || '',
+        pjid: +route.params.pjid || null,
+        sgid: +route.params.sgid || null
+    }),
+  },
+  {
     path: '/dc/map/id/:id([0-9]+)(/aid/)?:aid([0-9]+)?',
     name: 'dc-mapmodelviewer',
     component: MapModelWrapper,


### PR DESCRIPTION
Ticket: [LIMS-612](https://jira.diamond.ac.uk/browse/LIMS-612)

* URL parameters appear in order the user adds them, so /ty/ can come before or after /s/
* Add a routing option with regex with /ty/ and /s/ swapped around

This is obviously not a very generic way to achieve this, but hopefully this problem only occurs for this specific pair of swapped parameters.