### PR TITLE
LIMS-309: Remove the Create New button in the protein acronym field for MX

### DIFF
--- a/client/src/js/modules/types/mx/samples/sample-table-row.vue
+++ b/client/src/js/modules/types/mx/samples/sample-table-row.vue
@@ -30,6 +30,7 @@
         :input-index="sampleIndex"
         default-text=""
         size="small"
+        :canCreateNewItem="false"
         :exclude-element-class-list="['custom-add']"
       >
         <template slot-scope="{ option }">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-309](https://jira.diamond.ac.uk/browse/LIMS-309)

**Summary**:

MX users shouldn't be able to create new proteins within ISPyB, they should create them in UAS to be assessed, then they are copied over. The 'Create New' button that appears now doesn't do anything, so should be removed (for MX proteins, not in general)

**Changes**:
- Set property canCreateNewItem to false when creating the combo box

**To test**:
- Create a new puck, try to create a new protein, verify the 'Create New' button doesn't appear.
- Check can use existing proteins