### PR TITLE
LIMS-997: Don't allow incoming shipments on in/sw proposals

### DIFF
--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -145,8 +145,13 @@ define(['backbone',
                     this.ui.terms.show()
                     this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
                 } else {
-                    this.ui.facc.show()
-
+                    industrial_codes = ['in', 'sw']
+                    industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
+                    if (industrial_visit) {
+                        this.ui.facc.hide()
+                    } else {
+                        this.ui.facc.show()
+                    }
                 }
             } else {
                 this.ui.facc.hide()                


### PR DESCRIPTION
JIRA ticket: [LIMS-997](https://jira.diamond.ac.uk/browse/lims-997)

Description:

When creating an air waybill, hide the "Use Facility Account" button for in/sw proposals. This is already done for return shipments (see https://github.com/DiamondLightSource/SynchWeb/pull/393).

Changes:
* Only show "Use Facility Account" button if proposal doesn't start with in or sw.

To test:
* Test cannot use facility account for industrial proposals
* Test can still use facility account for non-industrial proposals