### PR TITLE
LIMS-1027: Allow emails to be sent whwn LDAP server is not configured

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -43,7 +43,7 @@
     # CAS CA Cert (for SSO)
     $cacert = '/etc/certs/ca-bundle.crt';
 
-    # ldap server, used for lookup and authentication (if using)
+    # ldap server, used for lookup and authentication (if using, set to null if not)
     # Update the ldap(s) prefix, hostname and search settings as required
     $ldap_server = 'ldaps://ldap.example.com';
     $ldap_search = 'ou=people,dc=example,dc=com';

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -915,6 +915,10 @@ class Page
         global $ldap_server, $ldap_search;
 
         $ret = array();
+        if (is_null($ldap_server)) {
+            error_log("Ldap server is not configured, not looking up user.");
+            return $ret;
+        }
         $ds = ldap_connect($ldap_server);
         if ($ds)
         {


### PR DESCRIPTION
**JIRA ticket**:  [TICKET-1027](https://jira.diamond.ac.uk/browse/LIMS-1027)

**Summary**:

If in config.php ldap server is set to null then no name lookup is done when emails are sent. This allows us to test sending email in dev 

**Changes**:
- Don't use LDAP server

**To test**:
- Send an email in dev with ldap server set to null. Emails should appear in emails.txt if using the latest podman image.
