### PR TITLE
Fix for LIMS-677: Show screening method as none when strategyOption is null

### DIFF
--- a/client/src/js/models/sample.js
+++ b/client/src/js/models/sample.js
@@ -43,6 +43,8 @@ define(['backbone', 'collections/components',
                     this.set('SAMPLEGROUP', option.sample_group)
                     this.set('STRATEGYOPTION', null)
                 }
+            } else if (this.get('BLSAMPLEID') && !this.get('SCREENINGMETHOD')) {
+                this.set('SCREENINGMETHOD', 'none')
             }
         },
 

--- a/client/src/js/models/sample.js
+++ b/client/src/js/models/sample.js
@@ -43,7 +43,7 @@ define(['backbone', 'collections/components',
                     this.set('SAMPLEGROUP', option.sample_group)
                     this.set('STRATEGYOPTION', null)
                 }
-            } else if (this.get('BLSAMPLEID') && !this.get('SCREENINGMETHOD')) {
+            } else if (this.get('BLSAMPLEID') && !this.get('SCREENINGMETHOD') && this.get('REQUIREDRESOLUTION')) {
                 this.set('SCREENINGMETHOD', 'none')
             }
         },

--- a/client/src/js/modules/types/mx/samples/tabbed-columns-view.vue
+++ b/client/src/js/modules/types/mx/samples/tabbed-columns-view.vue
@@ -365,7 +365,6 @@
       <extended-validation-provider
         :ref="`sample_${sampleIndex}_screening_method`"
         class-names="tw-px-2 tw-w-24"
-        :rules="sample['PROTEINID'] > -1 && queueForUDC ? 'required' : ''"
         :name="`Sample ${sampleIndex + 1} Screening Method`"
         :vid="`sample ${sampleIndex + 1} screening method`"
       >


### PR DESCRIPTION
Original ticket: [LIMS-677](https://jira.diamond.ac.uk/browse/LIMS-677)
Original PR: https://github.com/DiamondLightSource/SynchWeb/pull/544

The original fix for this ticket had a flaw - as screening method was now populated, a 'required resolution' was required, even for non-UDC pucks. This would make sample editing very annoying.

New fix:

- Screening Method is no longer a required field
- Only auto-populate screening method if required resolution is already set