### PR TITLE
LIMS-210: Prevent double clicking to create multiple samples

### DIFF
--- a/client/src/js/app/store/store.js
+++ b/client/src/js/app/store/store.js
@@ -367,7 +367,8 @@ const store = new Vuex.Store({
     oidcId: state => state.auth.oidcId,
     apiUrl: state => state.apiUrl,
     appUrl: state => state.appUrl,
-    getAppOptions: state => state.appOptions
+    getAppOptions: state => state.appOptions,
+    isLoading: state => state.isLoading,
   }
 })
 

--- a/client/src/js/modules/types/mx/shipment/views/container-mixin.js
+++ b/client/src/js/modules/types/mx/shipment/views/container-mixin.js
@@ -321,11 +321,10 @@ export default {
       try {
         this.$store.commit('loading', true)
         const result = await this.$refs.containerForm.validate()
-
         if (result) {
-          await this.saveSample(location)
           const samplesRef = this.$refs.samples
           samplesRef.$refs[`sample-row-${location}`][0].closeSampleEditing()
+          await this.saveSample(location)
           this.$refs.containerForm.reset()
         }
         else {

--- a/client/src/js/modules/types/mx/shipment/views/container-mixin.js
+++ b/client/src/js/modules/types/mx/shipment/views/container-mixin.js
@@ -318,13 +318,16 @@ export default {
     // Save the sample to the server via backbone model
     // Location should be the sample LOCATION
     async onSaveSample(location) {
-      try {
+      if (this.$store.getters.isLoading) { // avoid double click
+          return
+      }
+      try {        
         this.$store.commit('loading', true)
         const result = await this.$refs.containerForm.validate()
         if (result) {
-          const samplesRef = this.$refs.samples
-          samplesRef.$refs[`sample-row-${location}`][0].closeSampleEditing()
           await this.saveSample(location)
+          const samplesRef = this.$refs.samples
+          samplesRef.$refs[`sample-row-${location}`][0].closeSampleEditing()          
           this.$refs.containerForm.reset()
         }
         else {


### PR DESCRIPTION
Ticket: [LIMS-210](https://jira.diamond.ac.uk/browse/LIMS-210)

Changes:
* We now know that double-clicking on the tick button when editing samples can create 2 samples in the same location. By closing the editor before saving, we prevent that.

Tests:
* Editing a sample and single clicking creates one sample
* Editing a sample and double clicking only creates one sample
* Editing a sample, leaving invalid parameters, clicking should leave the editor open and not create a sample