### PR TITLE
LIMS-397: Dont email if dewar moves from i19 to dewar store

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -144,6 +144,13 @@
     # and for shipment booked,
     $shipbooked_email = 'goods@server.ac.uk';
 
+    # dewar back in storage (complete)
+    $dewar_complete_email = '';
+
+    # Send a 'visit finished' email when a dewar moves from this beamline to this (regex) location
+    $dewar_complete_email_locations = array('i03' => '/tray-\w+/',
+                                           );
+
     # Industrial Contacts
     # - Industrial users get a personalised email with in contact details,
     #   template in assets/emails/dewar-stores-in-in.html

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -413,10 +413,9 @@ class Shipment extends Page
     function _add_history()
     {
         global $in_contacts, $arrival_email;
-        global $dewar_complete_email; // Email list to cc if dewar back from beamline
+        global $dewar_complete_email, $dewar_complete_email_locations; // Email list to cc if dewar back from beamline
         # Flag to indicate we should e-mail users their dewar has returned from BL
-        $from_beamline = False;
-        $from_mx_beamline = False;
+        $send_email = False;
 
         if (!$this->bcr())
             $this->_error('You need to be on the internal network to add history');
@@ -453,20 +452,11 @@ class Shipment extends Page
             // We only add data to dewar history in lower case from this method.
             // If that ever changes, update this to become case insensitive search
             $last_location = $last_history['STORAGELOCATION'];
-
-            // Why don't we have beamline names in the database...?
-            // Currently grabbing them from the config object
-            // Not particularly efficient, but this is not a time critical operation so
-            // this approach covers all beamlines for future proofing.
-            // Stop/break if we find a match
-            $bls = $this->_get_beamlines_from_type('all');
-            if (in_array($last_location, $bls)) {
-                $from_beamline = True;
-            }
-
-            $mxbls = $this->_get_beamlines_from_type('mx');
-            if (in_array($last_location, $mxbls)) {
-                $from_mx_beamline = True;
+            if (array_key_exists($last_location, $dewar_complete_email_locations)) {
+                $email_location = $dewar_complete_email_locations[$last_location];
+                if (preg_match($email_location, strtolower($this->arg('LOCATION')))) {
+                    $send_email = True;
+                }
             }
         } else {
             // No history - could be a new dewar, so not necessarily an error...
@@ -526,9 +516,7 @@ class Shipment extends Page
             $email->send($dew['LCRETEMAIL']);
         }
 
-        $to_bl_storage = preg_match('/\w+-storage/', strtolower($this->arg('LOCATION')));
-        $to_mx_storage = preg_match('/tray-\w+/', strtolower($this->arg('LOCATION')));
-        if ($dew['LCRETEMAIL'] && ( ($from_beamline && $to_bl_storage) || ($from_mx_beamline && $to_mx_storage) ) ) {
+        if ($dew['LCRETEMAIL'] && $send_email) {
             // Any data collections for this dewar's containers?
             // Note this counts data collection ids for containers and uses the DataCollection.SESSIONID to determine the session/visit
             // Should work for UDC (where container.sessionid is set) as well as any normal scheduled session (where container.sessionid is not set)


### PR DESCRIPTION
Ticket: [LIMS-397](https://jira.diamond.ac.uk/browse/LIMS-397)

Currently users get emailed about their dewar if it moves:
* from i19 to the mx dewar store
* from one beamline to another beamline (or even to the same beamline)

Users should only be emailed about their dewar if it moves:
* from an mx beamline to the dewar store
* from any beamline to a '*-storage' location
