### PR TITLE
LIMS-98: Show Commissioning experiment type for staff

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/container-mixin.js
+++ b/client/src/js/modules/types/mx/shipment/views/container-mixin.js
@@ -159,7 +159,7 @@ export default {
     },
     formatExperimentKindList() {
       let experimentKindList = []
-      for (const [key, value] of Object.entries(ExperimentKindsList.list)) {
+      for (const [key, value] of Object.entries(ExperimentKindsList.getList())) {
         experimentKindList.push({ value, text: key })
       }
 


### PR DESCRIPTION
Ticket: [LIMS-98](https://jira.diamond.ac.uk/browse/LIMS-98)

- Use the getList function rather than the list object
- getList merges in commissioning if a staff member is logged in (see client/src/js/utils/experimentkinds.js)