### PR TITLE
LIMS-1126: Improve display of pia_estimated_d_min

### DIFF
--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -329,7 +329,7 @@ define(['jquery', 'marionette',
 
         displayResolution: function(val) {
             if (val < 0) { return 0 }
-            return 100 * Math.pow(val, -1)
+            return 100 / val
         },
 
         draw: function() {

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -327,6 +327,10 @@ define(['jquery', 'marionette',
             if (this.hasSnapshot && utils.inView(this.$el)) this.draw()
         },
 
+        displayResolution: function(val) {
+            if (val < 0) { return 0 }
+            return 100 * Math.pow(val, -1)
+        },
 
         draw: function() {
             if (!this.ctx || !this.gridFetched) return
@@ -414,15 +418,17 @@ define(['jquery', 'marionette',
 
             if (d.length > 0) {
                 let max = 0
-                let power = this.invertHeatMap ? -1 : 1
                 let val = 0
+
                 _.each(d, function(v) {
-                    val = Math.pow(v[1], power)
-                    if (val > max) max = val
+                    if (v[1] > max) max = v[1]
                 })
 
                 max = max === 0 ? 1 : max
-                if (this.getOption('padMax') && max < 10 && !this.invertHeatMap) max = max * 50
+                if (this.getOption('padMax') && max < 10) max = max * 50
+
+                // 1.4Å
+                if (this.invertHeatMap) max = 100 / 1.4
 
                 var sw = (this.perceivedw-(this.offset_w*this.scale))/this.grid.get('STEPS_X')
                 var sh = (this.perceivedh-(this.offset_h*this.scale))/this.grid.get('STEPS_Y')
@@ -433,7 +439,7 @@ define(['jquery', 'marionette',
                 var data = []
                 _.each(d, function(v) {
                     var k = v[0] - 1
-                    val = Math.pow(v[1], power)
+                    val = this.invertHeatMap ? this.displayResolution(v[1]) : v[1]
 
                     // Account for vertical grid scans
                     let xstep, ystep, x, y


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1126](https://jira.diamond.ac.uk/browse/LIMS-1126)

**Summary**:

Following on from LIMS-140, improve the display of pia_estimated_d_min

**Changes**:
- Revert some changes from LIMS-140 (https://github.com/DiamondLightSource/SynchWeb/pull/678)
- Use a function to use 100 / resolution to give a reasonable scale, but setting -1 (no diffraction) as 0.
- Set the max value as 100 / 1.4, ie 1.4 Angstroms

**To test**:
- View a VMXi gridscan eg /dc/visit/nt37104-4/id/12141916, check pia_estimated_d_min shows red around the crystals
- Check a weaker diffracting grid scan eg /dc/visit/nt37104-4/id/12097225, check pia_estimated_d_min shows more yellow around the crystals rather than red
- Check other pia results are unaffected
- Check non-VMXi grid scans are unaffected

