### PR TITLE
LIMS-154: Enable display of all grid scan snapshots in full

### DIFF
--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -25,9 +25,11 @@ define(['jquery', 'marionette',
             hmt: 'input[name=heatmap]',
             ty: 'select[name=type]',
             ty2: 'select[name=type2]',
+            ty3: 'select[name=type3]',
             xfm: '.xfm',
             flu: 'input[name=fluo]',
             el: 'select[name=element]',
+            sns: 'a[name=snapshots]',
         },
 
         events: {
@@ -36,6 +38,7 @@ define(['jquery', 'marionette',
 
             'change @ui.ty': 'setType',
             'change @ui.ty2': 'loadAttachment',
+            'change @ui.ty3': 'loadImage',
             'change @ui.hmt': 'setHM',
 
             'change @ui.flu': 'toggleFluo',
@@ -97,6 +100,7 @@ define(['jquery', 'marionette',
             this.offset_h = 0
             this.scale = 1
             this.current = -1
+            this.image_1_width = -1
 
             this.heatmapToggle = false
 
@@ -144,6 +148,28 @@ define(['jquery', 'marionette',
             }
         },
 
+        populateImageSelect: function() {
+            opts = []
+            for (n=1; n<=4; n++) {
+                if (this.getOption('parent').get('X'+n)) {
+                    opts.push('<option value='+n+'>Image '+n+'</option>')
+                    if (n == 1) {
+                        // show button to view image full size
+                        this.ui.sns.append('<a class="button" href="'+app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+n+'"><i class="fa fa-arrows"></a>')
+                    } else {
+                        this.ui.sns.append('<a class="hidden" href="'+app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+n+'"></a>')
+                    }
+                }
+            }
+            if (opts.length > 1) {
+                this.ui.ty3.html(opts).show()
+            }
+        },
+
+        loadImage: function() {
+            var n = this.ui.ty3.val()
+            this.snapshot.load(app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+n)
+        },
 
         toggleFluo: function() {
             if (this.ui.flu.is(':checked')) {
@@ -242,11 +268,18 @@ define(['jquery', 'marionette',
             this.hasSnapshot = true
             this.$el.removeClass('loading')
             this.draw()
+            if (this.ui.ty3.val() == 1) {
+                this.image_1_width = this.snapshot.width
+            }
+            var n = this.ui.ty3.val()
+            this.ui.sns.magnificPopup({ type: 'image', delegate: 'a', gallery: { enabled:true } })
         },
 
         onRender: function() {
             this.ui.xfm.hide()
             this.ui.ty2.hide()
+            this.ui.ty3.hide()
+            this.populateImageSelect()
         },
 
 
@@ -313,6 +346,17 @@ define(['jquery', 'marionette',
 
                     w *= scalef
                     h *= scalef
+                }
+
+                if (this.image_1_width > 0 && this.snapshot.width != this.image_1_width) {
+                    // Image size is different to image 1, so hide PIA results as they would be in the wrong location
+                    this.ui.ty.val(-1)
+                    this.ui.ty2.val('')
+                    this.ui.ty.prop('disabled', true)
+                    this.ui.ty2.prop('disabled', true)
+                } else {
+                    this.ui.ty.prop('disabled', false)
+                    this.ui.ty2.prop('disabled', false)
                 }
 
                 var cvratio = this.perceivedw / this.perceivedh

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -150,14 +150,14 @@ define(['jquery', 'marionette',
 
         populateImageSelect: function() {
             opts = []
-            for (n=1; n<=4; n++) {
-                if (this.getOption('parent').get('X'+n)) {
-                    opts.push('<option value='+n+'>Image '+n+'</option>')
-                    if (n == 1) {
+            for (let i=1; i<=4; i++) {
+                if (this.getOption('parent').get('X'+i)) {
+                    opts.push('<option value='+i+'>Image '+i+'</option>')
+                    if (i === 1) {
                         // show button to view image full size
-                        this.ui.sns.append('<a class="button" href="'+app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+n+'"><i class="fa fa-arrows"></a>')
+                        this.ui.sns.append('<a class="button" href="'+app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+i+'"><i class="fa fa-arrows"></a>')
                     } else {
-                        this.ui.sns.append('<a class="hidden" href="'+app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+n+'"></a>')
+                        this.ui.sns.append('<a class="hidden" href="'+app.apiurl+'/image/id/'+this.getOption('ID')+'/f/1/n/'+i+'"></a>')
                     }
                 }
             }

--- a/client/src/js/templates/dc/gridplot.html
+++ b/client/src/js/templates/dc/gridplot.html
@@ -1,4 +1,7 @@
 <div class="controls">
+	<a name="snapshots"></a>
+	<select name="type3"></select>
+
 	<select name="type">
 		<option value="0">Spots</option>
 		<option value="1">Bragg</option>


### PR DESCRIPTION
Ticket: [LIMS-154](https://jira.diamond.ac.uk/browse/LIMS-154)

* Add a dropdown for the various snapshots taken for a grid scan (see eg /dc/visit/sw34709-4/dcg/9689655)
* Add button to see the full image, not just the zoomed in area of the grid scan
* Add gallery controls to the full image view to allow moving through all of them
* Disable the per-image analysis overlay if the selected image is a different width to the first image, as the coordinates will not match (this is just VMXi, see eg /dc/visit/nt30330-129/id/10981728)