### PR TITLE
Let P beamlines show autoprocessing

### DIFF
--- a/client/src/js/app/store/modules/store.menus.js
+++ b/client/src/js/app/store/modules/store.menus.js
@@ -43,6 +43,8 @@ const menuStore = {
         'b22': GenProcMenu,
         'b23': GenProcMenu,
         'i21': GenProcMenu,
+        'p99': GenProcMenu,
+        'p45': GenProcMenu,
       }
     }),
 

--- a/client/src/js/modules/dc/components/dc-wrapper.vue
+++ b/client/src/js/modules/dc/components/dc-wrapper.vue
@@ -72,6 +72,8 @@ let dc_views = {
   b22: GenProcDCList,
   b23: GenProcDCList,
   i21: GenProcDCList,
+  p99: GenProcDCList,
+  p45: GenProcDCList,
 }
 
 export default {


### PR DESCRIPTION
Ticket: [LIMS-787](https://jira.diamond.ac.uk/browse/LIMS-787)

P99 is used for lots of testing, it would be really useful to be able to see the autoprocessing results in synchweb and its just a 2 line change to the code.