### PR TITLE
LIMS-210: Prevent multiple samples being created in the same location…

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1319,7 +1319,18 @@ class Sample extends Page
         if ($this->has_arg('collection')) {
             $this->db->start_transaction();
             $col = array();
+            $used = array();
             foreach ($this->arg('collection') as $s) {
+                $loc = $s['CONTAINERID'].'.'.$s['LOCATION'];
+                if (array_key_exists('SUBLOCATION', $s)) {
+                    $loc .= '.'.strval($s['SUBLOCATION']);
+                }
+                if (in_array($loc, $used)) {
+                    // LIMS-210 - dont throw an error, but dont create multiple samples in the same location
+                    error_log('Container location already in use: '.$loc);
+                    continue;
+                }
+                array_push($used, $loc);
                 $id = $this->_do_add_sample($this->_prepare_sample_args($s));
 
                 if ($id) {


### PR DESCRIPTION
… in the same container

Ticket: [LIMS-210](https://jira.diamond.ac.uk/browse/LIMS-210)

If Synchweb attempts to create multiple samples in the same container and the same location, this is probably an error and should be ignored.
Added a check for sublocation for future-proofing.