### PR TITLE
LIMS-140: Fix pia_estimated_d_min display on VMXi grid scans

### DIFF
--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -415,8 +415,10 @@ define(['jquery', 'marionette',
             if (d.length > 0) {
                 let max = 0
                 let power = this.invertHeatMap ? -1 : 1
+                let val = 0
                 _.each(d, function(v) {
-                    if (Math.pow(v[1],power) > max) max = Math.pow(v[1],power)
+                    val = Math.pow(v[1], power)
+                    if (val > max) max = val
                 })
 
                 max = max === 0 ? 1 : max
@@ -431,6 +433,7 @@ define(['jquery', 'marionette',
                 var data = []
                 _.each(d, function(v) {
                     var k = v[0] - 1
+                    val = Math.pow(v[1], power)
 
                     // Account for vertical grid scans
                     let xstep, ystep, x, y
@@ -461,7 +464,7 @@ define(['jquery', 'marionette',
                     data.push({
                         x: x,
                         y: y,
-                        value: v[1] < 1 && max > 1 ? 0 : Math.pow(v[1], power),
+                        value: val < 1 && max > 1 ? 0 : val,
                         radius: radius
                     })
 

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -524,12 +524,12 @@ define(['jquery', 'marionette',
 
         _getVal: function(pos) {
             var val = null
-            var d = []
+            let d = []
             if (this.ui.ty.is(":visible")) {
                 d = Number(this.ui.ty.val()) > -1 ? this.distl.get('data')[Number(this.ui.ty.val())] : []
             }
             if (this.ui.ty2.is(":visible")) {
-                var a = this.attachments.findWhere({ 'DATACOLLECTIONFILEATTACHMENTID': this.ui.ty2.val() })
+                let a = this.attachments.findWhere({ 'DATACOLLECTIONFILEATTACHMENTID': this.ui.ty2.val() })
                 if (a && a.get('DATA')) {
                     d = a.get('DATA')
                 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-140](https://jira.diamond.ac.uk/browse/LIMS-140)

**Summary**:

For a VMXi grid scan, if you select pia_estimated_d_min as the dropdown, the heat map disappears.

**Changes**:
- Fix the _getVal function to get data from the visible dropdown so that clicking on a box shows the value
- Invert the values sent to the heatmap for pia_estimated_d_min, as they are resolutions, so 1 is better than 2.
- Dont pad the maximum by 50x if values are inverted

**To test**:
- Test heat map of i03 grid scan (eg /dc/visit/cm33866-4/dcg/10292076), check heat map looks normal for all PIA selections
- Test heat map of VMXi grid scan (eg /dc/visit/nt30330-145/id/11688261), check heat map looks normal for all PIA selections, including for (inverted) values of pia_estimated_d_min