### PR TITLE
LIMS-219: Add All Samples To Queue

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -167,6 +167,7 @@ class Sample extends Page
         array('/sub/:ssid', 'put', '_update_sub_sample_full'),
         array('/sub', 'post', '_add_sub_sample'),
         array('/sub/:ssid', 'delete', '_delete_sub_sample'),
+        array('/sub/queue', 'post', '_pre_q_sub_sample'),
         array('/sub/queue(/:BLSUBSAMPLEID)', 'get', '_pre_q_sub_sample'),
 
         array('/plan', 'get', '_get_diffraction_plans'),

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -167,7 +167,7 @@ class Sample extends Page
         array('/sub/:ssid', 'put', '_update_sub_sample_full'),
         array('/sub', 'post', '_add_sub_sample'),
         array('/sub/:ssid', 'delete', '_delete_sub_sample'),
-        array('/sub/queue/cid/:cid', 'get', '_queue_all_sub_samples'),
+        array('/sub/queue/cid/:cid', 'post', '_queue_all_sub_samples'),
         array('/sub/queue(/:BLSUBSAMPLEID)', 'get', '_pre_q_sub_sample'),
 
         array('/plan', 'get', '_get_diffraction_plans'),
@@ -592,19 +592,23 @@ class Sample extends Page
         }
 
         $args = array($this->proposalid, $this->arg('cid'), $this->arg('cid'), $this->arg('cid'));
-        $where = ' AND c.containerid=:2';
+        $where = ' AND c.containerid=:2 AND cq2.completedtimestamp IS NULL';
         $first_inner_select_where = ' AND s.containerid=:3';
         $second_inner_select_where = ' AND s.containerid=:4';
 
         $this->db->wait_rep_sync(true);
         $ss_query_string = $this->get_sub_samples_query($where, $first_inner_select_where, $second_inner_select_where);
+        $this->db->set_debug(True);
         $subs = $this->db->pq($ss_query_string, $args);
+        $this->db->set_debug(False);
 
         $this->db->wait_rep_sync(false);
 
         $ret = array();
         foreach ($subs as $sub) {
-            array_push($ret, array('BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID'], 'CONTAINERQUEUESAMPLEID' => $this->_do_pre_q_sample(array('BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID']))));
+            array_push($ret, array(
+                'BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID'], 
+                'CONTAINERQUEUESAMPLEID' => $this->_do_pre_q_sample(array('BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID']))));
         }
         $this->_output($ret);
     }

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -167,7 +167,7 @@ class Sample extends Page
         array('/sub/:ssid', 'put', '_update_sub_sample_full'),
         array('/sub', 'post', '_add_sub_sample'),
         array('/sub/:ssid', 'delete', '_delete_sub_sample'),
-        array('/sub/queue', 'post', '_pre_q_sub_sample'),
+        array('/sub/queue/cid/:cid', 'get', '_queue_all_sub_samples'),
         array('/sub/queue(/:BLSUBSAMPLEID)', 'get', '_pre_q_sub_sample'),
 
         array('/plan', 'get', '_get_diffraction_plans'),
@@ -585,6 +585,29 @@ class Sample extends Page
         $this->_output(1);
     }
 
