### PR TITLE
LIMS-614: Use new XrayCentring/XrayCentringResults tables

### DIFF
--- a/api/src/Database/Type/MySQL.php
+++ b/api/src/Database/Type/MySQL.php
@@ -200,6 +200,7 @@ class MySQL extends DatabaseParent {
         'PhasingProgramAttachment',
 
         // Xray Centring
+        'XrayCentring',
         'XrayCentringResult',
 
         'BeamCalendar',

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -47,7 +47,6 @@ class DC extends Page
         array('/chi', 'post', '_chk_image'),
         array('/imq/:id', 'get', '_image_qi'),
         array('/grid/:id', 'get', '_grid_info'),
-        array('/grid/xrc/:id', 'get', '_grid_xrc'),
         array('/grid/map', 'get', '_grid_map'),
         array('/ed/:id', 'get', '_edge', array('id' => '\d+'), 'edge'),
         array('/mca/:id', 'get', '_mca', array('id' => '\d+'), 'mca'),
@@ -1472,27 +1471,6 @@ class DC extends Page
         $this->_output($map);
     }
 
-
-    # XRC
-    function _grid_xrc()
-    {
-        $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, xrc.method, xrc.x, xrc.y
-                FROM gridinfo g
-                INNER JOIN datacollection dc ON dc.datacollectiongroupid = g.datacollectiongroupid
-                INNER JOIN xraycentringresult xrc ON xrc.gridinfoid = g.gridinfoid
-                WHERE dc.datacollectionid = :1 ", array($this->arg('id')));
-
-        if (!sizeof($info))
-            $this->_output(array());
-        else {
-            foreach ($info[0] as $k => &$v) {
-                if ($k == 'METHOD')
-                    continue;
-                $v = floatval($v);
-            }
-            $this->_output($info[0]);
-        }
-    }
 
     # ------------------------------------------------------------------------
     # Fluorescence Map Info

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -90,8 +90,7 @@ class Processing extends Page {
             "SELECT xrc.status as xrcstatus, dc.datacollectionid
             FROM datacollection dc 
             INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
-            INNER JOIN gridinfo gr ON (gr.datacollectionid = dc.datacollectionid OR gr.datacollectiongroupid = dc.datacollectiongroupid)
-            LEFT OUTER JOIN xraycentringresult xrc ON xrc.gridinfoid = gr.gridinfoid
+            LEFT OUTER JOIN xraycentring xrc ON xrc.datacollectiongroupid = dc.datacollectiongroupid
             INNER JOIN blsession s ON s.sessionid = dcg.sessionid 
             INNER JOIN proposal p ON p.proposalid = s.proposalid
             WHERE $where",


### PR DESCRIPTION
Ticket: [LIMS-614](https://jira.diamond.ac.uk/browse/LIMS-614)

* Use XrayCentring.status instead of deprecated XrayCentringResult.status
* Remove unused endpoint