### PR TITLE
LIMS-1053: Put synchweb version in footer

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -57,6 +57,9 @@
     # - Show at the top of every page on first load
     $motd = 'This is the message of the day.';
 
+    # Synchweb version, displayed in footer of each page
+    $synchweb_version = '';
+
     # Maintainance Mode
     # - Disables site access, showing a message
     # - This is defined in client/js/config.json

--- a/api/index.php
+++ b/api/index.php
@@ -70,7 +70,7 @@ function setupApplication($mode): Slim
         global $motd, $authentication_type, $cas_url, $cas_sso, $sso_url, $package_description,
             $facility_courier_countries, $facility_courier_countries_nde,
             $dhl_enable, $dhl_link, $scale_grid, $scale_grid_end_date, $preset_proposal, $timezone,
-            $valid_components, $enabled_container_types, $ifsummary;
+            $valid_components, $enabled_container_types, $ifsummary, $synchweb_version;
         $app->contentType('application/json');
         $options = $app->container['options'];
         $app->response()->body(json_encode(array(
@@ -90,7 +90,8 @@ function setupApplication($mode): Slim
             'timezone' => $timezone,
             'valid_components' => $valid_components,
             'enabled_container_types' => $enabled_container_types,
-            'ifsummary' => $ifsummary
+            'ifsummary' => $ifsummary,
+            'synchweb_version' => $synchweb_version
         )));
     });
     return $app;

--- a/client/src/css/partials/_header.scss
+++ b/client/src/css/partials/_header.scss
@@ -149,44 +149,34 @@
     @apply tw-bg-footer-background tw-bg-footer-site-logo tw-bg-center tw-bg-no-repeat;
     // background: $footer-background url('~images/ispyb_gs_medium.png') center center no-repeat;
     height: 200px;
-    background-position: 50% 85%;
+    background-position: 50% 60%;
     
     @media (max-width: $breakpoint-medium) {
         clear: both;
     }
 
-    .whatnow {
+    .bottom_bar {
         border-top: 1px solid #bbb;
-        font-size: 16px;
+        font-size: 12px;
         font-family: $page-header-font;
-        text-align: center;
+        display: block;
+        padding: 0.5%;
+        color: #222;
+        background: #eee;
+        transition: 0.3s ease-in-out;
 
         a {
-            display: block;
-            padding: 0.5%;
-            color: #222;
-            background: #eee;
-            transition: 0.3s ease-in-out;
-
-            &:hover {
-                color: #000;
-            };
+            text-decoration: none;
         }
-    }
 
-    a {
-        color: $footer-color;
-        text-decoration: none;
-        
-        &:hover {
-            color: $footer-hover-color;
+        .powered_by {
+            float: left;
+            width: 50%;
         }
-    }
-    
-    p {
-        padding: 1%;
-        text-align: center;
-        color: $footer-color;
-        font-size: 10px;
+
+        .site {
+            margin-left: 50%;
+            text-align: right;
+        }
     }
 }

--- a/client/src/index.php
+++ b/client/src/index.php
@@ -64,10 +64,14 @@
             </div>
         
             <div id="footer">
-                <div class="whatnow">
-                    <a href="http://diamondlightsource.github.io/SynchWeb/">SynchWeb? What is This?</a>
+                <div class="bottom_bar">
+                    <div class="powered_by">
+                        <p>Powered by <a href="http://diamondlightsource.github.io/SynchWeb/">SynchWeb</a></p>
+                    </div>
+                    <div class="site">
+                        <p><a href="<%= htmlWebpackPlugin.options.jsonConfig.site_link || 'https://www.diamond.ac.uk' %>"><%- htmlWebpackPlugin.options.jsonConfig.site_name || 'Diamond Light Source' %></a> &copy;2013-<script>document.write(new Date().getFullYear())</script></p>
+                    </div>
                 </div>
-                <p><a href="<%= htmlWebpackPlugin.options.jsonConfig.site_link || 'https://www.diamond.ac.uk' %>"><%- htmlWebpackPlugin.options.jsonConfig.site_name || 'Diamond Light Source' %></a> &copy;2013-<script>document.write(new Date().getFullYear())</script></p>
             </div>
         
         </div>

--- a/client/src/js/app/components/footer.vue
+++ b/client/src/js/app/components/footer.vue
@@ -1,9 +1,14 @@
 <template>
   <div id="footer">
-    <div class="whatnow">
-      <a href="http://diamondlightsource.github.io/SynchWeb/">SynchWeb? What is This?</a>
+    <div class="bottom_bar">
+      <div class="powered_by">
+        <p>Powered by <a href="http://diamondlightsource.github.io/SynchWeb/">SynchWeb</a> {{ synchwebVersion }} </p>
+      </div>
+      <div class="site">
+        <p><a :href="siteLink">{{ siteName }}</a> &copy;2013-{{ currentYear }}</p>
+      </div>
     </div>
-    <p><a :href="siteLink">{{ siteName }}</a> &copy;2013-{{ currentYear }}</p>
+
   </div>
 </template>
 
@@ -18,6 +23,9 @@ export default {
         siteLink: config.site_link || 'https://www.diamond.ac.uk',
         siteName: config.site_name || 'Diamond Light Source'
       }
+    },
+    computed: {
+        synchwebVersion : function() { return this.$store.state.synchwebVersion }
     }
 }
 </script>
