### PR TITLE
LIMS-871: Fix wrong number of dewar uses for staff

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -568,7 +568,7 @@ class Shipment extends Page
         $args = array($this->proposalid);
         $where = 'p.proposalid=:1';
 
-        $fields = "r.dewarregistryid, max(CONCAT(p.proposalcode, p.proposalnumber)) as prop, r.facilitycode, TO_CHAR(r.purchasedate, 'DD-MM-YYYY') as purchasedate, ROUND(TIMESTAMPDIFF('DAY',r.purchasedate, CURRENT_TIMESTAMP)/30.42,1) as age, r.labcontactid, count(d.dewarid) as dewars, GROUP_CONCAT(distinct CONCAT(p.proposalcode,p.proposalnumber) SEPARATOR ', ') as proposals, r.bltimestamp, TO_CHAR(max(d.bltimestamp),'DD-MM-YYYY') as lastuse, count(dr.dewarreportid) as reports";
+        $fields = "r.dewarregistryid, max(CONCAT(p.proposalcode, p.proposalnumber)) as prop, r.facilitycode, TO_CHAR(r.purchasedate, 'DD-MM-YYYY') as purchasedate, ROUND(TIMESTAMPDIFF('DAY',r.purchasedate, CURRENT_TIMESTAMP)/30.42,1) as age, r.labcontactid, count(distinct d.dewarid) as dewars, GROUP_CONCAT(distinct CONCAT(p.proposalcode,p.proposalnumber) SEPARATOR ', ') as proposals, r.bltimestamp, TO_CHAR(max(d.bltimestamp),'DD-MM-YYYY') as lastuse, count(dr.dewarreportid) as reports";
         $group = "r.facilitycode";
 
         if ($this->has_arg('all') && $this->staff) {

--- a/client/src/js/modules/shipment/views/regdewar.js
+++ b/client/src/js/modules/shipment/views/regdewar.js
@@ -96,6 +96,7 @@ define(['marionette',
             })
 
             this.dewars = new Dewars(null, { FACILITYCODE: this.model.get('FACILITYCODE') })
+            this.dewars.queryParams.all = 1
             this.dewars.fetch().done(this.getHistory.bind(this))
 
             var columns = [


### PR DESCRIPTION
Ticket: [LIMS-871](https://jira.diamond.ac.uk/browse/LIMS-871)

* Staff see wrong number of uses of each dewar on the Registered Dewars page, they see (actual number of uses) * (number of proposals the dewar belongs to)
* Staff also get redirected to the max(proposal) when clicking on a registered dewar, and then only see the shipments for that dewar on that proposal

Testing:
1.  Log in as a staff member, go to proposal mx29907.
2. Go to Registered Dewars page
3. Search for DLS-MX-0873, it should show "# Uses" as around 19 (not 57)
4. Click on DLS-MX-0873, proposal should stay as mx29907 (not switch to mx30951)
5. The shipments section should show all 19 uses of this dewar, even those that belong to other proposals
6. Repeat as a user from mx29907, the only difference should be in step 5, it should only show shipments from mx29907