### PR TITLE
LIMS-1074: Allow accessing zipped files

### DIFF
--- a/api/scripts/mtz2map.sh
+++ b/api/scripts/mtz2map.sh
@@ -15,6 +15,24 @@ export CLIBD=$CCP4_MASTER/lib/data
 export CCP4_SCR=/tmp
 export root=$CCP4_MASTER/bin
 
+if [ -f $1 ]; then
+	mtz=$1
+else
+	if [ -f $1.gz ]; then
+		mtz=/tmp/$2_$3.mtz
+		gunzip -c $1.gz > $mtz
+	fi
+fi
+
+if [ -f $4 ]; then
+	pdb=$4
+else
+	if [ -f $4.gz ]; then
+		pdb=/tmp/$2_$3.pdb
+		gunzip -c $4.gz > $pdb
+	fi
+fi
+
 if [ $3 == 'dimple' -o $3 == 'mrbump' ]; then
 
 if [ $3 == 'dimple' ]; then
@@ -23,7 +41,7 @@ if [ $3 == 'dimple' ]; then
 	# fofc2="F1=F SIG1=SIGF PHI=PHWT W=FOM"
 	# fofc="F1=F SIG1=SIGF PHI=PHDELWT W=FOM"
 
-	if $root/mtzinfo $1 | grep -q PH2FOFCWT; then
+	if $root/mtzinfo $mtz | grep -q PH2FOFCWT; then
 		fofc2="F1=2FOFCWT SIG1=SIGF PHI=PH2FOFCWT"
 		fofc="F1=F SIG1=SIGF PHI=PHFOFCWT W=FOM"
 	else
@@ -37,7 +55,7 @@ fi
 
 # F SIGF FC PHIC FC_ALL PHIC_ALL FWT PHWT DELFWT PHDELWT FOM FC_ALL_LS PHIC_ALL_LS
 
-$root/fft HKLIN $1 MAPOUT "/tmp/$2_$3_2fofc.map.tmp" << eof
+$root/fft HKLIN $mtz MAPOUT "/tmp/$2_$3_2fofc.map.tmp" << eof
 title $2 2fofc
 xyzlim asu
 scale F1 1.0
@@ -46,11 +64,11 @@ $fofc2
 end
 eof
 
-$root/mapmask MAPIN "/tmp/$2_$3_2fofc.map.tmp" MAPOUT "/tmp/$2_$3_2fofc.map" XYZIN "$4" << eof
+$root/mapmask MAPIN "/tmp/$2_$3_2fofc.map.tmp" MAPOUT "/tmp/$2_$3_2fofc.map" XYZIN "$pdb" << eof
 BORDER 5
 eof
 
-$root/fft HKLIN $1 MAPOUT "/tmp/$2_$3_fofc.map.tmp" << eof
+$root/fft HKLIN $mtz MAPOUT "/tmp/$2_$3_fofc.map.tmp" << eof
 title $2 fofc
 xyzlim asu
 scale F1 1.0
@@ -60,7 +78,7 @@ end
 eof
 
 
-$root/mapmask MAPIN "/tmp/$2_$3_fofc.map.tmp" MAPOUT "/tmp/$2_$3_fofc.map" XYZIN "$4" << eof
+$root/mapmask MAPIN "/tmp/$2_$3_fofc.map.tmp" MAPOUT "/tmp/$2_$3_fofc.map" XYZIN "$pdb" << eof
 BORDER 5
 eof
 
@@ -69,7 +87,7 @@ gzip "/tmp/$2_$3_fofc.map"
 
 
 else
-$root/fft HKLIN $1 MAPOUT "/tmp/$2_$3.map" << eof
+$root/fft HKLIN $mtz MAPOUT "/tmp/$2_$3.map" << eof
 title $2 fofc
 xyzlim asu
 scale F1 1.0
@@ -78,7 +96,7 @@ F1=F SIG1=SIGF PHI=PHI W=FOM
 end
 eof
 
