### PR TITLE
LIMS-902: Clear sessionId from containers when requesting a dewar transfer

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -859,26 +859,25 @@ class Shipment extends Page
         if (!$this->has_arg('DEWARID'))
             $this->_error('No dewar specified');
 
-        $dew = $this->db->pq("SELECT d.dewarid,s.shippingid
+        $dew = $this->db->pq("SELECT d.dewarid,s.shippingid,c.containerid
               FROM dewar d
               INNER JOIN shipping s ON s.shippingid = d.shippingid
               INNER JOIN proposal p ON p.proposalid = s.proposalid
+              LEFT JOIN container c ON d.dewarid = c.dewarid
               WHERE d.dewarid=:1 and p.proposalid=:2", array($this->arg('DEWARID'), $this->proposalid));
 
         if (!sizeof($dew))
             $this->_error('No such dewar');
-        else
-            $dew = $dew[0];
 
 
         $this->db->pq(
             "INSERT INTO dewartransporthistory (dewartransporthistoryid,dewarid,dewarstatus,storagelocation,arrivaldate) 
               VALUES (s_dewartransporthistory.nextval,:1,'transfer-requested',:2,CURRENT_TIMESTAMP) RETURNING dewartransporthistoryid INTO :id",
-            array($dew['DEWARID'], $this->arg('LOCATION'))
+            array($this->arg('DEWARID'), $this->arg('LOCATION'))
         );
 
         // Update dewar status to transfer-requested to keep consistent with history
-        $this->db->pq("UPDATE dewar set dewarstatus='transfer-requested' WHERE dewarid=:1", array($dew['DEWARID']));
+        $this->db->pq("UPDATE dewar set dewarstatus='transfer-requested' WHERE dewarid=:1", array($this->arg('DEWARID')));
 
         if ($this->has_arg('NEXTVISIT')) {
             $sessions = $this->db->pq(
@@ -891,7 +890,13 @@ class Shipment extends Page
 
             $sessionId = !empty($sessions) ? $sessions[0]['SESSIONID'] : NULL;
 
-            $this->db->pq("UPDATE dewar SET firstexperimentid=:1 WHERE dewarid=:2", array($sessionId, $dew['DEWARID']));
+            $this->db->pq("UPDATE dewar SET firstexperimentid=:1 WHERE dewarid=:2", array($sessionId, $this->arg('DEWARID')));
+
+            if (is_null($sessionId)) {
+                foreach ($dew as $container) {
+                    $this->db->pq("UPDATE container SET sessionid=:1 WHERE containerid=:2", array($sessionId, $container['CONTAINERID']));
+                }
+            }
         }
 
         $email = new Email('dewar-transfer', '*** Dewar ready for internal transfer ***');


### PR DESCRIPTION
**JIRA ticket**: [LIMS-902](https://jira.diamond.ac.uk/browse/LIMS-902)

**Summary**:

When a user requests a dewar transfer, they either specify a future visit, or they can leave it blank if the visit has not yet been created. But if the samples have been collected through UDC, the containers will have an associated visit, and so the dewar won't appear on the list of those that need visits. So if they are requesting a transfer to a not-yet-created visit, then we should clear the sessionid's from the containers.

**Changes**:
- Get list of containers within the dewar
- Don't overwrite `$dew` so they can be accessed
- If the session id is null, set each container's session id to be null

**To test**:
- Test a dewar transfer request on a dewar with UDC pucks to a null session, puck session ids should be set to null
- Test a dewar transfer request on a dewar with UDC pucks to a non-null session, puck session ids should be unaffected
- Test a dewar transfer request on an empty dewar to a null session
- Test a dewar transfer request on an empty dewar to a non-null session