### PR TITLE
LIMS-1025: Fix lab contact search

### DIFF
--- a/api/src/Database/DatabaseQueryBuilder.php
+++ b/api/src/Database/DatabaseQueryBuilder.php
@@ -164,4 +164,16 @@ class DatabaseQueryBuilder
         array_push($this->query_bound_values, $value);
         return sizeof($this->query_bound_values);
     }
+
+    public static function getWhereSearch($searchValue, $fields, &$query_bound_values)
+    {
+        $where = " AND (0=1";
+
+        foreach ($fields as $field) {
+            array_push($query_bound_values, $searchValue);
+            $where .= " OR lower(" . $field . ") LIKE lower(CONCAT('%', :" . sizeof($query_bound_values) . ", '%'))";
+        }
+        $where .= ")";
+        return $where;
+    }
 }

--- a/api/src/Page/Contact.php
+++ b/api/src/Page/Contact.php
@@ -52,7 +52,6 @@ class Contact extends Page
                 $fields = array('pe.givenname', 'pe.familyname', 'c.cardname',
                     'l.name', 'l.address', 'l.city', 'l.country', 'pe.phonenumber', 'l.postcode');
                 $where = $where . DatabaseQueryBuilder::getWhereSearch($this->arg('s'), $fields, $args);
-                error_log($where);
             }
 
             $tot = $this->db->pq("SELECT count(c.labcontactid) as tot FROM labcontact c

--- a/api/src/Page/Contact.php
+++ b/api/src/Page/Contact.php
@@ -3,6 +3,7 @@
 namespace SynchWeb\Page;
 
 use SynchWeb\Page;
+use SynchWeb\Database\DatabaseQueryBuilder;
 
 class Contact extends Page
 {
@@ -48,16 +49,10 @@ class Contact extends Page
             }
 
             if ($this->has_arg('s')) {
-                $st = sizeof($args) + 1;
                 $fields = array('pe.givenname', 'pe.familyname', 'c.cardname',
                     'l.name', 'l.address', 'l.city', 'l.country', 'pe.phonenumber', 'l.postcode');
-                $where .= " AND (0=1";
-
-                foreach ($fields as $i => $field) {
-                    $where .= " OR lower(" . $field . ") LIKE lower(CONCAT('%', :" . ($st + $i) . ", '%'))";
-                    array_push($args, $this->arg('s'));
-                }
-                $where .= ")";
+                $where = $where . DatabaseQueryBuilder::getWhereSearch($this->arg('s'), $fields, $args);
+                error_log($where);
             }
 
             $tot = $this->db->pq("SELECT count(c.labcontactid) as tot FROM labcontact c

--- a/api/tests/Database/DatabaseQueryBuilderTest.php
+++ b/api/tests/Database/DatabaseQueryBuilderTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use SynchWeb\Database\DatabaseParent;
 use SynchWeb\Database\DatabaseQueryBuilder;
 
-final class DatabaseHelperTest extends TestCase
+use function PHPUnit\Framework\assertEquals;
+
+final class DatabaseQueryBuilderTest extends TestCase
 {
     use \phpmock\phpunit\PHPMock;
 
-    private function create_database_helper($fields, $expected_sql, $expected_id_value = null)
+    private function create_database_helper($fields, $expected_sql=null, $expected_id_value = null)
     {
         $expected_values = [];
         foreach ($fields as $field)
@@ -168,4 +170,18 @@ final class DatabaseHelperTest extends TestCase
         }
         $dbh->insert($expected_table);
     }
+
+    public function testWithSingleIdWhereClauseGetWhereClauseReturnIt() {
+        $fields = ["a.field1", "b.field2"];
+        $expected_sql = " AND (0=1 OR lower({$fields[0]}) LIKE lower(CONCAT('%', :2, '%')) OR lower({$fields[1]}) LIKE lower(CONCAT('%', :3, '%')))";
+        $expectedSearchValue = "searchVal";
+        
+        $element1 = "first";
+        $args=[$element1];
+        $sql = DatabaseQueryBuilder::getWhereSearch($expectedSearchValue, $fields, $args);
+
+        assertEquals($expected_sql, $sql);
+        assertEquals([$element1, $expectedSearchValue, $expectedSearchValue], $args);
+    }
+
 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1025](https://jira.diamond.ac.uk/browse/LIMS-1025)

**Summary**:

Fix lab contact search

**Changes**:
- Create a where clause to match the passed in search term to any of the lab contact fields
- Start with a known false condition as each field adds an "or" clause

**To test**:
- Go to a list of lab contacts on a proposal and search for each field in turn
- View a single lab contact, test it displays correctly
