### PR TITLE
LIMS-954: Add ability to edit manufacturer serial no on dewars

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -53,6 +53,7 @@ class Shipment extends Page
         'STATUS' => '[\w|\s|\-]+',
 
         'PURCHASEDATE' => '\d+-\d+-\d+',
+        'MANUFACTURERSERIALNUMBER' => '.*',
         'LABCONTACTID' => '\d+',
         'REPORT' => '.*',
 
@@ -569,7 +570,7 @@ class Shipment extends Page
         $args = array($this->proposalid);
         $where = 'p.proposalid=:1';
 
-        $fields = "r.dewarregistryid, max(CONCAT(p.proposalcode, p.proposalnumber)) as prop, r.facilitycode, TO_CHAR(r.purchasedate, 'DD-MM-YYYY') as purchasedate, ROUND(TIMESTAMPDIFF('DAY',r.purchasedate, CURRENT_TIMESTAMP)/30.42,1) as age, r.labcontactid, count(distinct d.dewarid) as dewars, GROUP_CONCAT(distinct CONCAT(p.proposalcode,p.proposalnumber) SEPARATOR ', ') as proposals, r.bltimestamp, TO_CHAR(max(d.bltimestamp),'DD-MM-YYYY') as lastuse, count(dr.dewarreportid) as reports";
+        $fields = "r.dewarregistryid, max(CONCAT(p.proposalcode, p.proposalnumber)) as prop, r.facilitycode, TO_CHAR(r.purchasedate, 'DD-MM-YYYY') as purchasedate, ROUND(TIMESTAMPDIFF('DAY',r.purchasedate, CURRENT_TIMESTAMP)/30.42,1) as age, r.labcontactid, count(distinct d.dewarid) as dewars, GROUP_CONCAT(distinct CONCAT(p.proposalcode,p.proposalnumber) SEPARATOR ', ') as proposals, r.bltimestamp, TO_CHAR(max(d.bltimestamp),'DD-MM-YYYY') as lastuse, count(dr.dewarreportid) as reports, r.manufacturerserialnumber";
         $group = "r.facilitycode";
 
         if ($this->has_arg('all') && $this->staff) {
@@ -661,7 +662,8 @@ class Shipment extends Page
         }
 
         $purchase = $this->has_arg('PURCHASEDATE') ? $this->arg('PURCHASEDATE') : '';
-        $this->db->pq("INSERT INTO dewarregistry (facilitycode, purchasedate, bltimestamp) VALUES (:1, TO_DATE(:2, 'DD-MM-YYYY'), SYSDATE)", array($fc, $purchase));
+        $serial = $this->has_arg('MANUFACTURERSERIALNUMBER') ? $this->arg('MANUFACTURERSERIALNUMBER') : '';
+        $this->db->pq("INSERT INTO dewarregistry (facilitycode, purchasedate, bltimestamp, manufacturerserialnumber) VALUES (:1, TO_DATE(:2, 'DD-MM-YYYY'), SYSDATE, :3)", array($fc, $purchase, $serial));
 
         $this->_output(array('FACILITYCODE' => $fc, 'DEWARREGISTRYID' => $this->db->id()));
     }
@@ -679,7 +681,7 @@ class Shipment extends Page
         else
             $dew = $dew[0];
 
-        $fields = array('PURCHASEDATE');
+        $fields = array('PURCHASEDATE', 'MANUFACTURERSERIALNUMBER');
         if ($this->staff)
             array_push($fields, 'NEWFACILITYCODE');
         foreach ($fields as $f) {

--- a/client/src/js/modules/shipment/models/dewarregistry.js
+++ b/client/src/js/modules/shipment/models/dewarregistry.js
@@ -23,6 +23,9 @@ define(['backbone'], function(Backbone) {
                 required: false,
                 pattern: 'edate'
             },
+            MANUFACTURERSERIALNUMBER: {
+                required: false,
+            },
         },
 
         validateFacilityCode: function(value, attr, state) {

--- a/client/src/js/modules/shipment/views/dewarregistry.js
+++ b/client/src/js/modules/shipment/views/dewarregistry.js
@@ -33,6 +33,7 @@ define(['marionette', 'backgrid',
         ui: {
             fc: 'input[name=FACILITYCODE]',
             date: 'input[name=PURCHASEDATE]',
+            serial: 'input[name=MANUFACTURERSERIALNUMBER]',
         },
 
         onRender: function() {
@@ -47,6 +48,7 @@ define(['marionette', 'backgrid',
             app.alert({message: 'New dewar registered ' + this.model.get('FACILITYCODE'), notify: true})
             this.ui.fc.val('')
             this.ui.date.val('')
+            this.ui.serial.val('')
             this.model.set({ DEWARS: 0, REPORTS: 0, BLTIMESTAMP: formatDate.default(new Date(), 'yyyy-MM-dd HH:mm:ss') })
             this.trigger('model:saved', this.model)
             this.setupValidation()

--- a/client/src/js/modules/shipment/views/regdewar.js
+++ b/client/src/js/modules/shipment/views/regdewar.js
@@ -181,6 +181,7 @@ define(['marionette',
         onRender: function() {  
             var edit = new Editable({ model: this.model, el: this.$el })
             edit.create('PURCHASEDATE', 'date')
+            edit.create('MANUFACTURERSERIALNUMBER', 'text')
 
             var self = this
             this.contacts = new LabContacts(null, { state: { pageSize: 9999 } })

--- a/client/src/js/templates/shipment/dewarregistryadd.html
+++ b/client/src/js/templates/shipment/dewarregistryadd.html
@@ -12,6 +12,10 @@
             </label>
             <input type="text" name="PURCHASEDATE" />
         </li>
+        <li>
+            <label>Manufacturer Serial Number</label>
+            <input type="text" name="MANUFACTURERSERIALNUMBER" />
+        </li>
     </ul>
 
     <button name="submit" value="1" type="submit" class="button submit"><i class="fa fa-plus"></i> Add Dewar</button>

--- a/client/src/js/templates/shipment/regdewar.html
+++ b/client/src/js/templates/shipment/regdewar.html
@@ -8,6 +8,10 @@
             <span class="label">Purchase Date</span>
             <span class="PURCHASEDATE"><%-PURCHASEDATE%></span> <span>(Age: <%-AGE%> months)</span>
         </li>
+        <li>
+            <span class="label">Manufacturer Serial Number</span>
+            <span class="MANUFACTURERSERIALNUMBER"><%-MANUFACTURERSERIALNUMBER%></span>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-954](https://jira.diamond.ac.uk/browse/LIMS-954)

**Summary**:

Now that the DewarRegistry table has a manufacturerSerialNumber column, we should make it editable in Synchweb.

**Changes**:
- Get serial number from database
- Update the INSERT statement for new dewars to allow serial number
- Update the loop that does the UPDATE statement for editing existing dewars
- Add optional text fields to both the new dewar and existing dewar pages
- Clear the field once a new dewar has been created

**To test**:
- Add a new Registered Dewar with and without a sserial number
- Edit an existing dewar to add a serial number (see PR https://github.com/DiamondLightSource/SynchWeb/pull/651 if you find a bug)