### PR TITLE
LIMS-1029: Fix bug creating lab contact with login

### DIFF
--- a/api/src/Page/Contact.php
+++ b/api/src/Page/Contact.php
@@ -167,7 +167,7 @@ class Contact extends Page
                     foreach ($lfields as $i => $f) {
                         if ($this->has_arg($f)) {
                             $c = $f == 'LABNAME' ? 'NAME' : $f;
-                            $this->db->pq('UPDATE laboratory SET '.$c.'=:1 WHERE laboratoryid=:2', array($this->arg($f), $lab['LABORATORYID']));
+                            $this->db->pq('UPDATE laboratory SET '.$c.'=:1 WHERE laboratoryid=:2', array($this->arg($f), $lab[0]['LABORATORYID']));
                         }
                     }
                 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1029](https://jira.diamond.ac.uk/browse/LIMS-1029)

**Summary**:

Fix bug getting laboratoryId when creating a Lab Contact using the Login field, introduced in https://github.com/DiamondLightSource/SynchWeb/pull/622

**Changes**:
- Fix getting laboratoryId, as db queries always return a list

**To test**:
- Test creating a Lab Contact using the Login field, when logged in someone with an associated Laboratory eg ndg63276
- Test creating a Lab Contact using the Login field, when logged in as someone with no associated Laboratory
- Test creating a Lab Contact leaving the Login field blank