-#$mm MAPIN "/tmp/$2_ep.map.tmp" MAPOUT "/tmp/$2_ep.map" XYZIN "$4" << eof
+#$mm MAPIN "/tmp/$2_ep.map.tmp" MAPOUT "/tmp/$2_ep.map" XYZIN "$pdb" << eof
 #BORDER 5
 #eof
 

--- a/api/scripts/mtz2map.sh
+++ b/api/scripts/mtz2map.sh
@@ -21,8 +21,13 @@ else
 	if [ -f $1.gz ]; then
 		mtz=/tmp/$2_$3.mtz
 		gunzip -c $1.gz > $mtz
+	else
+		echo "No mtz file found"
+		exit
 	fi
 fi
+
+if [ $3 == 'dimple' -o $3 == 'mrbump' ]; then
 
 if [ -f $4 ]; then
 	pdb=$4
@@ -30,16 +35,13 @@ else
 	if [ -f $4.gz ]; then
 		pdb=/tmp/$2_$3.pdb
 		gunzip -c $4.gz > $pdb
+	else
+		echo "No pdb file found"
+		exit
 	fi
 fi
 
-if [ $3 == 'dimple' -o $3 == 'mrbump' ]; then
-
 if [ $3 == 'dimple' ]; then
-	# fofc2="F1=F SIG1=SIGF PHI=PH2FOFCWT W=FOM"
-	# fofc="F1=F SIG1=SIGF PHI=PHFOFCWT W=FOM"
-	# fofc2="F1=F SIG1=SIGF PHI=PHWT W=FOM"
-	# fofc="F1=F SIG1=SIGF PHI=PHDELWT W=FOM"
 
 	if $root/mtzinfo $mtz | grep -q PH2FOFCWT; then
 		fofc2="F1=2FOFCWT SIG1=SIGF PHI=PH2FOFCWT"
@@ -85,6 +87,7 @@ eof
 gzip "/tmp/$2_$3_2fofc.map"
 gzip "/tmp/$2_$3_fofc.map"
 
+rm -f /tmp/$2_$3.pdb
 
 else
 $root/fft HKLIN $mtz MAPOUT "/tmp/$2_$3.map" << eof
@@ -96,10 +99,8 @@ F1=F SIG1=SIGF PHI=PHI W=FOM
 end
 eof
 
-#$mm MAPIN "/tmp/$2_ep.map.tmp" MAPOUT "/tmp/$2_ep.map" XYZIN "$pdb" << eof
-#BORDER 5
-#eof
-
 gzip "/tmp/$2_$3.map"
 
 fi
+
+rm -f /tmp/$2_$3.mtz

