### PR TITLE
LIMS-705: Ignore null visits

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -337,7 +337,7 @@ class Proposal extends Page
                 $p = $props[0]['ID'];
 
             $args = array($p);
-            $where = 'WHERE s.proposalid = :1';
+            $where = 'WHERE s.proposalid = :1 AND s.visit_number is not NULL';
         }
 
         if ($this->has_arg('year')) {

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -24,6 +24,7 @@ class Proposal extends Page
         'started' => '\d',
         'scheduled' => '\d',
         'current' => '\d',
+        'notnull' => '\d+',
 
         'COMMENTS' => '(\w|\s|-)+',
 
@@ -337,7 +338,11 @@ class Proposal extends Page
                 $p = $props[0]['ID'];
 
             $args = array($p);
-            $where = 'WHERE s.proposalid = :1 AND s.visit_number is not NULL';
+            $where = 'WHERE s.proposalid = :1';
+        }
+
+        if ($this->has_arg('notnull')) {
+            $where .= ' AND s.visit_number is not NULL';
         }
 
         if ($this->has_arg('year')) {

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -165,6 +165,7 @@ define(['marionette', 'views/form',
 
             var self = this
             this.visits = new VVisits(null, { state: { pageSize: 9999 } })
+            this.visits.queryParams.notnull = 1
             this.ready = []
             this.ready.push(this.visits.fetch())
 


### PR DESCRIPTION
Ticket: [LIMS-705](https://jira.diamond.ac.uk/browse/LIMS-705)

* New sessions with visit_number = NULL causes confusion and potential errors in dispatch request form
* So hide sessions with visit_number = NULL