### PR TITLE
LIMS-685: Hover text wrongly suggests data collection comments are editable

### DIFF
--- a/client/src/js/templates/dc/dc.html
+++ b/client/src/js/templates/dc/dc.html
@@ -36,7 +36,7 @@
         <li data-testid="dc-transmission">Transmission: <%-TRANSMISSION%>%</li>
         <li data-testid="dc-beam-size">Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         <li data-testid="dc-type">Type: <% if (DCT) print(DCT) %></li>
-        <li data-testid="dc-comment" class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li data-testid="dc-comment" class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li data-testid="dc-status">Status: <span class="b">Stopped</span></li><% } %>
     </ul>
 

--- a/client/src/js/templates/dc/grid.html
+++ b/client/src/js/templates/dc/grid.html
@@ -13,7 +13,7 @@
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         <li>Boxsize: <span class="boxx"></span>x<span class="boxy"></span>&mu;m</li>
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <span class="b">Stopped</span></li><% } %>
 
         <li>

--- a/client/src/js/templates/types/gen/dc/dc.html
+++ b/client/src/js/templates/types/gen/dc/dc.html
@@ -23,7 +23,7 @@
         <li>Resolution: <%-RESOLUTION%>&#197;</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <b>Stopped</b></li><% } %>
         </ul>
     

--- a/client/src/js/templates/types/pow/dc/dc.html
+++ b/client/src/js/templates/types/pow/dc/dc.html
@@ -22,7 +22,7 @@
         <li>Resolution: <%-RESOLUTION%>&#197;</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <b>Stopped</b></li><% } %>
     </ul>
     

--- a/client/src/js/templates/types/saxs/dc/dc.html
+++ b/client/src/js/templates/types/saxs/dc/dc.html
@@ -22,7 +22,7 @@
         <li>Resolution: <%-RESOLUTION%>&#197;</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <b>Stopped</b></li><% } %>
     </ul>
     

--- a/client/src/js/templates/types/sm/dc/dc.html
+++ b/client/src/js/templates/types/sm/dc/dc.html
@@ -38,7 +38,7 @@
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         <li>Type: <% if (DCT) print(DCT) %></li>
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <span class="b">Stopped</span></li><% } %>
     </ul>
     

--- a/client/src/js/templates/types/tomo/dc/dc.html
+++ b/client/src/js/templates/types/tomo/dc/dc.html
@@ -21,7 +21,7 @@
         <li>Resolution: <%-RESOLUTION%>&#197;</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <b>Stopped</b></li><% } %>
         </ul>
     

--- a/client/src/js/templates/types/xpdf/dc/dc.html
+++ b/client/src/js/templates/types/xpdf/dc/dc.html
@@ -26,7 +26,7 @@
         <li>No. Images: <%-NUMIMG%></li>
         <li>Detector: <%-DETECTORMANUFACTURER%> <%-DETECTORMODEL%></li>
         
-        <li class="comment" title="Click to edit the comment for this data collection">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
+        <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <b>Stopped</b></li><% } %>
 
         <li class="params" style="width: calc(97.5% - 15px)">Scan Parameters: </li>


### PR DESCRIPTION
Ticket: [LIMS-685](https://jira.diamond.ac.uk/browse/LIMS-685)

Remove the "title" tag from various locations of data collection comment. The onlo ones that seem to be editable are for Edge scans and MCA scans, so have left those unchanged.