### PR TITLE
LIMS-1068: Move discovery away from constructor, get cookie expiry dynamically

### DIFF
--- a/api/src/Authentication/Type/OIDC.php
+++ b/api/src/Authentication/Type/OIDC.php
@@ -11,7 +11,7 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
     private $providerConfig = array();
 
     private function getEndpoints() {
-        if (empty($providerConfig)) {
+        if (empty($this->providerConfig)) {
             global $sso_url, $oidc_client_id, $oidc_client_secret;
 
             $ch = curl_init();

--- a/api/src/Authentication/Type/OIDC.php
+++ b/api/src/Authentication/Type/OIDC.php
@@ -10,33 +10,36 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
 {
     private $providerConfig = array();
 
-    function __construct() {
-        global $sso_url, $oidc_client_id, $oidc_client_secret;
+    private function getEndpoints() {
+        if (empty($providerConfig)) {
+            global $sso_url, $oidc_client_id, $oidc_client_secret;
 
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, 'https://' . $sso_url . '/.well-known/openid-configuration');
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        $response = curl_exec($ch);
-        curl_close($ch);
-        $newProviderConfig = json_decode($response);
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, 'https://' . $sso_url . '/.well-known/openid-configuration');
+            curl_setopt($ch, CURLOPT_HEADER, 0);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+            $response = curl_exec($ch);
+            curl_close($ch);
+            $newProviderConfig = json_decode($response);
 
-        if(!$newProviderConfig
-            || !isset($newProviderConfig->userinfo_endpoint)
-            || !isset($newProviderConfig->authorization_endpoint) 
-            || !isset($newProviderConfig->token_endpoint)) {
-            error_log("OIDC Authentication provider replied with invalid JSON body");
-            return;
+            if(!$newProviderConfig
+                || !isset($newProviderConfig->userinfo_endpoint)
+                || !isset($newProviderConfig->authorization_endpoint) 
+                || !isset($newProviderConfig->token_endpoint)) {
+                error_log("OIDC Authentication provider replied with invalid JSON body");
+                return;
+            }
+            $newProviderConfig->b64ClientCreds = base64_encode(
+                $oidc_client_id . ":" . $oidc_client_secret
+            );
+
+            $this->providerConfig = $newProviderConfig;
         }
-        $newProviderConfig->b64ClientCreds = base64_encode(
-            $oidc_client_id . ":" . $oidc_client_secret
-        );
-
-        $this->providerConfig = $newProviderConfig;
     }
 
     private function getUser($token)
     {        
+        $this->getEndpoints();
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $this->providerConfig->userinfo_endpoint);
         curl_setopt($ch, CURLOPT_HEADER, 0);
@@ -71,6 +74,7 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
 
     function authorise() 
     {
+        $this->getEndpoints();
         global $oidc_client_id;
         $redirect_url = Utils::filterParamFromUrl($_SERVER["HTTP_REFERER"], "code");
 
@@ -82,6 +86,7 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
 
     function authenticateByCode($code) 
     {   
+        $this->getEndpoints();
         global $cacert, $oidc_client_secret, $oidc_client_id, $cookie_key;
 
         $redirect_url = Utils::filterParamFromUrl($_SERVER["HTTP_REFERER"], "code");
@@ -105,14 +110,14 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
         }        
         
         $token = $response_json->access_token;
-
+        
         if(!$token) {
             error_log("Invalid authentication attempt, provider returned no access token");
             return false;
         }
 
         $cookieOpts = array (
-            'expires' => time() + 60*60*24,
+            'expires' => time() + $response_json->expires_in,
             'path' => '/',
             'secure' => true,
             'httponly' => true,
@@ -123,4 +128,3 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
         return $this->getUser($token);
     }
 }
-


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1068](https://jira.diamond.ac.uk/browse/LIMS-1068)

**Summary**:

- Reduce number of calls to OIDC provider by only performing discovery when necessary
- Get expiration time for token from provider, apply it to cookie

**Changes**:
- Cookie expiry is applied based on value returned from OIDC provider
- Endpoint discovery is only performed when a function is called and there are no known endpoints

**To test**:
- Check if user logout behaves as expected
- Check if user login behaves as expected
- Check if opening page in a new tab doesn't trigger login
- Check if moving between pages works
