### PR TITLE
LIMS-996: Trim empty space around courier name

### DIFF
--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -19,7 +19,7 @@
             <a class="button send" href="#"><i class="fa fa-plane"></i> Mark as Sent</a>
         <% } %>
 
-        <% if (!DELIVERYAGENT_AGENTNAME || (DHL_ENABLE && DELIVERYAGENT_AGENTNAME.toLowerCase() == 'dhl')) { %>
+        <% if (!DELIVERYAGENT_AGENTNAME || (DHL_ENABLE && DELIVERYAGENT_AGENTNAME.toLowerCase().trim() == 'dhl')) { %>
         <% if (DELIVERYAGENT_HAS_LABEL == '1') { %>
             <a class="button pdf" href="<%-APIURL%>/pdf/awb/sid/<%-SHIPPINGID%>"><i class="fa fa-print"></i> Print Air Waybill</a>
             <!-- <a class="button cancel" href="#"><i class="fa fa-truck"></i> Cancel Pickup</a> -->


### PR DESCRIPTION
Ticket: [LIMS-996](https://jira.diamond.ac.uk/browse/LIMS-996)

Changes:
* Trim courier name before comparing to 'dhl', otherwise couriers like ' dhl' and 'dhl ' will be rejected.

Tests:
* Go to a test shipment eg on mx23694, edit courier name to 'DHL', check 'Create Air Waybill' button remains after refresh
* Edit courier name to ' DHL', check button remains after refresh
* Edit courier name to 'Fedex', check button has gone after refresh