### PR TITLE
LIMS-649: Increase max beam size for i23 in run stats page

### DIFF
--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -995,7 +995,7 @@ class Vstat extends Page
             if (is_null($max) || $h['X'] > $max) $max = $h['X'];
             if (is_null($min) || $h['X'] < $min) $min = $h['X'];
         }
-        $min = is_null($min) ? 0 : floor($min/$binSize) * $binSize; // make min align with bin size, or 0 for no data
+        $min = is_null($min) ? 0 : intval(floor($min/$binSize) * $binSize); // make min align with bin size, or 0 for no data
 
         $data = array();
         foreach ($bls as $bl => $y) {

--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -944,10 +944,15 @@ class Vstat extends Page
         $beamlines = $this->_get_beamlines_from_type($this->ty);
         $bls = implode('\', \'', $beamlines);
 
+        $max_beam_size = 600;
+        if ($this->has_arg('bl') && $this->arg('bl') != 'i23') {
+            $max_beam_size = 150;
+        }
+
         $types = array(
             'energy' => array('unit' => 'eV', 'st' => 1000, 'en' => 25000, 'bin_size' => 200, 'col' => '(1.98644568e-25/(dc.wavelength*1e-10))/1.60217646e-19', 'count' => 'dc.wavelength'),
-            'beamsizex' => array('unit' => 'um', 'st' => 0, 'en' => 150, 'bin_size' => 5, 'col' => 'dc.beamsizeatsamplex*1000', 'count' => 'dc.beamsizeatsamplex'),
-            'beamsizey' => array('unit' => 'um', 'st' => 0, 'en' => 150, 'bin_size' => 5, 'col' => 'dc.beamsizeatsampley*1000', 'count' => 'dc.beamsizeatsampley'),
+            'beamsizex' => array('unit' => 'um', 'st' => 0, 'en' => $max_beam_size, 'bin_size' => 5, 'col' => 'dc.beamsizeatsamplex*1000', 'count' => 'dc.beamsizeatsamplex'),
+            'beamsizey' => array('unit' => 'um', 'st' => 0, 'en' => $max_beam_size, 'bin_size' => 5, 'col' => 'dc.beamsizeatsampley*1000', 'count' => 'dc.beamsizeatsampley'),
             'exposuretime' => array('unit' => 'ms', 'st' => 0, 'en' => 5000, 'bin_size' => 50, 'col' => 'dc.exposuretime*1000', 'count' => 'dc.exposuretime'),
         );
 

--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -944,16 +944,11 @@ class Vstat extends Page
         $beamlines = $this->_get_beamlines_from_type($this->ty);
         $bls = implode('\', \'', $beamlines);
 
-        $max_beam_size = 600;
-        if ($this->has_arg('bl') && $this->arg('bl') != 'i23') {
-            $max_beam_size = 150;
-        }
-
         $types = array(
-            'energy' => array('unit' => 'eV', 'st' => 1000, 'en' => 25000, 'bin_size' => 200, 'col' => '(1.98644568e-25/(dc.wavelength*1e-10))/1.60217646e-19', 'count' => 'dc.wavelength'),
-            'beamsizex' => array('unit' => 'um', 'st' => 0, 'en' => $max_beam_size, 'bin_size' => 5, 'col' => 'dc.beamsizeatsamplex*1000', 'count' => 'dc.beamsizeatsamplex'),
-            'beamsizey' => array('unit' => 'um', 'st' => 0, 'en' => $max_beam_size, 'bin_size' => 5, 'col' => 'dc.beamsizeatsampley*1000', 'count' => 'dc.beamsizeatsampley'),
-            'exposuretime' => array('unit' => 'ms', 'st' => 0, 'en' => 5000, 'bin_size' => 50, 'col' => 'dc.exposuretime*1000', 'count' => 'dc.exposuretime'),
+            'energy' => array('unit' => 'eV', 'bin_size' => 200, 'col' => '(1.98644568e-25/(dc.wavelength*1e-10))/1.60217646e-19', 'count' => 'dc.wavelength'),
+            'beamsizex' => array('unit' => 'um', 'bin_size' => 5, 'col' => 'dc.beamsizeatsamplex*1000', 'count' => 'dc.beamsizeatsamplex'),
+            'beamsizey' => array('unit' => 'um', 'bin_size' => 5, 'col' => 'dc.beamsizeatsampley*1000', 'count' => 'dc.beamsizeatsampley'),
+            'exposuretime' => array('unit' => 'ms', 'bin_size' => 5, 'col' => 'dc.exposuretime*1000', 'count' => 'dc.exposuretime'),
         );
 
         $k = 'energy';
@@ -992,9 +987,14 @@ class Vstat extends Page
                 GROUP BY s.beamlinename,x
                 ORDER BY s.beamlinename", $args);
 
+        $min = null;
+        $max = null;
         $bls = array();
-        foreach ($hist as $h)
+        foreach ($hist as $h) {
             $bls[$h['BEAMLINENAME']] = 1;
+            if (is_null($max) || $h['X'] > $max) $max = $h['X'];
+            if (is_null($min) || $h['X'] < $min) $min = $h['X'];
+        }
 
         $data = array();
         foreach ($bls as $bl => $y) {
@@ -1006,7 +1006,7 @@ class Vstat extends Page
             }
 
             $gram = array();
-            for ($bin = $t['st']; $bin <= $t['en']; $bin += $t['bin_size']) {
+            for ($bin = $min; $bin <= $max; $bin += $t['bin_size']) {
                 $gram[$bin] = array_key_exists($bin, $ha) ? $ha[$bin] : 0;
             }
 

--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -975,9 +975,9 @@ class Vstat extends Page
 
         $col = $t['col'];
         $ct = $t['count'];
-        $bs = $t['bin_size'];
+        $binSize = $t['bin_size'];
 
-        $hist = $this->db->pq("SELECT ($col div $bs) * $bs as x, count($ct) as y, s.beamlinename
+        $hist = $this->db->pq("SELECT ($col div $binSize) * $binSize as x, count($ct) as y, s.beamlinename
                 FROM datacollection dc 
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                 INNER JOIN blsession s ON s.sessionid = dcg.sessionid
@@ -995,6 +995,7 @@ class Vstat extends Page
             if (is_null($max) || $h['X'] > $max) $max = $h['X'];
             if (is_null($min) || $h['X'] < $min) $min = $h['X'];
         }
+        $min = is_null($min) ? 0 : floor($min/$binSize) * $binSize; // make min align with bin size, or 0 for no data
 
         $data = array();
         foreach ($bls as $bl => $y) {
@@ -1006,7 +1007,7 @@ class Vstat extends Page
             }
 
             $gram = array();
-            for ($bin = $min; $bin <= $max; $bin += $t['bin_size']) {
+            for ($bin = $min; $bin <= $max; $bin += $binSize) {
                 $gram[$bin] = array_key_exists($bin, $ha) ? $ha[$bin] : 0;
             }
 

--- a/client/src/js/modules/blstats/views/histogram.js
+++ b/client/src/js/modules/blstats/views/histogram.js
@@ -79,7 +79,8 @@ define(['marionette', 'modules/blstats/models/histogram', 'utils',
             
             var ticks = []
             var i = 0
-            var int = Math.floor(Object.keys(f['data']).length/15)
+            // need at least one tick
+            var int = Math.max(Math.floor(Object.keys(f['data']).length/15), 1)
             _.each(f['data'], function(v, bin) {
                 ticks.push([i, i % int == 0 ? bin : ''])
                 i++


### PR DESCRIPTION
Ticket: [LIMS-649](https://jira.diamond.ac.uk/browse/LIMS-649)

* I23 use bigger beam sizes than other MX beamlines
* Use larger max value for x axis on beam size x/y histograms when beamline is i23, or comparing all beamlines