### PR TITLE
LIMS-1009: Remove the word 'remote' from 'responsive remote'

### DIFF
--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -146,7 +146,7 @@
             </li>
 
             <li>
-                <span class="label">Responsive Remote</span>
+                <span class="label">Responsive</span>
                 <span class="DYNAMIC"><%-DYNAMIC %></span>
             </li>
 

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -46,15 +46,15 @@
             <li>
                 <!-- Small tweaks to the styling here using tailwind flexbox -->
                 <label>First Experiment / Scheduling
-                    <span class="small">Select first experiment or if it's for an automated or responsive remote mail-in session</span>
+                    <span class="small">Select first experiment or if it's for an automated or responsive session</span>
                 </label>
                 <div class="tw-flex">
                     <select class="tw-h-6 tw-mr-2" name="FIRSTEXPERIMENTID" data-testid="add-shipment-experiment"></select>
                     <label class="secondary tw-mr-2">
-                        <input type="checkbox" name="noexp" data-testid="add-shipment-automated"> Automated / Imager
+                        <input type="checkbox" name="noexp" data-testid="add-shipment-automated"> UDC / Automated / Imager
                     </label>
                     <label class="secondary tw-mr-2">
-                        <input type="checkbox" name="DYNAMIC" data-testid="add-shipment-dynamic"> Responsive Remote / Mail-in
+                        <input type="checkbox" name="DYNAMIC" data-testid="add-shipment-dynamic"> Responsive / Mail-in
                     </label>
                 </div>
             </li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1009](https://jira.diamond.ac.uk/browse/LIMS-1009)

**Summary**:

As visits can now be in person and not just remote, we no longer need to refer to 'responsive remote' sessions, we can just say 'responsive' sessions.

**Changes**:
- Remove the word remote in a couple of places
- Clarify that UDC dewars should select Automated

**To test**:
- Test creating a shipment, new labels should appear
- View an existing shipment, new label should appear