### PR TITLE
LIMS-978: Use DewarRegistry_has_Proposal table

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -597,7 +597,7 @@ class Shipment extends Page
         $tot = $this->db->pq("SELECT count(r.facilitycode) as tot 
               FROM dewarregistry r 
               LEFT OUTER JOIN dewarregistry_has_proposal rhp ON r.dewarregistryid = rhp.dewarregistryid
-              LEFT OUTER JOIN proposal p ON p.proposalid = r.proposalid 
+              LEFT OUTER JOIN proposal p ON p.proposalid = rhp.proposalid
               WHERE $where", $args);
         $tot = intval($tot[0]['TOT']);
 
@@ -672,7 +672,11 @@ class Shipment extends Page
         if (!$this->has_arg('FACILITYCODE'))
             $this->_error('No dewar code specified');
 
-        $dew = $this->db->pq("SELECT facilitycode FROM dewarregistry WHERE facilitycode LIKE :1 AND proposalid = :2", array($this->arg('FACILITYCODE'), $this->proposalid));
+        $dew = $this->db->pq("SELECT facilitycode FROM dewarregistry dr
+              INNER JOIN dewarregistry_has_proposal drhp ON dr.dewarregistryid = drhp.dewarregistryid
+              WHERE dr.facilitycode LIKE :1
+              AND drhp.proposalid = :2",
+              array($this->arg('FACILITYCODE'), $this->proposalid));
 
         if (!sizeof($dew))
             $this->_error('No such dewar');


### PR DESCRIPTION
**JIRA ticket**: [LIMS-978](https://jira.diamond.ac.uk/browse/LIMS-978)

**Summary**:

If you look at a registered dewar that has been created since 2020, you cannot edit the purchase date or facility code.

**Changes**:
- Use the DewarRegistry_has_Proposal table to link DewarRegistry to Proposal, rather than DewarRegistry.proposalId.

**To test**:
- Log in, go to a proposal, then go to a recently registered dewar (eg /dewars/registry/DLS-MX-1230). Try to edit the facility code or the purchase date. Check the HTTP response, before this change you get "No such dewar".

**NB**
There is no need to put in OR statements to allow either the old style or the new style, as there is a ticket in to replace all the old style rows with new style ones.