### PR TITLE
LIMS-892: Dont allow UDC samples with no screening method and no reqd resolution

### DIFF
--- a/client/src/js/modules/types/mx/samples/tabbed-columns-view.vue
+++ b/client/src/js/modules/types/mx/samples/tabbed-columns-view.vue
@@ -388,7 +388,7 @@
       <extended-validation-provider
         :ref="`sample_${sampleIndex}_required_resolution`"
         class-names="tw-px-2 tw-w-24"
-        :rules="sample['PROTEINID'] > -1 ? `required_if:sample ${sampleIndex + 1} screening method,none|positive_decimal:6` : ''"
+        :rules="sample['PROTEINID'] > -1 && queueForUDC ? `required_if:sample ${sampleIndex + 1} screening method,none,|positive_decimal:6` : ''"
         :name="`Sample ${sampleIndex + 1} Required Resolution`"
         :vid="`sample ${sampleIndex + 1} required resolution`"
       >


### PR DESCRIPTION
Ticket: [LIMS-892](https://jira.diamond.ac.uk/browse/LIMS-892)

https://github.com/DiamondLightSource/SynchWeb/pull/558 (LIMS-677) introduced a bug where users could leave screening method and required resolution both blank and then queue for UDC. Required resolution should be a required field if queueing for UDC, and even if screening method is blank. (The extra comma in the rules line matches when screening method is blank).