@@ -27,7 +35,7 @@ export default {
     margin-top: 70px;
     background: #000 url(~images/ispyb_gs_medium.png) center center no-repeat;
     height: 200px;
-    background-position: 50% 85%
+    background-position: 50% 60%
 }
 
 @media (max-width: 1024px) {
@@ -36,40 +44,29 @@ export default {
     }
 }
 
-#footer .whatnow {
+#footer .bottom_bar {
     border-top: 1px solid #bbb;
-    font-size: 16px;
+    font-size: 12px;
     font-family: "Maven Pro";
-    text-align: center
-}
-
-#footer .whatnow a {
     display: block;
     padding: 0.5%;
     color: #222;
     background: #eee;
-    transition: 0.3s ease-in-out
+    transition: 0.3s ease-in-out;
 }
 
-#footer .whatnow a:hover {
-    color: #000
+#footer .bottom_bar a {
+    text-decoration: none;
 }
 
-#footer a {
-    color: #efefef;
-    text-decoration: none
+#footer .bottom-bar .powered_by {
+    float: left;
+    width: 50%;
 }
 
-#footer a:hover {
-    color: #efefef
+#footer .bottom-bar .site {
+    margin-left: 50%;
+    text-align: right;
 }
-
-#footer p {
-    padding: 1%;
-    text-align: center;
-    color: #efefef;
-    font-size: 10px
-}
-
 
 </style>

--- a/client/src/js/app/store/store.js
+++ b/client/src/js/app/store/store.js
@@ -44,6 +44,7 @@ const store = new Vuex.Store({
     isLoading: false,
     motd: '',
     ifsummary: false,
+    synchwebVersion: '',
     help: false, // Global help flag used to denote if we should display inline help on pages
     skipHomePage: config.skipHome || false,
     models: {},
@@ -68,6 +69,7 @@ const store = new Vuex.Store({
       state.motd = options.get('motd') || state.motd
 
       state.ifsummary = options.get('ifsummary') || state.ifsummary
+      state.synchwebVersion = options.get('synchweb_version') || state.synchwebVersion
 
       app.options = options
     },


### PR DESCRIPTION
**JIRA ticket**: [LIMS_1053](https://jira.diamond.ac.uk/browse/LIMS-1053)

**Summary**:

The MotD is not the best place for the Synchweb version number, so let's put it in the footer. While we're at it, let's improve the look of the footer, using @jlmuir's code from https://github.com/DiamondLightSource/SynchWeb/pull/144

**Changes**:
- Move Synchweb link to left of footer, site link to the right
- Do the same for both vue and non-vue versions
- Expose $synchweb_version in the api/options endpoint
- Add the Synchweb version to the footer if it is specified
- Add the variable to the example config.php

**To test**:
- View the footer on any page, check it looks ok
- Check the $synchweb_version is displayed
- Check no errors occur if $synchweb_version is absent
