### PR TITLE
LIMS-693: Give Name text field default focus in Add New Shipment view

### DIFF
--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -155,6 +155,10 @@ define(['marionette', 'views/form',
             this.checkFCodes()
         },
 
+        onShow: function() {
+            this.ui.name.focus()
+        },
+
         refreshDewars: function() {
             this.dewars.fetch()
         },


### PR DESCRIPTION
**Original issue**: https://github.com/DiamondLightSource/SynchWeb/issues/232
**JIRA ticket**: [LIMS-693](https://jira.diamond.ac.uk/browse/LIMS-693)

**Summary**:

Automatically focus on "Name" field on the Add New Shipment page.

**Changes**:
- Add a new onShow method (triggered after onRender) with the .focus() command

**To test**:
- Log in, pick a proposal, click Shipments, then Add New Shipment. Start typing, it should go into the Name field.