### PR TITLE
LIMS-899: Null path to blobs causes errors

### DIFF
--- a/api/src/Downstream/Type/Dimple.php
+++ b/api/src/Downstream/Type/Dimple.php
@@ -16,7 +16,8 @@ class Dimple extends DownstreamPlugin {
         return $this->db->pq(
             "SELECT view1, view2, view3, filepath 
             FROM mxmrrunblob
-            WHERE mxmrrunid = :1",
+            WHERE mxmrrunid = :1
+            AND filepath is not NULL",
             array($this->_mrrun["MXMRRUNID"])
         );
     }


### PR DESCRIPTION
Ticket: [LIMS-899](https://jira.diamond.ac.uk/browse/LIMS-899)

* The code tries to extract the mime type of an image blob from the file extension
* If filepath (or view1/2/3) is null in MXMRRunBlob, that fails with Undefined Variable

Testing:
* Go to a data collection with downstream processing eg https://ispyb.diamond.ac.uk/dc/visit/cm33903-3/id/11034210
* Click on downstream processing bar to expand
* See failed requests to eg https://ispyb.diamond.ac.uk/api/processing/downstream/images/96310113?prop=cm33903