### PR TITLE
LIMS-1011: Allow linking of registered dewars to proposals without a lab contact

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -729,8 +729,7 @@ class Shipment extends Page
             $this->_error('No dewar specified');
         if (!$this->has_arg('PROPOSALID'))
             $this->_error('No proposal specified');
-        if (!$this->has_arg('LABCONTACTID'))
-            $this->_error('No lab contact specified');
+        $lc = $this->has_arg('LABCONTACTID') ? $this->arg('LABCONTACTID') : null;
 
         $chk = $this->db->pq("SELECT dewarregistryid 
               FROM dewarregistry_has_proposal
@@ -739,7 +738,7 @@ class Shipment extends Page
             $this->_error('That dewar is already registered to that proposal');
 
         $this->db->pq("INSERT INTO dewarregistry_has_proposal (dewarregistryid,proposalid,personid,labcontactid) 
-              VALUES (:1,:2,:3,:4)", array($this->arg('DEWARREGISTRYID'), $this->arg('PROPOSALID'), $this->user->personId, $this->arg('LABCONTACTID')));
+              VALUES (:1,:2,:3,:4)", array($this->arg('DEWARREGISTRYID'), $this->arg('PROPOSALID'), $this->user->personId, $lc));
 
         $this->_output(array('DEWARREGISTRYHASPROPOSALID' => $this->db->id()));
     }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1011](https://jira.diamond.ac.uk/browse/LIMS-1011)

**Summary**:

New proposals need dewars registering to them before they can ship samples, and staff have to do this. But often new proposals dont have any lab contacts yet, so we cant add the proposal to the dewar.

**Changes**:
- Make lab contact an optional field in the function

**To test**:
- Add a dewar to a proposal without any lab contacts, eg nt33918, check the server responds with a DEWARREGISTRYHASPROPOSALID
- Add a dewar to a proposal with lab contacts, same check
