### PR TITLE
LIMS-727: Fix bug with non-staff tracking dewars on DHL

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1152,7 +1152,7 @@ class Shipment extends Page
         if (!$this->has_arg('DEWARID'))
             $this->_error('No dewar specified');
 
-        $where = 'AND p.proposalid=:1';
+        $where = 'AND p.proposalid=:2';
         $args = array($this->arg('DEWARID'), $this->proposalid);
 
         if ($this->user->hasPermission('all_dewars')) {


### PR DESCRIPTION
Ticket: [LIMS-727](https://jira.diamond.ac.uk/browse/LIMS-727)

* Incorrect number of args in $args
* Means non-staff cannot track DHL dewars