### PR TITLE
LIMS-1113: Shipping service dispatch redirect

### DIFF
--- a/api/assets/emails/html/dewar-dispatch-lite.html
+++ b/api/assets/emails/html/dewar-dispatch-lite.html
@@ -1,0 +1,30 @@
+<h1 style="font-size: 16px; font-weight: normal; border-bottom: 1px solid #000; margin: 1%; margin-bottom: 1.5%">Dewar ready to leave diamond</h1>
+
+<div class="inset" style="margin: 1%; padding: 1%; margin-bottom: 2%; border-radius: 5px; background: #82d180">
+	Goods Handling, please arrange dispatch of the following Dewar.
+</div>
+
+<table class="details" style="background: #f4f4f4; margin: 1%">
+	<tbody>
+		<tr>
+			<td style="padding: 1.5%; font-weight: bold">Proposal</td>
+			<td><?php echo $data['prop'] ?></td>
+		</tr>
+		<tr>
+			<td style="padding: 1.5%; font-weight: bold">Air Waybill</td>
+			<td><a href="<?php echo $data['AWBURL']; ?>"><?php echo $data['AWBURL']; ?></a></td>
+		</tr>
+		<tr>
+			<td style="padding: 1.5%; font-weight: bold">Dewar Facility Code</td>
+			<td><?php echo $data['FACILITYCODE'] ?></td>
+		</tr>
+		<tr>
+			<td style="padding: 1.5%; font-weight: bold">Dewar Barcode</td>
+			<td><?php echo $data['BARCODE'] ?></td>
+		</tr>
+		<tr>
+			<td style="padding: 1.5%; font-weight: bold">Current Location</td>
+			<td><?php echo $data['LOCATION'] ?></td>
+		</tr>
+	</tbody>
+</table>

--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -264,6 +264,7 @@
     # Shipping service details
     $use_shipping_service = null;
     $use_shipping_service_incoming_shipments = null;
+    $use_shipping_service_redirect = null;
     $shipping_service_api_url = null;
     $shipping_service_api_user = null;
     $shipping_service_api_password = null;

--- a/api/index.php
+++ b/api/index.php
@@ -70,7 +70,7 @@ function setupApplication($mode): Slim
         global $motd, $authentication_type, $cas_url, $cas_sso, $sso_url, $package_description,
             $facility_courier_countries, $facility_courier_countries_nde,
             $dhl_enable, $dhl_link, $scale_grid, $scale_grid_end_date, $preset_proposal, $timezone,
-            $valid_components, $enabled_container_types, $ifsummary;
+            $valid_components, $enabled_container_types, $ifsummary, $shipping_service_app_url, $use_shipping_service_redirect;
         $app->contentType('application/json');
         $options = $app->container['options'];
         $app->response()->body(json_encode(array(
@@ -90,7 +90,8 @@ function setupApplication($mode): Slim
             'timezone' => $timezone,
             'valid_components' => $valid_components,
             'enabled_container_types' => $enabled_container_types,
-            'ifsummary' => $ifsummary
+            'ifsummary' => $ifsummary,
+            'shipping_service_app_url' => $use_shipping_service_redirect ? $shipping_service_app_url : null,
         )));
     });
     return $app;

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1178,12 +1178,12 @@ class Shipment extends Page
         // If a local contact is given, try to find their email address
         // First try LDAP, if unsuccessful look at the ISPyB person record for a matching staff user
         $local_contact = $this->has_arg('LOCALCONTACT') ? $this->args['LOCALCONTACT'] : '';
-        // if ($local_contact) {
-        //     $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
-        //     if (!$this->args['LCEMAIL']) {
-        //         $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
-        //     }
-        // }
+        if ($local_contact) {
+            $this->args['LCEMAIL'] = $this->_get_email_fn($local_contact);
+            if (!$this->args['LCEMAIL']) {
+                $this->args['LCEMAIL'] = $this->_get_ispyb_email_fn($local_contact);
+            }
+        }
 
         if (!array_key_exists('FACILITYCODE', $data))
             $data['FACILITYCODE'] = '';

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1142,7 +1142,7 @@ class Shipment extends Page
                     try {
                         $shipment_id = $this->_dispatch_dewar_shipment_request($dew);
                     } catch (Exception $e) {
-                        error_log("Error returned from shipping service: " . $e . "\nShipment data: " . json_encode($shipment_data));
+                        error_log("Error returned from shipping service: " . $e . "\nDewar data: " . json_encode($dew));
                         $error_response = json_decode($e->getMessage());
                         $this->_error($error_response->content->detail, $error_response->status);
                     }

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -942,21 +942,31 @@ class Shipment extends Page
                                 "quantity" => 1
                             ],
                             [
-                                "shippable_item_type"=> "UNI_PUCK",
-                                "quantity" => (int) $dewar['NUM_PUCKS']
-                            ],
-                            [
                                 "shippable_item_type" => "SHELVED_UNI_PUCK_SHIPPING_CANE",
                                 "quantity" => 1
                             ],
