### PR TITLE
Make general dc path less important

### DIFF
--- a/client/src/js/modules/dc/router.js
+++ b/client/src/js/modules/dc/router.js
@@ -4,7 +4,6 @@ define(['utils/lazyrouter'], function(LazyRouter) {
     var Router = LazyRouter.extend({
         appRoutes: {
             'dc': 'dc_list',
-            
             'dc/view/id/:id': 'di_viewer',
             'dc/map/id/:id/aid/:aid': 'mapmodelviewer',
             'dc/rsv/id/:id': 'rsviewer',

--- a/client/src/js/modules/dc/router.js
+++ b/client/src/js/modules/dc/router.js
@@ -4,7 +4,7 @@ define(['utils/lazyrouter'], function(LazyRouter) {
     var Router = LazyRouter.extend({
         appRoutes: {
             'dc': 'dc_list',
-            'dc(/visit/:visit)(:pathmatch)': 'dc_list',
+            
             'dc/view/id/:id': 'di_viewer',
             'dc/map/id/:id/aid/:aid': 'mapmodelviewer',
             'dc/rsv/id/:id': 'rsviewer',
@@ -12,6 +12,7 @@ define(['utils/lazyrouter'], function(LazyRouter) {
             'dc/apstatussummary/visit/:visit(/ty/:ty)': 'apstatussummary',
             'dc/sc/visit/:visit': 'sampleChanger',
             'dc/queue/visit/:visit': 'queue',
+            'dc(/visit/:visit)(:pathmatch)': 'dc_list',
         },
         
         loadEvents: ['dclist:show', 'dc:show'],

--- a/client/src/js/modules/dc/routes.js
+++ b/client/src/js/modules/dc/routes.js
@@ -86,21 +86,6 @@ function lookupVisit(visit) {
 // The DC component handles the prefetching and proposal lookup in a cleaner method than using marionette wrapper directly
 let routes = [
   {
-    path: '/dc(/visit/)?:visit([a-zA-Z]{2}[0-9]+-[0-9]+)?:pathMatch(.*)*',
-    name: 'dc-list',
-    component: DCWrapper,
-    props: route => ({
-        id: +RoutesUtil.getParamValue(route.params.pathMatch, 'id') || null,
-        visit: route.params.visit || '',
-        dcg: +RoutesUtil.getParamValue(route.params.pathMatch, 'dcg') || null,
-        page: +RoutesUtil.getParamValue(route.params.pathMatch, 'page') || 1,
-        ty: RoutesUtil.getParamValue(route.params.pathMatch, 'ty') ||  '',
-        search: RoutesUtil.getParamValue(route.params.pathMatch, 's') || '',
-        pjid: +RoutesUtil.getParamValue(route.params.pathMatch, 'pjid') || null,
-        sgid: +RoutesUtil.getParamValue(route.params.pathMatch, 'sgid') || null
-    }),
-  },
-  {
     path: '/dc/map/id/:id([0-9]+)(/aid/)?:aid([0-9]+)?',
     name: 'dc-mapmodelviewer',
     component: MapModelWrapper,
@@ -123,6 +108,21 @@ let routes = [
     component: ReciprocalViewWrapper,
     props: route => ({
       id: +route.params.id || null,
+    }),
+  },
+  {
+    path: '/dc(/visit/)?:visit([a-zA-Z]{2}[0-9]+-[0-9]+)?:pathMatch(.*)*',
+    name: 'dc-list',
+    component: DCWrapper,
+    props: route => ({
+        id: +RoutesUtil.getParamValue(route.params.pathMatch, 'id') || null,
+        visit: route.params.visit || '',
+        dcg: +RoutesUtil.getParamValue(route.params.pathMatch, 'dcg') || null,
+        page: +RoutesUtil.getParamValue(route.params.pathMatch, 'page') || 1,
+        ty: RoutesUtil.getParamValue(route.params.pathMatch, 'ty') ||  '',
+        search: RoutesUtil.getParamValue(route.params.pathMatch, 's') || '',
+        pjid: +RoutesUtil.getParamValue(route.params.pathMatch, 'pjid') || null,
+        sgid: +RoutesUtil.getParamValue(route.params.pathMatch, 'sgid') || null
     }),
   },
   {


### PR DESCRIPTION
The path for DC page was made general so that it could accept arguments in any order but having done this it now takes the path from other routes. Move it doen the routing table so it matches last instead of first.