### PR TITLE
LIMS-1018: Cannot clone samples in new puck

### DIFF
--- a/client/src/js/app/store/modules/store.samples.js
+++ b/client/src/js/app/store/modules/store.samples.js
@@ -166,7 +166,7 @@ const samplesModule = {
       // Convert our samples json to a backbone collection
       state.samples.map(s => {
         s.CONTAINERID = containerId
-        let locationIndex = +s.INDEX
+        let locationIndex = +(s.LOCATION - 1)
         let proteinId = +s.PROTEINID
         if (proteinId > 0 && s.NAME !== '') {
           state.samplesCollection.at(locationIndex).set(s)


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1018](https://jira.diamond.ac.uk/browse/LIMS-1018)

**Summary**:

Ticket [LIMS-759](https://jira.diamond.ac.uk/browse/LIMS-759) (multipins) introduced a bug whereby the "clone sample" button didn't work.

**Changes**:
- Revert 1 change from https://github.com/DiamondLightSource/SynchWeb/pull/648
- The locationIndex is used only when pressing the "Add Container" button, and that index is used to splice a new sample into the existing samples. Using the INDEX property meant numbers larger than the capacity of the container were used.

**To test**:
- Test creating a puck with different samples, view puck to check samples have been saved
- Test creating a puck with cloned samples (ie after using the "Clone sample" button), view puck to check samples have been saved
- Test creating a puck after using the "Clone all from first row" button, view puck to check samples have been saved
- Test existing containers without sublocations still look ok eg /containers/cid/245858
- Test samples in sublocations are shown on existing containers eg /containers/cid/270597
- Test editing samples individually and with the bulk editor
