### PR TITLE
LIMS-677: Show screening method as none when strategyOption is null

### DIFF
--- a/client/src/js/models/sample.js
+++ b/client/src/js/models/sample.js
@@ -43,6 +43,8 @@ define(['backbone', 'collections/components',
                     this.set('SAMPLEGROUP', option.sample_group)
                     this.set('STRATEGYOPTION', null)
                 }
+            } else if (this.get('BLSAMPLEID') && !this.get('SCREENINGMETHOD')) {
+                this.set('SCREENINGMETHOD', 'none')
             }
         },
 


### PR DESCRIPTION
Ticket: [LIMS-677](https://jira.diamond.ac.uk/browse/LIMS-677)

* When a container is created by CSV upload, the DiffractionPlan.strategyOption field is often left blank/null
* Synchweb expects something in the Screening Method column to enable editing or queueing
* Show that column as 'None' when strategyOption is blank/null.