### PR TITLE
LIMS-499: Make reciprocal space viewer more obvious

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -394,6 +394,7 @@ class DC extends Page
         # Data collection group
         if ($this->has_arg('dcg') || $this->has_arg('PROCESSINGJOBID')) {
             $fields = "count(distinct dca.datacollectionfileattachmentid) as dcac,
+                    if(dca.fileType='recip',1,0) as recip,
                     count(distinct dcc.datacollectioncommentid) as dccc,
                     1 as dcc,
                     smp.name as sample,
@@ -527,6 +528,7 @@ class DC extends Page
             }
         } else {
             $fields = "count(distinct dca.datacollectionfileattachmentid) as dcac,
+                    if(dca.fileType='recip',1,0) as recip,
                     count(distinct dcc.datacollectioncommentid) as dccc,
                     count(distinct dc.datacollectionid) as dcc,
                     min(smp.name) as sample,
@@ -677,6 +679,7 @@ class DC extends Page
                 SELECT
                     $extc
                     1 as dcac,
+                    0 as recip,
                     1 as dccc,
                     1 as dcc,
                     smp.name as sample,
@@ -769,6 +772,7 @@ class DC extends Page
             SELECT
                 $extc
                 1 as dcac,
+                0 as recip,
                 1 as dccc,
                 1 as dcc,
                 smp.name as sample,
@@ -861,6 +865,7 @@ class DC extends Page
             SELECT
                 $extc
                 1 as dcac,
+                0 as recip,
                 1 as dccc,
                 1 as dcc,
                 smp.name as sample,

--- a/client/src/js/templates/dc/dc_title.html
+++ b/client/src/js/templates/dc/dc_title.html
@@ -9,7 +9,11 @@
             </span>
             <a href="#" class="comments button button-notext" title="Comments"><i class="fa fa-comments"></i> <b class="DCCC"><%-DCCC%></b> <span>Comment(s)</span></a>
 
-            <a href="#" class="button attach"><i class="fa fa-file"></i> <b class="DCAC"><%-DCAC%></b></a>
+            <% if (RECIP == "1") { %>
+                <a href="#" class="button attach" title="Reciprocal Space Viewer"><i class="fa fa-snowflake-o"></i> <b class="DCAC"><%-DCAC%></b></a>
+            <% } else { %>
+                <a href="#" class="button attach" title="Attachments"><i class="fa fa-file"></i> <b class="DCAC"><%-DCAC%></b></a>
+            <% } %>
 
             <span class="extra"></span>
         </span>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-499](https://jira.diamond.ac.uk/browse/LIMS-499)

**Summary**:

The reciprocal space viewer is a useful tool, hidden away in the (unlabelled) attachments for each data collection. We should make it more obvious.

**Changes**:
- Pull from the database whether any of the attachments are of type reciprocal space viewer (I would expect only one type of attachment per DC)
- If any are RSV's, then change the icon and title to something more suitable.

**To test**:
- Test a data collection group has the new icon and title for the icon, and the correct number still (eg /dc/visit/cm33866-3/ty/fc)
- Test a single data collection has the new icon etc (eg /dc/visit/cm33866-3/id/11467902)
- Test a data collection with a non-RSV attachment has the old file icon (eg /dc/visit/nt30330-129/ty/gr)

**New Icon**:
![image](https://github.com/DiamondLightSource/SynchWeb/assets/24956497/4ed29eb1-8d0b-44ba-9177-52d64ec1c536)