+    function _queue_all_sub_samples()
+    {
+        if (!$this->has_arg('cid')) {
+            $this->_error('No containerid specified');
+        }
+
+        $args = array($this->proposalid, $this->arg('cid'), $this->arg('cid'), $this->arg('cid'));
+        $where = ' AND c.containerid=:2';
+        $first_inner_select_where = ' AND s.containerid=:3';
+        $second_inner_select_where = ' AND s.containerid=:4';
+
+        $this->db->wait_rep_sync(true);
+        $ss_query_string = $this->get_sub_samples_query($where, $first_inner_select_where, $second_inner_select_where);
+        $subs = $this->db->pq($ss_query_string, $args);
+
+        $this->db->wait_rep_sync(false);
+
+        $ret = array();
+        foreach ($subs as $sub) {
+            array_push($ret, array('BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID'], 'CONTAINERQUEUESAMPLEID' => $this->_do_pre_q_sample(array('BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID']))));
+        }
+        $this->_output($ret);
+    }
 
     function _sub_samples()
     {

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -567,27 +567,16 @@ define(['marionette',
             e.preventDefault()
 
             var self = this
-            var sids = _.map(this.subsamples.fullCollection.filter(function(ss) { return (!ss.get('QUEUECOMPLETED'))  }), function(ss) {return ss.get('BLSUBSAMPLEID')})
 
-            // cannot send >1000 at once
-            const chunkSize = 500;
-            for (let i = 0; i < Math.ceil(sids.length / chunkSize); i++) {
-                var chunk = sids.slice(i*chunkSize, (i+1)*chunkSize);
-
-                Backbone.ajax({
-                    type: 'post',
-                    url: app.apiurl+'/sample/sub/queue',
-                    data: {
-                        BLSUBSAMPLEID: chunk,
-                    },
-                    success: function(resp) {
-                        _.each(resp, function (r) {
-                            var ss = self.subsamples.fullCollection.findWhere({ BLSUBSAMPLEID: r.BLSUBSAMPLEID })
-                            ss.set({ READYFORQUEUE: '1' })
-                        })
-                    },
-                })
-            }
+            Backbone.ajax({
+                url: app.apiurl+'/sample/sub/queue/cid/'+this.model.get('CONTAINERID'),
+                success: function(resp) {
+                    _.each(resp, function (r) {
+                        var ss = self.subsamples.fullCollection.findWhere({ BLSUBSAMPLEID: r.BLSUBSAMPLEID })
+                        ss.set({ READYFORQUEUE: '1' })
+                    })
+                },
+            })
 
             setTimeout(function() {
                 self.refreshQSubSamples.bind(self)

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -567,20 +567,22 @@ define(['marionette',
             e.preventDefault()
 
             var self = this
-
+            this.$el.addClass('loading');
             Backbone.ajax({
                 url: app.apiurl+'/sample/sub/queue/cid/'+this.model.get('CONTAINERID'),
+                method: "post",
+                data: {},
                 success: function(resp) {
                     _.each(resp, function (r) {
                         var ss = self.subsamples.fullCollection.findWhere({ BLSUBSAMPLEID: r.BLSUBSAMPLEID })
                         ss.set({ READYFORQUEUE: '1' })
                     })
                 },
-            })
-
-            setTimeout(function() {
-                self.refreshQSubSamples.bind(self)
-            }, 1000)
+                complete: function(resp, status) {
+                    self.$el.removeClass('loading')
+                    self.refreshQSubSamples(self)
+                }
+            })            
         },
 
 

--- a/client/src/js/templates/imaging/queuecontainer.html
+++ b/client/src/js/templates/imaging/queuecontainer.html
@@ -33,7 +33,8 @@
         <h2>Available Samples</h2>
         <div class="filter">
             <span class="r">
-                <a href="#" class="button addall"><i class="fa fa-plus"></i> <span>Add Current Page to Queue</span></a>
+                <a href="#" class="button addpage"><i class="fa fa-plus"></i> <span>Add Current Page to Queue</span></a>
+                <a href="#" class="button addall"><i class="fa fa-plus"></i> <span>Add All to Queue</span></a>
             </span>
             <ul>
                 <li><label><input type="checkbox" name="nodata" /> Without Data</label></li>


### PR DESCRIPTION
Ticket: [LIMS-219](https://jira.diamond.ac.uk/browse/LIMS-219)

- Add "Add All To Queue" button to GUI
- Copy queueAllSamples function to queuePageSamples, make queueAllSamples use post request
- Send in chunks of 500 as >1000 gives a PHP error
- Allow post requests

Testing instructions:

- Go to a container that is a plate, eg /containers/cid/263100
- Click 'Prepare For Data Collection'
- Click 'Add All To Queue'