### PR TITLE
LIMS-858: Ignore containers with blank samplechangerlocation

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1054,7 +1054,7 @@ class Sample extends Page
             else
                 $info = $info[0];
 
-            $where .= " AND d.dewarstatus='processing' AND c.beamlinelocation LIKE :" . (sizeof($args) + 1) . " AND c.samplechangerlocation is NOT NULL";
+            $where .= " AND d.dewarstatus='processing' AND c.beamlinelocation LIKE :" . (sizeof($args) + 1) . " AND c.samplechangerlocation is NOT NULL AND c.samplechangerlocation != ''";
             array_push($args, $info['BL']);
         }
 


### PR DESCRIPTION
Ticket: [LIMS-858](https://jira.diamond.ac.uk/browse/LIMS-858)

* Sample changer view has become very slow for XChem proposals, as all dewars remain as 'processing' forever
* But the Container.sampleChangerLocation is set to blank when pucks are unloaded
* Exclude blank strings as well as null values