### PR TITLE
LIMS[682,688]Improvement: Seperate dispatch address fields, strip whitespace

### DIFF
--- a/api/assets/emails/html/dewar-dispatch.html
+++ b/api/assets/emails/html/dewar-dispatch.html
@@ -47,7 +47,10 @@
 					<td>
 						<?php echo $data['GIVENNAME'] ?> <?php echo $data['FAMILYNAME'] ?><br />
 						<?php echo $data['LABNAME'] ?> <br />
-						<?php echo nl2br($data['ADDRESS']) ?>
+						<?php echo nl2br($data['ADDRESS']) ?> <br />
+						<?php echo $data['CITY'] ?> <br />
+						<?php echo $data['POSTCODE'] ?> <br />
+						<?php echo $data['COUNTRY'] ?>
 					</td>
 				</tr>
 				<tr>

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -57,6 +57,8 @@ class Shipment extends Page
 
         'ADDRESS' => '.*',
         'COUNTRY' => '.*',
+        'CITY' => '([\w\s\-])+',
+        'POSTCODE' => '([\w\s\-])+',
         //   'DESCRIPTION' => '.*',
         'EMAILADDRESS' => '.*',
         'FAMILYNAME' => '.*',
@@ -940,6 +942,8 @@ class Shipment extends Page
         $shipment_data = array(
             "consignee_company_name" => $dispatch_info['LABNAME'],
             "consignee_country" => $dispatch_info['COUNTRY'],
+            "consignee_city" => $dispatch_info['CITY'],
+            "consignee_post_code" => Utils::getValueOrDefault($dispatch_info['POSTCODE'], null),
             "consignee_contact_name" =>  $dispatch_info['GIVENNAME'] . " " .  $dispatch_info['FAMILYNAME'],
             "consignee_contact_phone_number" =>  $dispatch_info['PHONENUMBER'],
             "consignee_contact_email" =>  $dispatch_info['EMAILADDRESS'],
@@ -959,15 +963,9 @@ class Shipment extends Page
         # Split up address. Necessary as address is a single field in ispyb
         $address_lines = explode(PHP_EOL, rtrim($dispatch_info['ADDRESS']));
         $num_lines = count($address_lines);
-        if ($num_lines < 3) {
-            throw new Exception("Could not build request for shipping service: address input does contain at least 3 lines (inc. city and post code)");
-        } else if ($num_lines > 5) {
-            throw new Exception("Could not build request for shipping service: address input contains more than 5 lines (inc. city and post code)");
+        if ($num_lines  > 3) {
+            throw new Exception("Could not build request for shipping service: address input contains more than 3 lines (exc. city and post code)");
         }
-        $shipment_data['consignee_post_code'] = $address_lines[$num_lines - 1];
-        unset($address_lines[$num_lines - 1]);
-        $shipment_data['consignee_city'] = $address_lines[$num_lines - 2];
-        unset($address_lines[$num_lines - 2]);
         if (isset($address_lines[0])) $shipment_data['consignee_address_line1'] = $address_lines[0];
         if (isset($address_lines[1])) $shipment_data['consignee_address_line2'] = $address_lines[1];
         if (isset($address_lines[2])) $shipment_data['consignee_address_line3'] = $address_lines[2];
@@ -1095,12 +1093,12 @@ class Shipment extends Page
         // If a local contact is given, try to find their email address
         // First try LDAP, if unsuccessful look at the ISPyB person record for a matching staff user
         $local_contact = $this->has_arg('LOCALCONTACT') ? $this->args['LOCALCONTACT'] : '';
-        if ($local_contact) {
-            $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
-            if (!$this->args['LCEMAIL']) {
-                $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
-            }
-        }
+        // if ($local_contact) {
+        //     $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
+        //     if (!$this->args['LCEMAIL']) {
+        //         $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
+        //     }
+        // }
 
         if (!array_key_exists('FACILITYCODE', $data))
             $data['FACILITYCODE'] = '';
@@ -1116,7 +1114,6 @@ class Shipment extends Page
             $data['LOCALCONTACT'] = $local_contact;
         if (!array_key_exists('LCEMAIL', $data))
             $data['LCEMAIL'] = '';
-        $data['ADDRESS'] = $data['ADDRESS'] . PHP_EOL . $country;
         $email->data = $data;
 
         if ($country != $facility_country && !is_null($dispatch_email_intl)) {

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1093,12 +1093,12 @@ class Shipment extends Page
         // If a local contact is given, try to find their email address
         // First try LDAP, if unsuccessful look at the ISPyB person record for a matching staff user
         $local_contact = $this->has_arg('LOCALCONTACT') ? $this->args['LOCALCONTACT'] : '';
-        // if ($local_contact) {
-        //     $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
-        //     if (!$this->args['LCEMAIL']) {
-        //         $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
-        //     }
-        // }
+        if ($local_contact) {
+            $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
+            if (!$this->args['LCEMAIL']) {
+                $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
+            }
+        }
 
         if (!array_key_exists('FACILITYCODE', $data))
             $data['FACILITYCODE'] = '';

--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -55,6 +55,16 @@ define(['backbone'], function(Backbone) {
             required: true
         },
 
+        CITY: {
+            required: true
+        },
+
+        POSTCODE: {
+            required: function() {
+                return this.postCodeRequired
+            }
+        },
+
         COUNTRY: {
             required: true,
             pattern: 'country',
@@ -97,6 +107,7 @@ define(['backbone'], function(Backbone) {
     },
 
     courierDetailsRequired: false, // We want to set this default to false unless 'DELIVERYAGENT_AGENTCODE' has a value in the shipment model
+    postCodeRequired: false,
   })
        
 })

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -278,8 +278,8 @@ define(['marionette', 'views/form',
         },
 
         formatAddress: function() {
-            // Remove duplicate new lines and whitespace before/after each line
-            this.ui.addr.val(this.ui.addr.val().replace(/,? *\n+\s*/g, "\n").trim())
+            // Remove duplicate new lines and whitespace or commas before/after each line
+            this.ui.addr.val(this.ui.addr.val().replace(/([,\s]*\n[,\s]*)+/g, "\n").trim())
         }
     })
 

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -57,7 +57,10 @@ define(['marionette', 'views/form',
             'change @ui.lc': 'getlcdetails',    
             'change @ui.exp': 'updateLC',
             'click @ui.useAnotherCourierAccount': 'toggleCourierAccountEditing',
-            'click @ui.facc': 'showTerms'
+            'click @ui.facc': 'showTerms',
+            'blur @ui.postCode': 'stripPostCode',
+            'blur @ui.addr': 'formatAddress',
+            'change @ui.country': 'checkPostCodeRequired'
         },
         
         ui: {
@@ -70,6 +73,8 @@ define(['marionette', 'views/form',
             gn: 'input[name=GIVENNAME]',
             fn: 'input[name=FAMILYNAME]',
             addr: 'textarea[name=ADDRESS]',
+            city: 'input[name=CITY]',
+            postCode: 'input[name=POSTCODE]',
             country: 'select[name=COUNTRY]',
             em: 'input[name=EMAILADDRESS]',
             ph: 'input[name=PHONENUMBER]',
@@ -223,9 +228,12 @@ define(['marionette', 'views/form',
                 this.ui.em.val(lc.get('EMAILADDRESS'))
                 this.ui.ph.val(lc.get('PHONENUMBER'))
                 this.ui.lab.val(lc.get('LABNAME'))
-                this.ui.addr.val([lc.get('ADDRESS'), lc.get('CITY'), lc.get('POSTCODE')].join('\n'))
+                this.ui.addr.val(lc.get('ADDRESS'))
+                this.ui.city.val(lc.get('CITY'))
+                this.ui.postCode.val(lc.get('POSTCODE'))
                 this.labContactCountry = lc.get('COUNTRY')
                 this.ui.country.val(this.labContactCountry)
+                this.checkPostCodeRequired()
             }
         },
 
@@ -255,6 +263,23 @@ define(['marionette', 'views/form',
             this.ui.courierDetails.hide()
             this.ui.facilityCourier.show()
             this.model.courierDetailsRequired = false
+        },
+
+        checkPostCodeRequired: function() {
+            if (this.ui.country.val() === "United Kingdom"){
+                this.model.postCodeRequired = true
+            } else {
+                this.model.postCodeRequired = false
+            }
+        },
+
+        stripPostCode: function() {
+            this.ui.postCode.val(this.ui.postCode.val().trim())
+        },
+
+        formatAddress: function() {
+            // Remove duplicate new lines and whitespace before/after each line
+            this.ui.addr.val(this.ui.addr.val().replace(/,? *\n+\s*/g, "\n").trim())
         }
     })
 

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -83,9 +83,23 @@
 
             <li>
                 <label>Address
-                    <span class="small">Address for courier</span>
+                    <span class="small">Address for courier <br/>Exclude post code and city</span>
                 </label>
                 <textarea name="ADDRESS" data-testid="dispatch-lab-address"></textarea>
+            </li>
+
+            <li>
+                <label>City
+                    <span class="small">Laboratory City</span>
+                </label>
+                <input type="text" name="CITY" data-testid="dispatch-city"/>
+            </li>
+
+            <li>
+                <label>Post Code
+                    <span class="small">Laboratory Post Code</span>
+                </label>
+                <input type="text" name="POSTCODE" data-testid="dispatch-post-code"/>
             </li>
 
             <li>


### PR DESCRIPTION
JIRA tickets: [LIMS-682](https://jira.diamond.ac.uk/browse/lims-682), [LIMS-688](https://jira.diamond.ac.uk/browse/lims-688)

Changes:
- Add extra args for `CITY` and `POSTCODE` in `Shipment.php`, use these for Dewar dispatch
- Add extra lines for city and postcode in Dewar dispatch email template (rather than append them to `ADDRESS`)
- Add extra fields in dispatch form for city and post code
- Add front-end validation for city and post code: city is always required, post code is required if country is 'United Kingdom'
- Strip whitespace from beginning and end of post code on blur event.
- Strip repeated new lines and trailing commas from address on blur event.

To test:
- Check that a Dewar dispatch can be requested using the new city and post code fields.
- Check that shipment creation and dispatch requests can be made to the shipping service using the new form.
- Check the above in cases of repeated newlines, trailing commas, whitespace etc.