### PR TITLE
LIMS-933: Attach auth header to shipping service requests

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -248,7 +248,10 @@
     # Shipping service details
     $use_shipping_service = null;
     $use_shipping_service_incoming_shipments = null;
-    $shipping_service_url = null;
+    $shipping_service_api_url = null;
+    $shipping_service_api_user = null;
+    $shipping_service_api_password = null;
+    $shipping_service_app_url = null;
     $shipping_service_links_in_emails = null;
 
 

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -927,10 +927,10 @@ class Shipment extends Page
         global $facility_country;
         global $facility_phone;
         global $facility_contact;
-        global $shipping_service_url;
+        global $shipping_service_api_url;
         global $facility_email;
-        if (!isset($shipping_service_url)) {
-            throw new Exception("Could not send request to shipping service: shipping_service_url not set");
+        if (!isset($shipping_service_api_url)) {
+            throw new Exception("Could not send request to shipping service: shipping_service_api_url not set");
         }
 
         # Create shipment

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -10,7 +10,6 @@ class ShippingService
 {
     private $shipping_api_url;
     private $shipping_app_url;
-    private $headers;
     public const JOURNEY_TO_FACILITY = "TO_FACILITY";
     public const JOURNEY_FROM_FACILITY = "FROM_FACILITY";
 
@@ -45,18 +44,18 @@ class ShippingService
         global $shipping_service_app_url;
         $this->shipping_api_url = $shipping_service_api_url;
         $this->shipping_app_url = $shipping_service_app_url;
-        $this->headers = $this->_build_headers();
     }
 
 
     function _send_request($url, $type, $data, $expected_status_code)
     {
         $ch = curl_init($url);
+        $base_headers = $this->_build_headers();
         curl_setopt_array(
             $ch,
             array(
                 CURLOPT_RETURNTRANSFER => TRUE,
-                CURLOPT_HTTPHEADER => $this->headers,
+                CURLOPT_HTTPHEADER => $base_headers,
                 CURLOPT_TIMEOUT => 5
             )
         );
@@ -77,7 +76,7 @@ class ShippingService
                     $ch,
                     array(
                         CURLOPT_CUSTOMREQUEST => "PUT",
-                        CURLOPT_HTTPHEADER => array_merge($this->headers, array('Content-Length: ' . strlen(json_encode($data)))),
+                        CURLOPT_HTTPHEADER => array_merge($base_headers, array('Content-Length: ' . strlen(json_encode($data)))),
                         CURLOPT_POSTFIELDS => json_encode($data),
                     )
                 );


### PR DESCRIPTION
**JIRA ticket**: [LIMS-933](https://jira.diamond.ac.uk/browse/lims933)

**Summary**:

This change attaches an auth header to shipping service requests. This is either the user access token as a bearer token or basic auth using stored synchweb credentials.

**Changes**:
- Added new separate configuration parameters for shipping service API and frontend URLS.
- Added configuration parameters for shipping service basic auth credentials.
- If the user session token cookie is present, it is added as a bearer token in shipping service requests. If not present, stored basic auth credentials are used.
- AWB PDF email link has been changed to point to the frontend AWB page rather than a direct link to the PDF from the backend.

**To test**:
- Check that, when a user books a shipping service shipment through the SynchWeb web application, an access token is used in shipping service requests.
- Check that, when a shipping service shipment is booked without user SSO, basic auth is used in shipping service requests.
