### PR TITLE
LIMS-95: Show max score for each drop in a plate

### DIFF
--- a/client/src/css/partials/_utility.scss
+++ b/client/src/css/partials/_utility.scss
@@ -60,6 +60,18 @@
     text-align: right;
 }
 
+.flex {
+    display: flex;
+}
+
+.flex_take_space {
+    flex: 1 1 auto
+}
+
+.flex_dont_change {
+    flex: 0 0 auto
+}
+
 /* TODO: If we can ever get rid of this class, we can also remove the
    work-around in plotly support which needs to circumvent it */
 .active {

--- a/client/src/js/modules/imaging/views/imageviewer.js
+++ b/client/src/js/modules/imaging/views/imageviewer.js
@@ -315,6 +315,9 @@ define(['marionette',
             var sc = this.scores.findWhere({ BLSAMPLEIMAGESCOREID: this.ui.score.val() })
             this.model.set('BLSAMPLEIMAGESCOREID', this.ui.score.val())
             this.model.set('SCORECOLOUR', sc.get('COLOUR'))
+            if (sc.get('SCORE') > this.model.get('MAXSCORE')) {
+                this.model.set('MAXSCORECOLOUR', sc.get('COLOUR'))
+            }
             this.model.save({ BLSAMPLEIMAGESCOREID: this.ui.score.val() }, { patch: true })
             this.trigger('image:scored')
         },

--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -256,6 +256,7 @@ define(['marionette',
             adh: 'span.adhoc',
             que: 'div.queue',
             ss: 'input[name=sample_status]',
+            ssm: 'input[name=sample_status_max]',
 
             param: 'select[name=param]',
             rank: 'input[name=rank]',
@@ -281,6 +282,7 @@ define(['marionette',
             'click a.adhoc': 'requestAdhoc',
             'click a.return': 'requestReturn',
             'change @ui.ss': 'toggleSampleStatus',
+            'change @ui.ssm': 'toggleSampleStatusMax',
 
             'click @ui.rank': 'setRankStatus',
             'change @ui.param': 'setRankStatus',
@@ -296,9 +298,20 @@ define(['marionette',
         },
 
         toggleSampleStatus: function() {
+            this.ui.ssm.prop('checked', false)
             this.ui.auto.prop('checked', false)
             this.plateView.setAutoStatus(false)
-            this.plateView.setShowSampleStatus(this.ui.ss.is(':checked'))
+            sampleStatus = this.ui.ss.is(':checked')
+            this.plateView.setShowSampleStatus(sampleStatus, !sampleStatus, false)
+        },
+
+        toggleSampleStatusMax: function() {
+            this.ui.ss.prop('checked', false)
+            this.ui.auto.prop('checked', false)
+            this.ui.rank.prop('checked', false)
+            this.plateView.setAutoStatus(false)
+            showMaxScore = this.ui.ssm.is(':checked')
+            this.plateView.setShowSampleStatus(false, !showMaxScore, showMaxScore)
         },
 
         setRankStatus: function() {
@@ -323,8 +336,9 @@ define(['marionette',
 
         setAutoStatus: function() {
             this.ui.ss.prop('checked', false)
+            this.ui.ssm.prop('checked', false)
             this.ui.rank.prop('checked', false)
-            this.plateView.setShowSampleStatus(false)
+            this.plateView.setShowSampleStatus(false, true, false)
 
             var enabled = this.ui.auto.is(':checked')
             console.log('setAutoStatus', enabled, this.ui.class.val(), enabled && this.ui.class.val())

--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -255,13 +255,14 @@ define(['marionette',
             ret: 'div.return',
             adh: 'span.adhoc',
             que: 'div.queue',
-            ss: 'input[name=sample_status]',
-            ssm: 'input[name=sample_status_max]',
+            sampleStatusData: 'input[id=sample_status_data]',
+            sampleStatusMax: 'input[id=sample_status_max]',
 
+            sampleStatusCurrent: 'input[id=sample_status_current]',
             param: 'select[name=param]',
             rank: 'input[name=rank]',
 
-            auto: 'input[name=auto]',
+            sampleStatusAuto: 'input[id=sample_status_auto]',
             schema: 'select[name=schema]',
             class: 'select[name=class]',
         },
@@ -281,13 +282,14 @@ define(['marionette',
 
             'click a.adhoc': 'requestAdhoc',
             'click a.return': 'requestReturn',
-            'change @ui.ss': 'toggleSampleStatus',
-            'change @ui.ssm': 'toggleSampleStatusMax',
+            'change @ui.sampleStatusData': 'setSampleStatusShown',
+            'change @ui.sampleStatusMax': 'setSampleStatusShown',
+            'change @ui.sampleStatusCurrent': 'setSampleStatusShown',
 
             'click @ui.rank': 'setRankStatus',
-            'change @ui.param': 'setRankStatus',
+            'change @ui.param': 'setParamValue',
 
-            'click @ui.auto': 'setAutoStatus',
+            'click @ui.sampleStatusAuto': 'setSampleStatusShown',
             'change @ui.class': 'setAutoStatus',
 
             'change @ui.schema': 'selectSchema',
@@ -297,26 +299,19 @@ define(['marionette',
             'change:QUEUED': 'updatedQueued',
         },
 
-        toggleSampleStatus: function() {
-            this.ui.ssm.prop('checked', false)
-            this.ui.auto.prop('checked', false)
-            this.plateView.setAutoStatus(false)
-            sampleStatus = this.ui.ss.is(':checked')
-            this.plateView.setShowSampleStatus(sampleStatus, !sampleStatus, false)
-        },
+        setSampleStatusShown: function() {
+            
+            const showCurrentScore = this.ui.sampleStatusCurrent.is(':checked')            
+            const showMaxScore = this.ui.sampleStatusMax.is(':checked')
+            const showDataStatus = this.ui.sampleStatusData.is(':checked')
+            const showAutoScore = this.ui.sampleStatusAuto.is(':checked')
+            this.plateView.setShowSampleStatus(showDataStatus, showCurrentScore || showAutoScore, showMaxScore)
+            this.plateView.setAutoStatus(showAutoScore && this.ui.class.val())
 
-        toggleSampleStatusMax: function() {
-            this.ui.ss.prop('checked', false)
-            this.ui.auto.prop('checked', false)
-            this.ui.rank.prop('checked', false)
-            this.plateView.setAutoStatus(false)
-            showMaxScore = this.ui.ssm.is(':checked')
-            this.plateView.setShowSampleStatus(false, !showMaxScore, showMaxScore)
-        },
-
-        setRankStatus: function() {
+            // set ranked options
             var opt = this.ui.param.find('option:selected')
-            var options = this.ui.rank.is(':checked') ? {
+            const is_rank_by = this.ui.rank.is(':checked')
+            var options = is_rank_by ? {
                 value: opt.attr('value'),
                 min: opt.data('min'),
                 check: opt.data('check'),
@@ -326,23 +321,23 @@ define(['marionette',
             this.plateView.setRankStatus(options)
             this.image.setRankStatus(options)
 
+        },
+
+        setParamValue: function() {
+            this.ui.rank.prop('checked', true)
+            this.setRankStatus()
+        },
+
+        setRankStatus: function() {
             if (this.ui.rank.is(':checked')) {
-                if (!this.ui.ss.is(':checked')) {
-                    this.ui.ss.prop('checked', true)
-                    this.toggleSampleStatus()
-                }
+                this.ui.sampleStatusData.prop('checked', true)
             }
+            this.setSampleStatusShown()
         },
 
         setAutoStatus: function() {
-            this.ui.ss.prop('checked', false)
-            this.ui.ssm.prop('checked', false)
-            this.ui.rank.prop('checked', false)
-            this.plateView.setShowSampleStatus(false, true, false)
-
-            var enabled = this.ui.auto.is(':checked')
-            console.log('setAutoStatus', enabled, this.ui.class.val(), enabled && this.ui.class.val())
-            this.plateView.setAutoStatus(enabled && this.ui.class.val())
+            this.ui.sampleStatusAuto.prop('checked', true)
+            this.setSampleStatusShown()
         },
 
         updateAdhoc: function() {

--- a/client/src/js/modules/shipment/views/plate.js
+++ b/client/src/js/modules/shipment/views/plate.js
@@ -45,6 +45,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
             this.hover = {}
             this.showImageStatus = this.getOption('showImageStatus')
             this.showSampleStatus = this.getOption('showSampleStatus')
+            this.showMaxScore = false
             
             Backbone.Validation.bind(this, {
                 collection: this.collection
@@ -61,9 +62,10 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
             this.autoscores = scores
         },
 
-        setShowSampleStatus: function(status) {
-            this.showSampleStatus = status
-            this.showImageStatus = !status
+        setShowSampleStatus: function(sampleStatus, imageStatus, showMaxScore) {
+            this.showSampleStatus = sampleStatus
+            this.showImageStatus = imageStatus
+            this.showMaxScore = showMaxScore
             this.drawPlate()
         },
 
@@ -191,7 +193,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                         var sampleid = i*this.pt.dropTotal()+did+1
                         var sample = this.collection.findWhere({ LOCATION: sampleid.toString() })
 
-                        if (sample && this.showImageStatus && this.inspectionimages) var im = this.inspectionimages.findWhere({ BLSAMPLEID: sample.get('BLSAMPLEID') })
+                        if (sample && (this.showImageStatus || this.showMaxScore) && this.inspectionimages) var im = this.inspectionimages.findWhere({ BLSAMPLEID: sample.get('BLSAMPLEID') })
                         else var im = null
                         
                         this.ctx.beginPath()
@@ -280,7 +282,17 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                                     this.ctx.fill()  
                                 } 
                             }
+                        }
 
+                        // Show max image score
+                        if (sample && this.showMaxScore) {
+                            if (im) {
+                                var isc = im.get('MAXSCORECOLOUR')
+                                if (isc){
+                                    this.ctx.fillStyle = isc
+                                    this.ctx.fill()
+                                }
+                            }
                         }
 
                         // Auto image scores

--- a/client/src/js/templates/shipment/containerplateimage.html
+++ b/client/src/js/templates/shipment/containerplateimage.html
@@ -44,7 +44,7 @@
                 <div>
                     <label>
                         <input type="radio" value="sample_status_auto" name="sample_status" id="sample_status_auto"/> 
-                        Auto Scores
+                        CHIMP Auto Scores
                     </label>
                     <!--There is only ever one option in schema but it was too hard to remove the code see ticket LIMS-1064 -->
                     <select name="schema" style="display:none"></select> 

--- a/client/src/js/templates/shipment/containerplateimage.html
+++ b/client/src/js/templates/shipment/containerplateimage.html
@@ -12,6 +12,7 @@
     <div class="left">
         <div class="plate"></div>
         <div class="ra">
+            <span class="label">Show Max Scores</span> <input type="checkbox" name="sample_status_max" />
             <span class="label">Show Data Status</span> <input type="checkbox" name="sample_status" />
             <label>
                 Rank By

--- a/client/src/js/templates/shipment/containerplateimage.html
+++ b/client/src/js/templates/shipment/containerplateimage.html
@@ -11,24 +11,47 @@
     <div class="img right"></div>
     <div class="left">
         <div class="plate"></div>
-        <div class="ra">
-            <span class="label">Show Max Scores</span> <input type="checkbox" name="sample_status_max" />
-            <span class="label">Show Data Status</span> <input type="checkbox" name="sample_status" />
-            <label>
-                Rank By
-                <input type="checkbox" name="rank" />
-            </label>:
-            <select name="param">
-                <option value="DCRESOLUTION" data-inverted="1" data-check="DC">AP Resolution</option>
-                <option value="DCCOMPLETENESS" data-check="DC" data-min="0.85">AP Completeness</option>
-            </select>
-
-            <div>
-                <span class="label">Show Auto Scores</span> <input type="checkbox" name="auto" /> 
-                <select name="schema"></select>
-                Class: <select name="class"></select>
+        <div class="flex">
+            <div class="flex_take_space"></div>
+            <div class="la flex_dont_change">
+                Status Shows
+                <div>
+                    <label>
+                        <input type="radio" value="sample_status_current" name="sample_status" id="sample_status_current" checked="checked" />
+                        Current Score 
+                    </label>                    
+                </div>
+                <div>
+                    <label>
+                        <input type="radio" value="sample_status_max" name="sample_status" id="sample_status_max"/> 
+                        Max Scores
+                    </label>
+                </div>
+                <div>
+                    <label>
+                        <input type="radio" value="sample_status_data" name="sample_status" id="sample_status_data"/> 
+                        Data Status
+                    </label>
+                    <label>
+                        Rank By
+                        <input type="checkbox" name="rank" />
+                    </label>:
+                    <select name="param">
+                        <option value="DCRESOLUTION" data-inverted="1" data-check="DC">AP Resolution</option>
+                        <option value="DCCOMPLETENESS" data-check="DC" data-min="0.85">AP Completeness</option>
+                    </select>
+                </div>
+                <div>
+                    <label>
+                        <input type="radio" value="sample_status_auto" name="sample_status" id="sample_status_auto"/> 
+                        Auto Scores
+                    </label>
+                    <!--There is only ever one option in schema but it was too hard to remove the code see ticket LIMS-1064 -->
+                    <select name="schema" style="display:none"></select> 
+                    Class: <select name="class"></select>
+                </div>
+                <div class="sta small"></div> 
             </div>
-            <div class="sta small"></div> 
         </div>
         <div class="form">
             <!-- Added a couple of tailwind / css style tweaks to align buttons with input height and make spinner readable -->


### PR DESCRIPTION
Ticket: [LIMS-95](https://jira.diamond.ac.uk/browse/LIMS-95)

* Once a plate is imaged, the previous drop scoring is hidden, so a user may have to click through each drop again and score them
* Add a checkbox to show the 'max' score for each drop, which will allow them to quickly see which drops have been highly scored in the past

Testing (on dev db):
* go to proposal 30330, go to a container
* click on some drops, set a score, change inspections and repeat
* tick 'Max scores' radio button to show the highest score colour for each drop
* Also try "Current scores", "Data Status" and "Auto Scores" with various drop downs (Schema CHIMP should not be visible)