### PR TITLE
LIMS-1125: Prompt user login on shipping service 401 status

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2895,7 +2895,12 @@ class Shipment extends Page
 
                 $ship['DELIVERYAGENT_FLIGHTCODE'] = $awb['awb'];
             } catch (\Exception $e) {
-                $this->_error($e->getMessage());
+                if (Utils::getValueOrDefault($use_shipping_service_incoming_shipments) && $accno === $dhl_acc){
+                    $error_response = json_decode($e->getMessage());
+                    $this->_error($error_response->content->detail, $error_response->status);
+                } else {
+                    $this->_error($e->getMessage());
+                }
             }
         }
         $pickup = null;


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1125](https://jira.diamond.ac.uk/browse/lims-1125)

**Summary**:

If the shipping service returns a 401 when a user attempts to book an incoming shipment (due to an expired token), prompt the user to log in again.

**Changes**:
- Return errors received from the shipping service to the frontend when trying to book an incoming shipment.

**To test**:
- Check that shipping service error statuses and content details are returned to the client from the backend. In particular, check that a 401 error code results in the user being prompted to log in again.
