### PR TITLE
LIMS-150: Cannot edit fault components

### DIFF
--- a/client/src/js/modules/fault/routes.js
+++ b/client/src/js/modules/fault/routes.js
@@ -85,6 +85,7 @@ const routes = [
             {
                 path: 'edit',
                 name: 'faults-view-edit',
+                component: MarionetteView,
                 props: {
                     mview: FaultTypeEditor,
                     breadcrumbs: [bc, { title: 'Edit Fault Types' }],


### PR DESCRIPTION
**JIRA ticket**: [LIMS-150](https://jira.diamond.ac.uk/browse/LIMS-150)

**Summary**:

Fix bug where https://ispyb.diamond.ac.uk/faults/edit is broken.

**Changes**:
- Add MarionetteView component in the same way as faults/add and faults/{faultid}

**To test**:
- Test user with fault_admin privilege can see the "Fault Database Editor" at faults/edit
- Test unprivileged user sees an error
- Test can add new Systems, Components and Subcomponents
