### PR TITLE
LIMS-651: Allow colons in Shipping.extra fields

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1444,8 +1444,8 @@ class Shipment extends Page
                 $extra_arg_value = addslashes($this->arg($extra_arg_name));
                 $shippingid = $this->arg('sid');
                 $this->db->pq(
-                    "UPDATE shipping SET extra = JSON_SET(extra, '$." . $extra_arg_name . "', '" . $extra_arg_value . "') WHERE shippingid=:1",
-                    array($shippingid)
+                    "UPDATE shipping SET extra = JSON_SET(extra, :1, :2 ) WHERE shippingid=:3",
+                    array('$.' . $extra_arg_name, $extra_arg_value, $shippingid)
                 );
                 $this->_output(array($extra_arg_name => $extra_arg_value));
             }


### PR DESCRIPTION
Ticket: [LIMS-651](https://jira.diamond.ac.uk/browse/LIMS-651)

- If one of the new Shipping.extra fields (eg scheduling restrictions) is set with a colon (eg 11:00), then the db->pq function thinks that is a variable to be substituted (eg :1, :2)
- So bind the parameters in to prevent this