### PR TITLE
LIMS-952: Display xray centring results if running 3d xray centring

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -47,6 +47,7 @@ class DC extends Page
         array('/chi', 'post', '_chk_image'),
         array('/imq/:id', 'get', '_image_qi'),
         array('/grid/:id', 'get', '_grid_info'),
+        array('/grid/xrc/:id', 'get', '_grid_xrc'),
         array('/grid/map', 'get', '_grid_map'),
         array('/ed/:id', 'get', '_edge', array('id' => '\d+'), 'edge'),
         array('/mca/:id', 'get', '_mca', array('id' => '\d+'), 'mca'),
@@ -1472,6 +1473,32 @@ class DC extends Page
                 WHERE datacollectionid=:1", array($this->arg('id')));
 
         $this->_output($map);
+    }
+
+
+    # XRC
+    function _grid_xrc()
+    {
+        $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid,
+                xrc.xraycentringtype as method, xrcr.xraycentringresultid,
+                xrcr.centreofmassx as x, xrcr.centreofmassy as y, xrcr.centreofmassz as z
+                FROM datacollection dc
+                INNER JOIN xraycentring xrc ON xrc.datacollectiongroupid = dc.datacollectiongroupid
+                INNER JOIN xraycentringresult xrcr ON xrcr.xraycentringid = xrc.xraycentringid
+                WHERE dc.datacollectionid = :1 ", array($this->arg('id')));
+
+        if (!sizeof($info))
+            $this->_output(array());
+        else {
+            foreach ($info as &$i) {
+                foreach ($i as $k => &$v) {
+                    if ($k == 'METHOD')
+                        continue;
+                    $v = round(floatval($v), 2);
+                }
+            }
+            $this->_output(array('total' => sizeof($info), 'data' => $info));
+        }
     }
 
 

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1488,7 +1488,7 @@ class DC extends Page
                 WHERE dc.datacollectionid = :1 ", array($this->arg('id')));
 
         if (!sizeof($info))
-            $this->_output(array());
+            $this->_output(array('total' => 0, 'data' => array()));
         else {
             foreach ($info as &$i) {
                 foreach ($i as $k => &$v) {

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -87,10 +87,11 @@ class Processing extends Page {
 
     function _xrc_status($where, $ids) {
         $dcs = $this->db->pq(
-            "SELECT xrc.status as xrcstatus, dc.datacollectionid, xrc.xrayCentringType as method
+            "SELECT xrc.status as xrcstatus, dc.datacollectionid, xrc.xrayCentringType as method, xrcr.xraycentringresultid as xrcresults
             FROM datacollection dc 
             INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
             LEFT OUTER JOIN xraycentring xrc ON xrc.datacollectiongroupid = dc.datacollectiongroupid
+            LEFT OUTER JOIN XrayCentringResult xrcr ON xrc.xrayCentringId = xrcr.xrayCentringId
             INNER JOIN blsession s ON s.sessionid = dcg.sessionid 
             INNER JOIN proposal p ON p.proposalid = s.proposalid
             WHERE $where",
@@ -110,7 +111,7 @@ class Processing extends Page {
                         ? 0
                         : ($dc['XRCSTATUS'] === 'pending'
                             ? 1
-                            : ($dc['XRCSTATUS'] === 'success'
+                            : ($dc['XRCSTATUS'] === 'success' && $dc['XRCRESULTS'] !== null
                                 ? 2
                                 : 3)));
         }

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -87,7 +87,7 @@ class Processing extends Page {
 
     function _xrc_status($where, $ids) {
         $dcs = $this->db->pq(
-            "SELECT xrc.status as xrcstatus, dc.datacollectionid
+            "SELECT xrc.status as xrcstatus, dc.datacollectionid, xrc.xrayCentringType as method
             FROM datacollection dc 
             INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
             LEFT OUTER JOIN xraycentring xrc ON xrc.datacollectiongroupid = dc.datacollectiongroupid
@@ -104,13 +104,15 @@ class Processing extends Page {
             }
 
             $statuses[$dc['DATACOLLECTIONID']]['XrayCentring'] =
-                $dc['XRCSTATUS'] === null
-                    ? 0
-                    : ($dc['XRCSTATUS'] === 'pending'
-                        ? 1
-                        : ($dc['XRCSTATUS'] === 'success'
-                            ? 2
-                            : 3));
+                $dc['METHOD'] !== '3d'
+                    ? -1
+                    : ($dc['XRCSTATUS'] === null
+                        ? 0
+                        : ($dc['XRCSTATUS'] === 'pending'
+                            ? 1
+                            : ($dc['XRCSTATUS'] === 'success'
+                                ? 2
+                                : 3)));
         }
 
         return $statuses;

--- a/client/src/js/modules/dc/views/grid.js
+++ b/client/src/js/modules/dc/views/grid.js
@@ -121,7 +121,7 @@ define(['marionette',
                 this.hasXRC = true
             }
 
-            if (state == 2) {
+            if (state >= 2) {
                 this.xrc = new GridXRC({ id: this.model.get('ID') })
                 this.xrc.fetch({
                     success: this.showXRC.bind(this)
@@ -136,7 +136,11 @@ define(['marionette',
         for (var i = 0; i < xrcs.length; i++) {
             t += ' - Crystal '+(i+1)+': X Pos '+xrcs[i]['X']+' Y Pos '+xrcs[i]['Y']+' Z Pos '+xrcs[i]['Z']
         }
-        this.ui.holder.prepend('Method: '+xrcs[0]['METHOD']+t)
+        if (xrcs.length > 0) {
+            this.ui.holder.prepend('Method: '+xrcs[0]['METHOD']+t)
+        } else {
+            this.ui.holder.prepend('Found no diffraction')
+        }
     },
                                       
     onDestroy: function() {

--- a/client/src/js/modules/dc/views/grid.js
+++ b/client/src/js/modules/dc/views/grid.js
@@ -131,7 +131,12 @@ define(['marionette',
     },
 
     showXRC: function() {
-        this.ui.holder.prepend('Method: '+this.xrc.get('METHOD')+' - X Pos: '+this.xrc.get('X')+' Y Pos: '+this.xrc.get('Y'))
+        var xrcs = this.xrc.get('data')
+        var t = ''
+        for (var i = 0; i < xrcs.length; i++) {
+            t += ' - Crystal '+(i+1)+': X Pos '+xrcs[i]['X']+' Y Pos '+xrcs[i]['Y']+' Z Pos '+xrcs[i]['Z']
+        }
+        this.ui.holder.prepend('Method: '+xrcs[0]['METHOD']+t)
     },
                                       
     onDestroy: function() {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-952](https://jira.diamond.ac.uk/browse/LIMS-952)

**Summary**:

Beamlines have complained that an Xray Centring results bar appears under any grid scan, so only show the bar if '3d' xray centring has been used. A normal grid scan is classified as '2d'. Also fix the results displayed.

**Changes**:
- Don't display the results bar if not using '3d' xray centring
- Restore the /grid/xrc/:id endpoint, and return all crystal results from xray centring, with x/y/z values
- Display all crystal x/y/z results in results bar

**To test**:
- Check no results bar displayed for 'normal' grid scan (eg /dc/visit/cm33866-3/id/11284158)
- Check results bar displayed with multiple crystal positions if found (eg /dc/visit/nr27313-243/dcg/10077627)
- Check results bar shows failure if no diffraction found (eg /dc/visit/mx31353-70/dcg/10077396)