### PR TITLE
[LIMS-684]Improvement: Frendlify booking failed email message

### DIFF
--- a/api/assets/emails/html/dewar-dispatch.html
+++ b/api/assets/emails/html/dewar-dispatch.html
@@ -17,7 +17,7 @@
 						<tr>
 							<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
 							<td>Shipping service could not book the shipment.<br/>
-								Please book a shipment for this Dewar using the details below.</td>
+								Goods Handling, please book a shipment for this Dewar using the details below.</td>
 						</tr>
 					<?php endif; ?>
 				<?php endif; ?>


### PR DESCRIPTION
JIRA ticket: [LIMS-684](https://jira.diamond.ac.uk/browse/lims-684)

Changes:
- Tweak shipping service booking failure message in dispatch email to specify that it is Goods Handling that should book the shipment.

To test:
- Check that the message in the email is as expected.