--- a/api/src/Downstream/BigEPPhasing.php
+++ b/api/src/Downstream/BigEPPhasing.php
@@ -28,14 +28,13 @@ class BigEPPhasing extends DownstreamPlugin {
         $dat['IMAGE'] = file_exists($image) || file_exists($image.'.gz');
 
         $model = $this->_get_attachments('big_ep_model_ispyb.json');
+
         $dat['HASMODEL'] = $model && (file_exists($model['FILE']) || file_exists($model['FILE'].'.gz'));
         if ($model) {
             if (file_exists($model['FILE'])) {
                 $json_str = file_get_contents($model['FILE']);
             } elseif (file_exists($model['FILE'].'.gz')) {
-                $zd = gzopen($model['FILE'].'.gz', 'r');
-                $json_str = gzread($zd, 10000000);
-                gzclose($zd);
+                $json_str = readgzfile($model['FILE'].'.gz');
             }
             if (isset($json_str)) {
                 $json_data = json_decode($json_str, true);

--- a/api/src/Downstream/BigEPPhasing.php
+++ b/api/src/Downstream/BigEPPhasing.php
@@ -34,7 +34,7 @@ class BigEPPhasing extends DownstreamPlugin {
             if (file_exists($model['FILE'])) {
                 $json_str = file_get_contents($model['FILE']);
             } elseif (file_exists($model['FILE'].'.gz')) {
-                $json_str = readgzfile($model['FILE'].'.gz');
+                $json_str = gzdecode(file_get_contents($model['FILE'].'.gz'));
             }
             if (isset($json_str)) {
                 $json_data = json_decode($json_str, true);

--- a/api/src/Downstream/BigEPPhasing.php
+++ b/api/src/Downstream/BigEPPhasing.php
@@ -28,7 +28,6 @@ class BigEPPhasing extends DownstreamPlugin {
         $dat['IMAGE'] = file_exists($image) || file_exists($image.'.gz');
 
         $model = $this->_get_attachments('big_ep_model_ispyb.json');
-
         $dat['HASMODEL'] = $model && (file_exists($model['FILE']) || file_exists($model['FILE'].'.gz'));
         if ($model) {
             if (file_exists($model['FILE'])) {

--- a/api/src/Downstream/BigEPPhasing.php
+++ b/api/src/Downstream/BigEPPhasing.php
@@ -25,13 +25,19 @@ class BigEPPhasing extends DownstreamPlugin {
         }
 
         $image = $this->_get_image();
-        $dat['IMAGE'] = file_exists($image);
+        $dat['IMAGE'] = file_exists($image) || file_exists($image.'.gz');
 
         $model = $this->_get_attachments('big_ep_model_ispyb.json');
-        $dat['HASMODEL'] = $model && file_exists($model['FILE']);
+        $dat['HASMODEL'] = $model && (file_exists($model['FILE']) || file_exists($model['FILE'].'.gz'));
         if ($model) {
             if (file_exists($model['FILE'])) {
                 $json_str = file_get_contents($model['FILE']);
+            } elseif (file_exists($model['FILE'].'.gz')) {
+                $zd = gzopen($model['FILE'].'.gz', 'r');
+                $json_str = gzread($zd, 10000000);
+                gzclose($zd);
+            }
+            if (isset($json_str)) {
                 $json_data = json_decode($json_str, true);
                 foreach (
                     array(

--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -18,7 +18,7 @@ class FastEp extends DownstreamPlugin {
             if (file_exists($pdb["FILE"])) {
                 $pdb = file_get_contents($pdb["FILE"]);
             } elseif (file_exists($pdb['FILE'].'.gz')) {
-                $pdb = readgzfile($pdb['FILE'].'.gz');
+                $pdb = gzdecode(file_get_contents($pdb['FILE'].'.gz'));
             } else {
                 $this->_error('Could not find sad_fa.pdb file');
             }

--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -17,82 +17,98 @@ class FastEp extends DownstreamPlugin {
         if ($pdb) {
             if (file_exists($pdb["FILE"])) {
                 $pdb = file_get_contents($pdb["FILE"]);
-                foreach (explode("\n", $pdb) as $l) {
-                    if (strpos($l, 'HETATM') !== false) {
-                        $parts = preg_split('/\s+/', $l);
-                        array_push($ats, array(
-                            $parts[1],
-                            $parts[5],
-                            $parts[6],
-                            $parts[7],
-                            $parts[8],
-                        ));
-                    }
-                }
-
-                $dat['ATOMS'] = array_slice($ats, 0, 5);
+            } elseif (file_exists($pdb['FILE'].'.gz')) {
+                $zd = gzopen($pdb['FILE'].'.gz', 'r');
+                $pdb = gzread($zd, 10000000);
+                gzclose($zd);
+            } else {
+                $this->_error('Could not find sad_fa.pdb file');
             }
+
+            foreach (explode("\n", $pdb) as $l) {
+                if (strpos($l, 'HETATM') !== false) {
+                    $parts = preg_split('/\s+/', $l);
+                    array_push($ats, array(
+                        $parts[1],
+                        $parts[5],
+                        $parts[6],
+                        $parts[7],
+                        $parts[8],
+                    ));
+                }
+            }
+
+            $dat['ATOMS'] = array_slice($ats, 0, 5);
+
         }
 
         $lst = $this->_get_attachments("sad.lst");
         if ($lst) {
             if (file_exists($lst['FILE'])) {
-                $p1 = array();
-                $p2 = array();
-
                 $lst = file_get_contents($lst['FILE']);
-                $graph_vals = 0;
-                $gvals = array();
-                foreach (explode("\n", $lst) as $l) {
-                    if (
-                        strpos(
-                            $l,
-                            'Estimated mean FOM and mapCC as a function of resolution'
-                        ) !== false
-                    ) {
-                        $graph_vals = 1;
-                    }
-
-                    if ($graph_vals && $graph_vals < 5) {
-                        array_push($gvals, $l);
-                        $graph_vals++;
-                    }
-
-                    if (
-                        preg_match(
-                            '/ Estimated mean FOM = (\d+.\d+)\s+Pseudo-free CC = (\d+.\d+)/',
-                            $l,
-                            $mat
-                        )
-                    ) {
-                        $dat['FOM'] = floatval($mat[1]);
-                        $dat['CC'] = floatval($mat[2]);
-                    }
-                }
-
-                if (sizeof($gvals) > 0) {
-                    $x = array_map(
-                        'floatval',
-                        array_slice(explode(' - ', $gvals[1]), 1)
-                    );
-                    $y = array_map(
-                        'floatval',
-                        array_slice(preg_split('/\s+/', $gvals[2]), 2)
-                    );
-                    $y2 = array_map(
-                        'floatval',
-                        array_slice(preg_split('/\s+/', $gvals[3]), 2)
-                    );
-
-                    foreach ($x as $i => $v) {
-                        array_push($p1, array(1.0 / pow($v, 2), $y[$i]));
-                        array_push($p2, array(1.0 / pow($v, 2), $y2[$i]));
-                    }
-                }
-
-                $dat['PLOTS']['FOM'] = $p1;
-                $dat['PLOTS']['CC'] = $p2;
+            } elseif (file_exists($lst['FILE'].'.gz')) {
+                $zd = gzopen($lst['FILE'].'.gz', 'r');
+                $lst = gzread($zd, 10000000);
+                gzclose($zd);
+            } else {
+                $this->_error('Could not find sad.lst file');
             }
+
+            $p1 = array();
+            $p2 = array();
+
+            $graph_vals = 0;
+            $gvals = array();
+            foreach (explode("\n", $lst) as $l) {
+                if (
+                    strpos(
+                        $l,
+                        'Estimated mean FOM and mapCC as a function of resolution'
+                    ) !== false
+                ) {
+                    $graph_vals = 1;
+                }
+
+                if ($graph_vals && $graph_vals < 5) {
+                    array_push($gvals, $l);
+                    $graph_vals++;
+                }
+
+                if (
+                    preg_match(
+                        '/ Estimated mean FOM = (\d+.\d+)\s+Pseudo-free CC = (\d+.\d+)/',
+                        $l,
+                        $mat
+                    )
+                ) {
+                    $dat['FOM'] = floatval($mat[1]);
+                    $dat['CC'] = floatval($mat[2]);
+                }
+            }
+
+            if (sizeof($gvals) > 0) {
+                $x = array_map(
+                    'floatval',
+                    array_slice(explode(' - ', $gvals[1]), 1)
+                );
+                $y = array_map(
+                    'floatval',
+                    array_slice(preg_split('/\s+/', $gvals[2]), 2)
+                );
+                $y2 = array_map(
+                    'floatval',
+                    array_slice(preg_split('/\s+/', $gvals[3]), 2)
+                );
+
+                foreach ($x as $i => $v) {
+                    array_push($p1, array(1.0 / pow($v, 2), $y[$i]));
+                    array_push($p2, array(1.0 / pow($v, 2), $y2[$i]));
+                }
+            }
+
+            $dat['PLOTS']['FOM'] = $p1;
+            $dat['PLOTS']['CC'] = $p2;
+
         }
 
         $results = new DownstreamResult($this);

--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -18,9 +18,7 @@ class FastEp extends DownstreamPlugin {
             if (file_exists($pdb["FILE"])) {
                 $pdb = file_get_contents($pdb["FILE"]);
             } elseif (file_exists($pdb['FILE'].'.gz')) {
-                $zd = gzopen($pdb['FILE'].'.gz', 'r');
-                $pdb = gzread($zd, 10000000);
-                gzclose($zd);
+                $pdb = readgzfile($pdb['FILE'].'.gz');
             } else {
                 $this->_error('Could not find sad_fa.pdb file');
             }
@@ -47,9 +45,7 @@ class FastEp extends DownstreamPlugin {
             if (file_exists($lst['FILE'])) {
                 $lst = file_get_contents($lst['FILE']);
             } elseif (file_exists($lst['FILE'].'.gz')) {
-                $zd = gzopen($lst['FILE'].'.gz', 'r');
-                $lst = gzread($zd, 10000000);
-                gzclose($zd);
+                $lst = readgzfile($lst['FILE'].'.gz');
             } else {
                 $this->_error('Could not find sad.lst file');
             }

--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -16,14 +16,14 @@ class FastEp extends DownstreamPlugin {
         $pdb = $this->_get_attachments("sad_fa.pdb");
         if ($pdb) {
             if (file_exists($pdb["FILE"])) {
-                $pdb = file_get_contents($pdb["FILE"]);
+                $pdb_cont = file_get_contents($pdb["FILE"]);
             } elseif (file_exists($pdb['FILE'].'.gz')) {
-                $pdb = gzdecode(file_get_contents($pdb['FILE'].'.gz'));
-            } else {
-                $this->_error('Could not find sad_fa.pdb file');
+                $pdb_cont = gzdecode(file_get_contents($pdb['FILE'].'.gz'));
             }
+        }
 
-            foreach (explode("\n", $pdb) as $l) {
+        if (isset($pdb_cont)) {
+            foreach (explode("\n", $pdb_cont) as $l) {
                 if (strpos($l, 'HETATM') !== false) {
                     $parts = preg_split('/\s+/', $l);
                     array_push($ats, array(
@@ -43,19 +43,19 @@ class FastEp extends DownstreamPlugin {
         $lst = $this->_get_attachments("sad.lst");
         if ($lst) {
             if (file_exists($lst['FILE'])) {
-                $lst = file_get_contents($lst['FILE']);
+                $lst_cont = file_get_contents($lst['FILE']);
             } elseif (file_exists($lst['FILE'].'.gz')) {
-                $lst = gzdecode(file_get_contents($lst['FILE'].'.gz'));
-            } else {
-                $this->_error('Could not find sad.lst file');
+                $lst_cont = gzdecode(file_get_contents($lst['FILE'].'.gz'));
             }
+        }
 
+        if (isset($lst_cont)) {
             $p1 = array();
             $p2 = array();
 
             $graph_vals = 0;
             $gvals = array();
-            foreach (explode("\n", $lst) as $l) {
+            foreach (explode("\n", $lst_cont) as $l) {
                 if (
                     strpos(
                         $l,

--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -45,7 +45,7 @@ class FastEp extends DownstreamPlugin {
             if (file_exists($lst['FILE'])) {
                 $lst = file_get_contents($lst['FILE']);
             } elseif (file_exists($lst['FILE'].'.gz')) {
-                $lst = readgzfile($lst['FILE'].'.gz');
+                $lst = gzdecode(file_get_contents($lst['FILE'].'.gz'));
             } else {
                 $this->_error('Could not find sad.lst file');
             }

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1606,7 +1606,7 @@ class DC extends Page
         if (file_exists($file)) {
             $log = file_get_contents($file);
         } elseif (file_exists($file.'.gz')) {
-            $log = readgzfile($file.'.gz');
+            $log = gzdecode(file_get_contents($file.'.gz'));
         }
         if (isset($log)) {
 

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1608,7 +1608,6 @@ class DC extends Page
         } elseif (file_exists($file.'.gz')) {
             $zd = gzopen($file.'.gz', 'r');
             $log = gzread($zd, 10000000);
-            error_log($log);
             gzclose($zd);
         }
         if (isset($log)) {

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1605,6 +1605,13 @@ class DC extends Page
         $rows = array();
         if (file_exists($file)) {
             $log = file_get_contents($file);
+        } elseif (file_exists($file.'.gz')) {
+            $zd = gzopen($file.'.gz', 'r');
+            $log = gzread($zd, 10000000);
+            error_log($log);
+            gzclose($zd);
+        }
+        if (isset($log)) {
 
             $start = 0;
             foreach (explode("\n", $log) as $l) {

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1606,9 +1606,7 @@ class DC extends Page
         if (file_exists($file)) {
             $log = file_get_contents($file);
         } elseif (file_exists($file.'.gz')) {
-            $zd = gzopen($file.'.gz', 'r');
-            $log = gzread($zd, 10000000);
-            gzclose($zd);
+            $log = readgzfile($file.'.gz');
         }
         if (isset($log)) {
 

--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -257,15 +257,16 @@ class Download extends Page
     {
         // We don't want to allow unlimited file sizes
         ini_set('memory_limit', '512M');
+        $filesystem = new Filesystem();
 
         $filename = $file['FILEPATH'] . '/' . $file['FILENAME'];
 
         // Do the check first, if no file quit early
-        if (file_exists($filename)) {
+        if ($filesystem->exists($filename)) {
             $response = new BinaryFileResponse($filename);
             $this->set_mime_content($response, $filename, $id);
             $response->headers->set("Content-Length", filesize($filename));
-        } elseif (file_exists($filename.'.gz')) {
+        } elseif ($filesystem->exists($filename.'.gz')) {
             $filename = $filename.'.gz';
             if ($this->arg('download') == 1) {
                 // View log file, so unzip and serve
@@ -479,7 +480,7 @@ class Download extends Page
                 if (file_exists($filename)) {
                     $zip->addFileFromPath(basename($filename), $filename);
                 } elseif (file_exists($filename.'.gz')) {
-                    $zip->addFileFromPath(basename($filename), $filename.'.gz');
+                    $zip->addFileFromPath(basename($filename).'.gz', $filename.'.gz');
                 }
             }
 

--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -139,9 +139,7 @@ class Download extends Page
             if (file_exists($json)) {
                 $cont = file_get_contents($json);
             } elseif (file_exists($json.'.gz')) {
-                $zd = gzopen($json.'.gz', 'r');
-                $cont = gzread($zd, 10000000);
-                gzclose($zd);
+                $cont = readgzfile($json.'.gz');
             }
 
             if (isset($cont)) {

--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -511,19 +511,19 @@ class Download extends Page
             $response->headers->set("Content-Disposition", ResponseHeaderBag::DISPOSITION_INLINE);
         } elseif ($path_ext == 'pdf') {
             $response->headers->set("Content-Type", "application/pdf");
-            $response->headers->set("Content-Disposition", ResponseHeaderBag::DISPOSITION_ATTACHMENT, $saved_filename);
+            $response->headers->set("Content-Disposition", "attachment; filename=".$saved_filename);
         } elseif ($path_ext == 'png') {
             $response->headers->set("Content-Type", "image/png");
-            $response->headers->set("Content-Disposition", ResponseHeaderBag::DISPOSITION_ATTACHMENT, $saved_filename);
+            $response->headers->set("Content-Disposition", "attachment; filename=".$saved_filename);
         } elseif (in_array($path_ext, array('jpg', 'jpeg'))) {
             $response->headers->set("Content-Type", "image/jpeg");
-            $response->headers->set("Content-Disposition", ResponseHeaderBag::DISPOSITION_ATTACHMENT, $saved_filename);
+            $response->headers->set("Content-Disposition", "attachment; filename=".$saved_filename);
         } elseif (in_array($path_ext, array('log', 'txt', 'error', 'LP', 'json', 'lsa'))) {
             $response->headers->set("Content-Type", "text/plain");
             $response->headers->set("Content-Disposition", ResponseHeaderBag::DISPOSITION_INLINE);
         } else {
             $response->headers->set("Content-Type", "application/octet-stream");
-            $response->headers->set("Content-Disposition", ResponseHeaderBag::DISPOSITION_ATTACHMENT, $saved_filename);
+            $response->headers->set("Content-Disposition", "attachment; filename=".$saved_filename);
         }
     }
 

--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -139,7 +139,7 @@ class Download extends Page
             if (file_exists($json)) {
                 $cont = file_get_contents($json);
             } elseif (file_exists($json.'.gz')) {
-                $cont = readgzfile($json.'.gz');
+                $cont = gzdecode(file_get_contents($json.'.gz'));
             }
 
             if (isset($cont)) {

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -592,7 +592,7 @@ class Processing extends Page {
             // Specify whether to load map or model, default is model
             $this->has_arg('map') ? $this->arg('map') : false
         );
-        
+
         if (file_exists($mapmodel)) {
             $this->app->response->headers->set(
                 "Content-Length",

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -593,8 +593,6 @@ class Processing extends Page {
             $this->has_arg('map') ? $this->arg('map') : false
         );
         
-        error_log('mapmodel: '.$mapmodel);
-
         if (file_exists($mapmodel)) {
             $this->app->response->headers->set(
                 "Content-Length",

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -522,9 +522,7 @@ class Processing extends Page {
                 $this->_browser_cache();
                 readfile($im);
             } elseif (file_exists($im.'.gz')) {
-                $zd = gzopen($im.'.gz', 'r');
-                $image = gzread($zd, 10000000);
-                gzclose($zd);
+                $image = readgzfile($im.'.gz');
                 $this->_set_content_type_header($im);
                 $this->_browser_cache();
                 $this->app->response()->body($image);
@@ -600,9 +598,7 @@ class Processing extends Page {
             );
             readfile($mapmodel);
         } elseif (file_exists($mapmodel.'.gz')) {
-            $zd = gzopen($mapmodel.'.gz', 'r');
-            $log = gzread($zd, 10000000);
-            gzclose($zd);
+            $log = readgzfile($mapmodel.'.gz');
             $this->app->response()->body($log);
         } else {
             $this->_error('Could not find map / model');

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -518,17 +518,27 @@ class Processing extends Page {
         $im = $plugin->images($this->has_arg('n') ? $this->arg("n") : 0);
         if ($im) {
             if (file_exists($im)) {
-                $ext = pathinfo($im, PATHINFO_EXTENSION);
-                if (in_array($ext, array('png', 'jpg', 'jpeg', 'gif'))) {
-                    $head = 'image/' . $ext;
-                }
-
+                $this->_set_content_type_header($im);
                 $this->_browser_cache();
-                $this->app->contentType($head);
                 readfile($im);
+            } elseif (file_exists($im.'.gz')) {
+                $zd = gzopen($im.'.gz', 'r');
+                $image = gzread($zd, 10000000);
+                gzclose($zd);
+                $this->_set_content_type_header($im);
+                $this->_browser_cache();
+                $this->app->response()->body($image);
             } else {
                 $this->_error("No such image");
             }
+        }
+    }
+
+    function _set_content_type_header($im) {
+        $ext = pathinfo($im, PATHINFO_EXTENSION);
+        if (in_array($ext, array('png', 'jpg', 'jpeg', 'gif'))) {
+            $head = 'image/' . $ext;
+            $this->app->contentType($head);
         }
     }
 

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -424,8 +424,10 @@ class Processing extends Page {
             if ($downstream["PARAMETERS"]) {
                 $str_params = explode(',', $downstream["PARAMETERS"]);
                 foreach ($str_params as $str_param) {
-                    list($key, $value) = explode('=', $str_param);
-                    $params[$key] = $value;
+                    if (str_contains($str_param, '=')) {
+                        list($key, $value) = explode('=', $str_param);
+                        $params[$key] = $value;
+                    }
                 }
             }
             $downstream['PARAMETERS'] = $params;
@@ -522,10 +524,9 @@ class Processing extends Page {
                 $this->_browser_cache();
                 readfile($im);
             } elseif (file_exists($im.'.gz')) {
-                $image = readgzfile($im.'.gz');
                 $this->_set_content_type_header($im);
                 $this->_browser_cache();
-                $this->app->response()->body($image);
+                readgzfile($im.'.gz');
             } else {
                 $this->_error("No such image");
             }
@@ -598,8 +599,7 @@ class Processing extends Page {
             );
             readfile($mapmodel);
         } elseif (file_exists($mapmodel.'.gz')) {
-            $log = readgzfile($mapmodel.'.gz');
-            $this->app->response()->body($log);
+            readgzfile($mapmodel.'.gz');
         } else {
             $this->_error('Could not find map / model');
         }

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -582,6 +582,8 @@ class Processing extends Page {
             // Specify whether to load map or model, default is model
             $this->has_arg('map') ? $this->arg('map') : false
         );
+        
+        error_log('mapmodel: '.$mapmodel);
 
         if (file_exists($mapmodel)) {
             $this->app->response->headers->set(
@@ -589,6 +591,11 @@ class Processing extends Page {
                 filesize($mapmodel)
             );
             readfile($mapmodel);
+        } elseif (file_exists($mapmodel.'.gz')) {
+            $zd = gzopen($mapmodel.'.gz', 'r');
+            $log = gzread($zd, 10000000);
+            gzclose($zd);
+            $this->app->response()->body($log);
         } else {
             $this->_error('Could not find map / model');
         }

--- a/client/src/js/modules/dc/views/autoprocattachments.js
+++ b/client/src/js/modules/dc/views/autoprocattachments.js
@@ -18,7 +18,7 @@ define(['marionette',
         },
 
         render: function() {
-            this.$el.html('<a href="'+app.apiurl+'/download/'+this.column.escape('urlRoot')+'/attachments/'+this.model.escape(this.column.get('idParam'))+'/dl/1" class="button dl"><i class="fa fa-download"></i> Download</a>')
+            this.$el.html('<a href="'+app.apiurl+'/download/'+this.column.escape('urlRoot')+'/attachments/'+this.model.escape(this.column.get('idParam'))+'/dl/2" class="button dl"><i class="fa fa-download"></i> Download</a>')
 
             if (this.model.get('FILETYPE') == 'Log' || this.model.get('FILETYPE') == 'Logfile') {
                 this.$el.append('<a class="vaplog button" href="'+app.apiurl+'/download/'+this.column.escape('urlRoot')+'/attachments/'+this.model.escape(this.column.get('idParam'))+'/dl/1"><i class="fa fa-search"></i> View</a>')

--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -8,7 +8,7 @@
         <a class="apattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
     </p>
 
-    <p>This procesing job failed: <%-PROCESSINGMESSAGE%></p>
+    <p>This processing job failed: <%-PROCESSINGMESSAGE%></p>
 
     <% } else { %>
 

--- a/client/src/js/templates/dc/downstreamerror.html
+++ b/client/src/js/templates/dc/downstreamerror.html
@@ -3,4 +3,4 @@
     <a class="pattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
 </p>
 
-<p>This procesing job failed: <%-PROCESS.PROCESSINGMESSAGE%></p>
+<p>This processing job failed: <%-PROCESS.PROCESSINGMESSAGE%></p>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1074](https://jira.diamond.ac.uk/browse/LIMS-1074)

**Summary**:

To save on disk space, many files created by auto processing pipelines have been zipped (*.gz), which breaks the links to them in Synchweb, as well as a number of image files and map / model viewers. These should be fixed server-side.

**Changes**:
- Use gzopen and gzread to temporarily unzip the processing files before serving them to the front end
- Add already zipped files to archive.zip file served by "Archive" button (they download as unzipped files zipped together)
- Fix the map / model viewer shell script to unzip the relevant files first
- Fix 2 silly spelling mistakes

**To test**:
- View a pre-2022 data collection with autoprocessing, eg /dc/visit/mx23694-64/id/6669874
- For fast_dp
  - Check the 'Archive' button downloads a full zip file
  - Check the 'Plots' button produces graphs
  - Check the 'Radiation Damage' button produces a graph
  - View the 'Logs & Files' modal, and try viewing files of type log and graph and downloading files of type log, graph and result
  - Repeat tests for different autoprocessing pipelines
- For downstream processing
  - Check the 'Archive' and 'Logs & Files' buttons as above
  - Check the 'Map / Model Viewer' button loads a model
  - Check thumbnails of models load for Autosharp, Autobuild and Crank2
- Check no error messages appear on display or in dev console

