### PR TITLE
LIMS-639: Use getFromCache not setInCache

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2444,7 +2444,7 @@ class Shipment extends Page
     {
         if (!$this->has_arg('name'))
             $this->_error('No key specified');
-        $this->_output($this->user->setInCache($this->arg('name')));
+        $this->_output($this->user->getFromCache($this->arg('name')));
     }
 
     function _dummy_shipment_put()


### PR DESCRIPTION
Ticket: [LIMS-639](https://jira.diamond.ac.uk/browse/LIMS-639)

* Accidental use of setInCache rather than getFromCache
* Introduced in https://github.com/DiamondLightSource/SynchWeb/commit/ab9c8d5ce4cd3453070fa67174aa32c4108873ef#