-                            [
-                                "shippable_item_type" => "SPINE_SAMPLE_HOLDER",
-                                "quantity" => (int) $dewar['NUM_SAMPLES']
-                            ]
                         ]
                     ]
                 ]
             );
+            if ((int) $dewar['NUM_PUCKS'] > 0) {
+                array_push(
+                    $shipment_request_info["packages"][0]["line_items"],
+                    [
+                        "shippable_item_type"=> "UNI_PUCK",
+                        "quantity" => (int) $dewar['NUM_PUCKS']
+                    ]
+                );
+            }
+            if ((int) $dewar['NUM_SAMPLES'] > 0) {
+                array_push(
+                    $shipment_request_info["packages"][0]["line_items"],
+                    [
+                        "shippable_item_type"=> "SPINE_SAMPLE_HOLDER",
+                        "quantity" => (int) $dewar['NUM_SAMPLES']
+                    ]
+                );
+            }
             try {
                 $response = $this->shipping_service->create_shipment_request($shipment_request_info);
                 $external_shipping_id = $response['shipmentRequestId'];
@@ -1068,7 +1078,7 @@ class Shipment extends Page
                 FROM dewar d 
                 INNER JOIN shipping s ON s.shippingid = d.shippingid 
                 INNER JOIN proposal p ON p.proposalid = s.proposalid
-                INNER JOIN container c on c.dewarid = d.dewarid
+                LEFT JOIN container c on c.dewarid = d.dewarid
                 LEFT JOIN BLSample b on b.containerId = c.containerId
                 WHERE d.dewarid=:1 and p.proposalid=:2",
             array($this->arg('DEWARID'), $this->proposalid)

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1139,7 +1139,7 @@ class Shipment extends Page
                         $this->_error($e);
                     }
                     if (Utils::getValueOrDefault($shipping_service_links_in_emails)) {
-                        $data['AWBURL'] = "{$shipping_service_app_url}/shipment_requests/{$shipment_id}/outgoing";
+                        $data['AWBURL'] = "{$shipping_service_app_url}/shipment-requests/{$shipment_id}/outgoing";
                     }
                 } else {
                     try {

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -151,4 +151,14 @@ class ShippingService
     {
         return $this->shipping_app_url . '/shipments/' . $shipment_id . '/awb';
     }
+
+    function create_shipment_request($shipment_request_data)
+    {
+        return $this->_send_request(
+            $this->shipping_api_url . '/shipment_requests/',
+            "POST",
+            $shipment_request_data,
+            201
+        );
+    }
 }

--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -16,7 +16,9 @@ define(['backbone'], function(Backbone) {
         },
 
         VISIT: {
-            required: true,
+            required: function() {
+                return this.visitRequired
+            },
             pattern: 'visit',
         },
 
@@ -108,6 +110,7 @@ define(['backbone'], function(Backbone) {
 
     courierDetailsRequired: false, // We want to set this default to false unless 'DELIVERYAGENT_AGENTCODE' has a value in the shipment model
     postCodeRequired: false,
+    visitRequired: true,
   })
        
 })

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -84,6 +84,7 @@ define(['marionette', 'views/form',
             accountNumber: 'input[NAME=DELIVERYAGENT_AGENTCODE]',
             courier: 'input[name=DELIVERYAGENT_AGENTNAME]',
             courierDetails: '.courierDetails',
+            dispatchDetails: '.dispatchDetails',
             facilityCourier: '.facilityCourier',
             awbNumber: 'input[name=AWBNUMBER]',
             useAnotherCourierAccount: 'input[name=USE_ANOTHER_COURIER_ACCOUNT]',
@@ -112,6 +113,14 @@ define(['marionette', 'views/form',
         
         success: function() {
             app.trigger('shipment:show', this.getOption('dewar').get('SHIPPINGID'))
+            if (app.options.get("shipping_service_app_url") && (this.terms.get('ACCEPTED') == 1)) { // terms.ACCPETED could be undefined, 1, or "1"
+                this.getOption('dewar').fetch().done((dewar) => {
+                    const external_id = dewar.EXTERNALSHIPPINGIDFROMSYNCHROTRON;
+                    window.location.assign(
+                        `https://${app.options.get("shipping_service_app_url")}/shipment-requests/${external_id}/outgoing`
+                    )
+                })
+            }
         },
 
         failure: function() {
@@ -120,6 +129,7 @@ define(['marionette', 'views/form',
         
         onRender: function() {
             this.date('input[name=DELIVERYAGENT_SHIPPINGDATE]')
+            this.$el.hide()
 
             var d = new Date()
             var today = (d.getDate() < 10 ? '0'+d.getDate() : d.getDate()) + '-' + (d.getMonth() < 9 ? '0'+(d.getMonth()+1) : d.getMonth()+1) + '-' + d.getFullYear()
@@ -150,6 +160,8 @@ define(['marionette', 'views/form',
             this.populateCountries()
             this.stripPostCode()
             this.formatAddress()
+            this.$el.show()
+            this.getOption('dewar').fetch().done((foo)=>{console.log(foo);})
         },
 
         populateCountries: function() {
@@ -266,6 +278,10 @@ define(['marionette', 'views/form',
             this.ui.courierDetails.hide()
             this.ui.facilityCourier.show()
             this.model.courierDetailsRequired = false
+            if (app.options.get("shipping_service_app_url")){
+                this.model.visitRequired = false
+                this.ui.dispatchDetails.hide()
+            }
         },
 
         checkPostCodeRequired: function() {

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -117,7 +117,7 @@ define(['marionette', 'views/form',
                 this.getOption('dewar').fetch().done((dewar) => {
                     const external_id = dewar.EXTERNALSHIPPINGIDFROMSYNCHROTRON;
                     window.location.assign(
-                        `https://${app.options.get("shipping_service_app_url")}/shipment-requests/${external_id}/outgoing`
+                        `${app.options.get("shipping_service_app_url")}/shipment-requests/${external_id}/outgoing`
                     )
                 })
             }

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -115,7 +115,7 @@ define(['marionette', 'views/form',
         
         success: function() {
             app.trigger('shipment:show', this.getOption('dewar').get('SHIPPINGID'))
-            if (app.options.get("shipping_service_app_url") && (this.terms.get('ACCEPTED') == 1)) { // terms.ACCPETED could be undefined, 1, or "1"
+            if (app.options.get("shipping_service_app_url") && (Number(this.terms.get('ACCEPTED')) === 1)) { // terms.ACCPETED could be undefined, 1, or "1"
                 this.getOption('dewar').fetch().done((dewar) => {
                     const external_id = dewar.EXTERNALSHIPPINGIDFROMSYNCHROTRON;
                     window.location.assign(

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -279,7 +279,10 @@ define(['marionette', 'views/form',
             this.ui.courierDetails.hide()
             this.ui.facilityCourier.show()
             this.model.courierDetailsRequired = false
-            if (app.options.get("shipping_service_app_url")){
+            if (
+                app.options.get("shipping_service_app_url")
+                && app.options.get("facility_courier_countries").includes(this.ui.country.val())
+            ){
                 this.model.visitRequired = false
                 this.ui.dispatchDetails.hide()
                 this.ui.submit.text("Proceed")

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -80,6 +80,8 @@ define(['marionette', 'views/form',
             ph: 'input[name=PHONENUMBER]',
             lab: 'input[name=LABNAME]',
 
+            submit: 'button[name=submit]',
+
             facc: 'a.facc',
             accountNumber: 'input[NAME=DELIVERYAGENT_AGENTCODE]',
             courier: 'input[name=DELIVERYAGENT_AGENTNAME]',
@@ -161,7 +163,6 @@ define(['marionette', 'views/form',
             this.stripPostCode()
             this.formatAddress()
             this.$el.show()
-            this.getOption('dewar').fetch().done((foo)=>{console.log(foo);})
         },
 
         populateCountries: function() {
@@ -281,6 +282,7 @@ define(['marionette', 'views/form',
             if (app.options.get("shipping_service_app_url")){
                 this.model.visitRequired = false
                 this.ui.dispatchDetails.hide()
+                this.ui.submit.text("Proceed")
             }
         },
 

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -115,7 +115,11 @@ define(['marionette', 'views/form',
         
         success: function() {
             app.trigger('shipment:show', this.getOption('dewar').get('SHIPPINGID'))
-            if (app.options.get("shipping_service_app_url") && (Number(this.terms.get('ACCEPTED')) === 1)) { // terms.ACCPETED could be undefined, 1, or "1"
+            if (
+                app.options.get("shipping_service_app_url")
+                && (Number(this.terms.get('ACCEPTED')) === 1) // terms.ACCPETED could be undefined, 1, or "1"
+                && app.options.get("facility_courier_countries").includes(this.labContactCountry)
+            ) {
                 this.getOption('dewar').fetch().done((dewar) => {
                     const external_id = dewar.EXTERNALSHIPPINGIDFROMSYNCHROTRON;
                     window.location.assign(

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -281,7 +281,7 @@ define(['marionette', 'views/form',
             this.model.courierDetailsRequired = false
             if (
                 app.options.get("shipping_service_app_url")
-                && app.options.get("facility_courier_countries").includes(this.ui.country.val())
+                && app.options.get("facility_courier_countries").includes(this.labContactCountry)
             ){
                 this.model.visitRequired = false
                 this.ui.dispatchDetails.hide()

--- a/client/src/js/templates/shipment/dewarlistrow.html
+++ b/client/src/js/templates/shipment/dewarlistrow.html
@@ -15,7 +15,12 @@
         <a class="button button-notext add" title="Click to add a container" href="/containers/add/did/<%-DEWARID%>"><i class="fa fa-plus"></i> <span>Add Container</span></a>
 
         <% if (STORAGELOCATION != 'stores-out') { %>
-        <a class="button button-notext" title="Click to dispatch dewar back to your lab" href="/dewars/dispatch/<%-DEWARID%>"><i class="fa fa-home"></i> <span>Dispatch Dewar</span></a>
+            <% if (app.options.get("shipping_service_app_url") && EXTERNALSHIPPINGIDFROMSYNCHROTRON) { %>
+                <% const link = `${app.options.get("shipping_service_app_url")}/shipment-requests/${EXTERNALSHIPPINGIDFROMSYNCHROTRON}/outgoing` %>
+                <a class="button button-notext" title="Click to view dispatch information" href="<%-link%>"><i class="fa fa-home"></i> <span>Dispatch Dewar</span></a>
+            <% } else { %>
+                <a class="button button-notext" title="Click to dispatch dewar back to your lab" href="/dewars/dispatch/<%-DEWARID%>"><i class="fa fa-home"></i> <span>Dispatch Dewar</span></a>
+            <% } %>
         <a class="button button-notext" title="Click to transfer dewar to another beamline" href="/dewars/transfer/<%-DEWARID%>"><i class="fa fa-arrows-h"></i> <span>Transfer Dewar</span></a>
         <% } %>
     </td>

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -23,6 +23,56 @@
                 <span class="" data-testid="dispatch-facility-code"><%-DEWAR.FACILITYCODE%></span>
             </li>
             <% } %>
+
+            
+            <li class="head">
+                Courier Details
+                <span></span>
+                <a href="#" class="facc button" data-testid="dispatch-use-facility-courier"><i class="fa fa-envelope"></i> Use Facility Account</a>
+            </li>
+
+            <% if (SHIPPING.TERMSACCEPTED == 0) { %>
+
+            <li class="courierDetails">
+                <label>Courier
+                    <span class="small">Courier Name</span>
+                </label>
+                <input type="text" name="DELIVERYAGENT_AGENTNAME" data-testid="dispatch-courier-name"/>
+            </li>
+
+            <li class="courierDetails">
+                <label>Account Number
+                    <span class="small">Courier account number</span>
+                </label>
+                <input type="text" name="DELIVERYAGENT_AGENTCODE" data-testid="dispatch-courier-account"/>
+            </li>
+
+            <% if (SHIPPING.DELIVERYAGENT_AGENTNAME && SHIPPING.DELIVERYAGENT_AGENTCODE) { %>
+            <li class="courierDetails">
+                <label>
+                    Use another account
+                    <span class="small">Use another courier account instead</span>
+                </label>
+                <input type="checkbox" name="USE_ANOTHER_COURIER_ACCOUNT" value="0" data-testid="dispatch-use-another-account"/>
+            </li>
+            <% } %>
+
+            <li class="courierDetails">
+                <label>Air Waybill Number
+                    <span class="small">Air waybill no. if you have generated your own</span>
+                </label>
+                <input type="text" name="AWBNUMBER" data-testid="dispatch-air-waybill"/>
+            </li>
+
+            <% } %>
+
+            <li class="facilityCourier">
+                <label>Courier</label>
+                <span class="small" data-testid="dispatch-facility-courier">This dewar will be returned using the facility's courier account</span>
+            </li>
+            
+        </ul>
+        <ul class="dispatchDetails">
             
             <li class="head">Visit Details</li>
             <li>
@@ -125,53 +175,6 @@
                 </label>
                 <input class="half" type="text" name="DELIVERYAGENT_SHIPPINGDATE" data-testid="dispatch-shipping-date"/>
             </li>
-
-            
-            <li class="head">
-                Courier Details
-                <span></span>
-                <a href="#" class="facc button" data-testid="dispatch-use-facility-courier"><i class="fa fa-envelope"></i> Use Facility Account</a>
-            </li>
-
-            <% if (SHIPPING.TERMSACCEPTED == 0) { %>
-
-            <li class="courierDetails">
-                <label>Courier
-                    <span class="small">Courier Name</span>
-                </label>
-                <input type="text" name="DELIVERYAGENT_AGENTNAME" data-testid="dispatch-courier-name"/>
-            </li>
-
-            <li class="courierDetails">
-                <label>Account Number
-                    <span class="small">Courier account number</span>
-                </label>
-                <input type="text" name="DELIVERYAGENT_AGENTCODE" data-testid="dispatch-courier-account"/>
-            </li>
-
-            <% if (SHIPPING.DELIVERYAGENT_AGENTNAME && SHIPPING.DELIVERYAGENT_AGENTCODE) { %>
-            <li class="courierDetails">
-                <label>
-                    Use another account
-                    <span class="small">Use another courier account instead</span>
-                </label>
-                <input type="checkbox" name="USE_ANOTHER_COURIER_ACCOUNT" value="0" data-testid="dispatch-use-another-account"/>
-            </li>
-            <% } %>
-
-            <li class="courierDetails">
-                <label>Air Waybill Number
-                    <span class="small">Air waybill no. if you have generated your own</span>
-                </label>
-                <input type="text" name="AWBNUMBER" data-testid="dispatch-air-waybill"/>
-            </li>
-
-            <% } %>
-
-            <li class="facilityCourier">
-                <label>Courier</label>
-                <span class="small" data-testid="dispatch-facility-courier">This dewar will be returned using the facility's courier account</span>
-            </li>
     
 
             <li>
@@ -180,10 +183,10 @@
                 </label>
                 <textarea name="COMMENTS" data-testid="dispatch-comments"></textarea>
             </li>
-
-            <button name="submit" value="1" type="submit" class="button submit" data-testid="dispatch-submit">Request Dewar Dispatch</button>
-            
         </ul>
+
+        <button name="submit" value="1" type="submit" class="button submit" data-testid="dispatch-submit">Request Dewar Dispatch</button>
+            
     </div>
     
 </form>

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -185,7 +185,7 @@
             </li>
         </ul>
 
-        <button name="submit" value="1" type="submit" class="button submit" data-testid="dispatch-submit">Request Dewar Dispatch</button>
+        <button name="submit" value="1" class="button submit" data-testid="dispatch-submit">Request Dewar Dispatch</button>
             
     </div>
     

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -24,6 +24,19 @@
             </li>
             <% } %>
 
+            <li>
+                <label>Email Address<span class="small">The contact email for the Dewar return</span></label>
+                <input type="email" name="EMAILADDRESS" data-testid="dispatch-email-address"/>
+            </li>
+            <li>
+                <label>Destination country
+                    <span class="small">The country the Dewar is being dispatched to</span>
+                </label>
+                <select name="DISPATCHCOUNTRY"></select>
+            </li>
+
+        </ul>
+        <ul class="courierSection">
             
             <li class="head">
                 Courier Details
@@ -117,11 +130,6 @@
             <li>
                 <label>Phone Number</label>
                 <input type="text" name="PHONENUMBER" data-testid="dispatch-phone-number" />
-            </li>
-
-            <li>
-                <label>Email Address</label>
-                <input type="email" name="EMAILADDRESS" data-testid="dispatch-email-address"/>
             </li>
 
             <li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1113](https://jira.diamond.ac.uk/browse/lims-1113)

**Summary**:
Adds the option to redirect to the shipping service to book shipments when requesting dispatch of appropriate Dewars.

**Changes**:
- Adds feature flag `$use_shipping_service_redirect` which enables/disables this feature
- On requesting Dewar dispatch, create a shipment request in the shipping service and redirect to the appropriate shipment workflow to book a shipment
- Use minimised dispatch request email for shipments booked via the new pathway

**To test**:
- Check that the appropriate dispatch form is displayed for academic, industrial, international users
- Check that the appropriate shipment request is created in the shipping service when requesting dispatch of a domestic academic Dewar
- Check that the minified dispatch-lite email template is used for such dispatch requests; ensure this has an appropriate link to where a Goods Handling operative can view and print the air waybill
- Check that the dispatch button links to the shipping service once a dispatch shipment request has been successfully created.
