### PR TITLE
LIMS-898: Fix callouts in visit stats

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -62,6 +62,12 @@
     # URL to access the PV archiver
     $archive_url = '';
 
+    # URL to access elog logbook
+    $elog_base_url = '';
+    $elog_callouts_page = '';
+    $elog_ehc_page = '';
+
+
     # Valid Components
     #   Denotes that only staff may create proteins, otherwise they must come from replication 
     #   with a valid `externalid`, users may still clone proteins
@@ -298,7 +304,8 @@
         array(
             'name' => 'i03',
             'group' => 'mx',
-            'archived' => False
+            'archived' => False,
+            'logbook' => 'BLI03'
         ),
         array(
             'name' => 'i04',

--- a/client/src/js/modules/stats/views/callout.js
+++ b/client/src/js/modules/stats/views/callout.js
@@ -11,9 +11,7 @@ define(['marionette', 'modules/stats/collections/callouts', 'views/table'], func
         initialize: function(options) {
             var columns = [
                 { name: 'username', label: 'User', cell: 'string', editable: false },
-                { name: 'logcontent', label: 'Description', cell: 'string', editable: false },
-                { name: 'intime', label: 'In Time', cell: 'string', editable: false },
-                { name: 'hometime', label: 'Out Time', cell: 'string', editable: false },
+                { name: 'hometime', label: 'Time', cell: 'string', editable: false },
             ]
             
             this.collection = new Callouts(null, { visit: options.visit })

--- a/client/src/js/modules/stats/views/visit.js
+++ b/client/src/js/modules/stats/views/visit.js
@@ -39,8 +39,8 @@ define(['marionette',
             this.bd.show(new BreakdownView({ model: this.getOption('breakdown'), params: this.getOption('params') }))
             this.det.show(new DetailsView({ model: this.getOption('breakdown') }))
             this.hrs.show(new HourliesView({ visit: this.model.get('VISIT') }))
-            if (app.staff) this.call.show(new EHCLogView({ visit: this.model.get('VISIT') }))
-            if (app.staff) this.ehc.show(new CalloutView({ visit: this.model.get('VISIT') }))
+            if (app.staff) this.ehc.show(new EHCLogView({ visit: this.model.get('VISIT') }))
+            if (app.staff) this.call.show(new CalloutView({ visit: this.model.get('VISIT') }))
             
             this.pie = new PieView({ visit: this.model.get('VISIT'), el: this.$el.find('#visit_pie') })
             

--- a/client/src/js/templates/stats/visit.html
+++ b/client/src/js/templates/stats/visit.html
@@ -25,6 +25,6 @@
         <div class="roboterrors"></div>
         <div class="faults"></div>
 
-
-        <div class="callouts"></div>
         <div class="ehclogs"></div>
+        <div class="callouts"></div>
+


### PR DESCRIPTION
Ticket: [LIMS-898](https://jira.diamond.ac.uk/browse/LIMS-898)

* Main bug was returning the object containing the callouts instead of an array of the callouts (foreach clause on $calls_tmp)
* Moved URLs to config.php
* Removed the blank columns from callouts
* Fixed callouts and elog entries divs being flipped