### PR TITLE
LIMS_817: Update shipping service requests

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -951,7 +951,9 @@ class Shipment extends Page
             "shipper_contact_email" => $facility_email,
             "internal_contact_name" => $this->has_arg('LOCALCONTACT') ? $this->args['LOCALCONTACT'] : null,
             "shipment_reference" =>  $dispatch_info['VISIT'],
-            "external_id" => (int) $dispatch_info['DEWARID']
+            "external_id" => (int) $dispatch_info['DEWARID'],
+            "journey_type" => "FROM_FACILITY",
+            "packages" => array(array("external_id" => $dispatch_info['DEWARID']))
         );
 
         # Split up address. Necessary as address is a single field in ispyb
@@ -970,8 +972,8 @@ class Shipment extends Page
             if ($create === true) {
                 $response = $this->shipping_service->create_shipment($shipment_data);
             } else {
-                $this->shipping_service->update_shipment($dispatch_info['DEWARID'], $shipment_data);
-                $response = $this->shipping_service->get_shipment($dispatch_info['DEWARID']);
+                $this->shipping_service->update_shipment($dispatch_info['DEWARID'], $shipment_data, "FROM_FACILITY");
+                $response = $this->shipping_service->get_shipment($dispatch_info['DEWARID'], "FROM_FACILITY");
             }
             $shipment_id = $response['shipmentId'];
             $this->shipping_service->dispatch_shipment($shipment_id);

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -77,10 +77,10 @@ class ShippingService
     }
 
 
-    function get_shipment($external_id)
+    function get_shipment($external_id, $journey_type)
     {
         return $this->_send_request(
-            $this->shipping_api_url . '/shipments/external_id/' . $external_id,
+            $this->shipping_api_url . '/shipments/external_id/' . $external_id . '?journey_type=' . $journey_type,
             "GET",
             null,
             200
@@ -88,10 +88,10 @@ class ShippingService
     }
 
 
-    function update_shipment($external_id, $shipment_data)
+    function update_shipment($external_id, $shipment_data, $journey_type)
     {
         return $this->_send_request(
-            $this->shipping_api_url . '/shipments/external_id/' . $external_id,
+            $this->shipping_api_url . '/shipments/external_id/' . $external_id . '?journey_type=' . $journey_type,
             "PUT",
             $shipment_data,
             204
@@ -102,9 +102,9 @@ class ShippingService
     function dispatch_shipment($shipment_id)
     {
         return $this->_send_request(
-            $this->shipping_api_url . '/shipments/' . $shipment_id . '/dispatch',
+            $this->shipping_api_url . '/shipments/' . $shipment_id . '/dispatch?pickup_requested=false',
             "POST",
-            array(),
+            null,
             201
         );
     }


### PR DESCRIPTION
JIRA ticket: [LIMS-817](https://jira.diamond.ac.uk/browse/lims-817)

Changes:
- Update calls to shipping service to specify packages in shipment creation/update requests and make use of `journey_type` and `pickup_requested` parameters
- Send no body rather than an empty array when making shipping service dispatch requests

To test:
- Check that shipping service Dewar dispatch requests work as before

Note: These changes require shipping-service version >= `0.2.3`