### PR TITLE
[LIMS-832]Feature: Use shipping service for incoming shipments

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -242,6 +242,7 @@
 
     # Shipping service details
     $use_shipping_service = null;
+    $use_shipping_service_incoming_shipments = null;
     $shipping_service_url = null;
     $shipping_service_links_in_emails = null;
 

--- a/api/src/Database/DatabaseFactory.php
+++ b/api/src/Database/DatabaseFactory.php
@@ -31,17 +31,17 @@ class DatabaseFactory
 
         if (!$databaseType) {
             error_log('Database type variable, dbtype, is not specified in config.php - defaulting to MySql.');
-            $database_type = 'MySQL';
+            $databaseType = 'MySQL';
         }
 
         // Determine fully-qualified class name of database class corresponding to $database_type.
         if (key_exists(strtolower($databaseType), $this->database_types)) {
-            $dbType = $this->database_types[strtolower($databaseType)];
+            $selectedDBConfig = $this->database_types[strtolower($databaseType)];
 
-            $full_class_name = 'SynchWeb\\Database\\Type\\' . $dbType["dbClassName"];
+            $full_class_name = 'SynchWeb\\Database\\Type\\' . $selectedDBConfig["dbClassName"];
 
             if (class_exists($full_class_name)) {
-                $conn = $this->databaseConnectionFactory->get($dbType["dataConnectionName"]);
+                $conn = $this->databaseConnectionFactory->get($selectedDBConfig["dataConnectionName"]);
                 return new $full_class_name($conn);
             }
             else {

--- a/api/src/Database/DatabaseFactory.php
+++ b/api/src/Database/DatabaseFactory.php
@@ -22,9 +22,10 @@ class DatabaseFactory
 
     public function get($databaseType = null)
     {   
+        global $dbtype;
+            
         if ( $databaseType == null) {
             // Global variable is named $dbtype in config.php.
-            global $dbtype;
             $databaseType = $dbtype;
         }
 
@@ -37,7 +38,7 @@ class DatabaseFactory
         if (key_exists(strtolower($databaseType), $this->database_types)) {
             $dbType = $this->database_types[strtolower($databaseType)];
 
-            $full_class_name = 'SynchWeb\\Database\\Type\\' . $dbType["dbClassName"];;
+            $full_class_name = 'SynchWeb\\Database\\Type\\' . $dbType["dbClassName"];
 
             if (class_exists($full_class_name)) {
                 $conn = $this->databaseConnectionFactory->get($dbType["dataConnectionName"]);

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2666,7 +2666,7 @@ class Shipment extends Page
             "shipment_reference" => $shipment["PROP"],
             "external_id" => $shipment['SHIPPINGID'],
             "packages" => array_map(
-                fn($dewar) => array("external_id" => $dewar["DEWARID"]),
+                function($dewar) {return array("external_id" => $dewar["DEWARID"]);},
                 $dewars
             )
         );
@@ -2675,11 +2675,11 @@ class Shipment extends Page
         try {
             $response = $this->shipping_service->get_shipment($shipment['SHIPPINGID'], $journey_type);
             $user_shipment_role = $this->has_arg('RETURN') ? "consignee" : "shipper";
-            $shipment_data = array_merge(
-                $shipment_data,
-                array_combine(array_map(fn($key) => $user_shipment_role."_".$key, array_keys($contact)), $contact)
-            );
-            $shipment_data = array_merge($response, $shipment_data);
+            $relabelled_contact = array_combine(
+                array_map(function($key) use ($user_shipment_role) {return $user_shipment_role."_".$key;}, 
+                    array_keys($contact)), 
+                $contact);
+            $shipment_data = array_merge($response, $shipment_data, $relabelled_contact);
             $this->shipping_service->update_shipment($shipment["SHIPPINGID"], $shipment_data, "TO_FACILITY");
         } catch (\Exception $e) {
             $shipment_data["contact"] = $contact;
@@ -2691,7 +2691,7 @@ class Shipment extends Page
         $dispatch_details = $this->shipping_service->dispatch_shipment($shipmentId, false);
 
         $awb_pieces = array_map(
-            fn($package, $index) => array("piecenumber" => $index+1, "licenceplate" => $package["tracking_number"]),
+            function($package, $index) {return array("piecenumber" => $index+1, "licenseplate" => $package["tracking_number"]);},
             $dispatch_details["packages"],
             array_keys($dispatch_details["packages"])
         );

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2657,10 +2657,10 @@ class Shipment extends Page
             "address_line3" => isset($address_lines[2]) ? $address_lines[2] : null,
             "city" => $user["city"],
             "country" => $user["country"],
-            "post_code" => $user["postcode"],
+            "post_code" => rtrim($user["postcode"]),
             "contact_name" => $user["name"],
             "contact_phone_number" => $user["phone"],
-            "contact_email" => $user["email"]
+            "contact_email" => rtrim($user["email"])
         );
         $shipment_data = array(
             "shipment_reference" => $shipment["PROP"],

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2822,10 +2822,11 @@ class Shipment extends Page
         $awb = null;
         if (!$ship['DELIVERYAGENT_FLIGHTCODE']) {
             try {
-                if (Utils::getValueOrDefault($use_shipping_service_incoming_shipments)) {
+                if (Utils::getValueOrDefault($use_shipping_service_incoming_shipments) && $accno === $dhl_acc) {
                     $journey_type = $this->has_arg('RETURN') ? ShippingService::JOURNEY_FROM_FACILITY : ShippingService::JOURNEY_TO_FACILITY;
                     $awb = $this->_book_shipment_in_shipping_service($user, $ship, $dewars, $journey_type);
                 } else {
+                    error_log("Not using shipping service for: {$ship['SHIPPINGID']}");
                     $awb = $this->dhl->create_awb(array(
                         'payee' => $payee,
                         'accountnumber' => $accno,

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -952,7 +952,7 @@ class Shipment extends Page
             "internal_contact_name" => $this->has_arg('LOCALCONTACT') ? $this->args['LOCALCONTACT'] : null,
             "shipment_reference" =>  $dispatch_info['VISIT'],
             "external_id" => (int) $dispatch_info['DEWARID'],
-            "journey_type" => "FROM_FACILITY",
+            "journey_type" => ShippingService::JOURNEY_FROM_FACILITY,
             "packages" => array(array("external_id" => (int) $dispatch_info['DEWARID']))
         );
 
@@ -972,8 +972,8 @@ class Shipment extends Page
             if ($create === true) {
                 $response = $this->shipping_service->create_shipment($shipment_data);
             } else {
-                $this->shipping_service->update_shipment($dispatch_info['DEWARID'], $shipment_data, "FROM_FACILITY");
-                $response = $this->shipping_service->get_shipment($dispatch_info['DEWARID'], "FROM_FACILITY");
+                $this->shipping_service->update_shipment($dispatch_info['DEWARID'], $shipment_data, ShippingService::JOURNEY_FROM_FACILITY);
+                $response = $this->shipping_service->get_shipment($dispatch_info['DEWARID'], ShippingService::JOURNEY_FROM_FACILITY);
             }
             $shipment_id = $response['shipmentId'];
             $this->shipping_service->dispatch_shipment($shipment_id, false);
@@ -2680,7 +2680,7 @@ class Shipment extends Page
                     array_keys($contact)), 
                 $contact);
             $shipment_data = array_merge($response, $shipment_data, $relabelled_contact);
-            $this->shipping_service->update_shipment($shipment["SHIPPINGID"], $shipment_data, "TO_FACILITY");
+            $this->shipping_service->update_shipment($shipment["SHIPPINGID"], $shipment_data, ShippingService::JOURNEY_TO_FACILITY);
         } catch (\Exception $e) {
             $shipment_data["contact"] = $contact;
             $response = $this->shipping_service->create_shipment_by_journey_type($shipment_data, $journey_type);
@@ -2823,7 +2823,7 @@ class Shipment extends Page
         if (!$ship['DELIVERYAGENT_FLIGHTCODE']) {
             try {
                 if (Utils::getValueOrDefault($use_shipping_service_incoming_shipments)) {
-                    $journey_type = $this->has_arg('RETURN') ? "FROM_FACILITY" : "TO_FACILITY";
+                    $journey_type = $this->has_arg('RETURN') ? ShippingService::JOURNEY_FROM_FACILITY : ShippingService::JOURNEY_TO_FACILITY;
                     $awb = $this->_book_shipment_in_shipping_service($user, $ship, $dewars, $journey_type);
                 } else {
                     $awb = $this->dhl->create_awb(array(

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -978,7 +978,7 @@ class Shipment extends Page
             $shipment_id = $response['shipmentId'];
             $this->shipping_service->dispatch_shipment($shipment_id, false);
         } catch (Exception $e) {
-            throw new Exception("Error returned from shipping service: " . $e . "\nShipment data: " . $shipment_data);
+            throw new Exception("Error returned from shipping service: " . $e . "\nShipment data: " . json_encode($shipment_data));
         }
 
         return $shipment_id;

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -10,6 +10,8 @@ class ShippingService
 {
     private $shipping_api_url;
     private $headers;
+    public const JOURNEY_TO_FACILITY = "TO_FACILITY";
+    public const JOURNEY_FROM_FACILITY = "FROM_FACILITY";
 
     function __construct()
     {

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -77,6 +77,17 @@ class ShippingService
     }
 
 
+    function create_shipment_by_journey_type($shipment_data, $journey_type)
+    {
+        return $this->_send_request(
+            $this->shipping_api_url . '/shipments/' . $journey_type,
+            "POST",
+            $shipment_data,
+            201
+        );
+    }
+
+
     function get_shipment($external_id, $journey_type)
     {
         return $this->_send_request(

--- a/api/tests/Database/DatabaseFactoryTest.php
+++ b/api/tests/Database/DatabaseFactoryTest.php
@@ -64,7 +64,7 @@ final class DatabaseFactoryTest extends TestCase
     {
         global $dbtype;
         $dbtype = "obscure-db2";
-        $this->dbFactory->database_types[$dbtype] = $dbtype;
+        $this->dbFactory->database_types[$dbtype] = ["dbClassName" =>$dbtype, "dataConnectionName" => 'MySQL'];        
 
         $log = $this->getFunctionMock(__NAMESPACE__, "error_log");
         $log->expects($this->once())->with("Database class 'SynchWeb\Database\Type\obscure-db2' does not exist.");

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -314,11 +314,19 @@ define(['backbone',
         },
 
         checkAvailability: function() {
-            if (this.shipment.get('DELIVERYAGENT_AGENTNAME').toLowerCase() != 'dhl' && (
-                    !(app.options.get('facility_courier_countries').indexOf(this.lc.get('COUNTRY')) > -1) &&
-                    !(app.options.get('facility_courier_countries_nde').indexOf(this.lc.get('COUNTRY')) > -1)
-                ))
-                app.message({ title: 'Service Not Available', message: 'This service is only available for shipments from '+app.options.get('facility_courier_countries').concat(app.options.get('facility_courier_countries_nde')).join(',')+', or for user with DHL accounts. Please either update your labcontact or the shipment courier'})
+            const agent_name = this.shipment.get('DELIVERYAGENT_AGENTNAME')
+            const facility_courier_countries = app.options.get('facility_courier_countries')
+            const facility_courier_countries_nde = app.options.get('facility_courier_countries_nde')
+            if ((agent_name==null || agent_name.toLowerCase() != 'dhl') && (
+                    !(facility_courier_countries.indexOf(this.lc.get('COUNTRY')) > -1) &&
+                    !(facility_courier_countries_nde.indexOf(this.lc.get('COUNTRY')) > -1)
+                )) {
+                    const valid_countries = facility_courier_countries.concat(facility_courier_countries_nde).join(', ')
+                    app.message({ 
+                        title: 'Service Not Available', 
+                        message: 'This service is only available for shipments from ' + valid_countries +
+                            ', or for user with DHL accounts. Please either update your labcontact or the shipment courier'})
+                }
         },
 
         populateLC: function() {            
@@ -435,7 +443,7 @@ define(['backbone',
                     PRODUCTCODE: prod,
                 },
                 success: function(resp) {
-                    app.alert({ message: 'Air Waybill Successfully Created'})
+                    app.message({ message: 'Air Waybill Successfully Created'})
                     setTimeout(function() {
                         app.trigger('shipment:show', self.shipment.get('SHIPPINGID'))
                     }, 1000)
@@ -452,7 +460,8 @@ define(['backbone',
                             console.error("Error parsing response: ", err)
                         }
                     }
-                    app.alert({ message: json.message })
+                    app.alert({ message: json.message, persist:true })
+                    app.alert({ message: json.message})
                     self.ui.submit.prop('disabled', false)
                     self.$el.removeClass('loading')
                 }

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -148,6 +148,8 @@ define(['marionette', 'views/form',
             this.ui.exp.html(this.visits.opts()).val(this.model.get('VISIT'))
             this.updateLC()
             this.populateCountries()
+            this.stripPostCode()
+            this.formatAddress()
         },
 
         populateCountries: function() {

--- a/client/src/js/templates/contact/contactview.html
+++ b/client/src/js/templates/contact/contactview.html
@@ -42,7 +42,7 @@
         </li>
         
         <li class="clearfix">
-            <span class="label">Street Address <br />(excluding post code, city)</span>
+            <span class="label">Street Address <br />(Max 3 lines, excluding post code, city)</span>
             <div class="ADDRESS text editable tw-block"><%-ADDRESS%></div>
         </li>
         

--- a/client/src/js/templates/shipment/createawb.html
+++ b/client/src/js/templates/shipment/createawb.html
@@ -64,7 +64,7 @@
         </li>
         
         <li class="clearfix">
-            <span class="label">Laboratory Address <br /><span class="small">(excluding post code)</span></span>
+            <span class="label">Laboratory Address <br /><span class="small">(Max 3 lines, excluding post code, city)</span></span>
             <div class="ADDRESS text"></div>
         </li>
         


### PR DESCRIPTION
Requires #618 

JIRA ticket: [LIMS-832](https://jira.diamond.ac.uk/browse/lims-832)

Changes:
- Add config parameter `$use_shipping_service_incoming_shipments` to toggle using the shipping service for incoming shipments
- Make requests to the shipping service for booking incoming shipments
- Fix problem logging `$shipment_data` on shipping service dispatch error
- Format address and post code when first loading the dispatch form

To test:
- Check that, with  `$use_shipping_service_incoming_shipments=true;`, shipments are created/updated in the shipping service when booking an incoming shipment
- Check that SynchWeb behaviour is unchanged when booking an incoming shipment