### PR TITLE
LIMS-1163: Improve error message when token is invalid

### DIFF
--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -168,10 +168,11 @@ class AuthenticationController
                 $token = $token[0];
                 if ($token['AGE'] > $max_token_age)
                 {
-                    $err = 'Authorisation token too old. Age: '.$token['AGE'].'s. Max age: '.$max_token_age.'s.';
-                    $err .= ' Please press back and then try again.';
+                    $err = 'Authorisation token too old. Please press back and then try again.';
                     $err .= ' If this problem persists, please try clearing your cookies or using a different browser.';
-                    $this->returnError(400, $err, true);
+                    error_log('Authorisation token too old. Age: '.$token['AGE'].'s. Max age: '.$max_token_age.'s.');
+                    error_log('User-agent: ' . $_SERVER['HTTP_USER_AGENT']);
+                    $this->returnError(400, $err);
                 }
                 $qs = $_SERVER['QUERY_STRING'] ? (preg_replace('/(&amp;)?token=\w+/', '', str_replace('&', '&amp;', $_SERVER['QUERY_STRING']))) : null;
                 if ($qs)
@@ -197,7 +198,9 @@ class AuthenticationController
             {
                 $err = 'No authorisation token found. ';
                 $err .= 'If this error persists, please try clearing your cookies or using a different browser.';
-                $this->returnError(400, $err, true);
+                error_log('No authorisation token found.');
+                error_log('User-agent: ' . $_SERVER['HTTP_USER_AGENT']);
+                $this->returnError(400, $err);
             }
             # Remove tokens more than $max_token_age seconds old, they should have been used
             $this->dataLayer->deleteOldOneTimeUseTokens($max_token_age);
@@ -315,13 +318,8 @@ class AuthenticationController
         }
     }
 
-    private function returnError($code, $message, $logError = false)
+    private function returnError($code, $message)
     {
-        if ($logError)
-        {
-            error_log('Authentication error: ' . $message);
-            error_log('User-agent: ' . $_SERVER['HTTP_USER_AGENT']);
-        }
         $this->returnResponse($code, array('error' => $message));
     }
 

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -163,7 +163,7 @@ class AuthenticationController
         {
             $max_token_age = 10;
             $token = $this->dataLayer->getOneTimeUseToken($tokenId);
-            if (false && sizeof($token))
+            if (sizeof($token))
             {
                 $token = $token[0];
                 if ($token['AGE'] > $max_token_age)

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -188,7 +188,7 @@ class AuthenticationController
                 }
                 else
                 {
-                    $err = 'Authorisation token not valid for this address.';
+                    $err = 'Authorisation token not valid for this URL.';
                     $this->returnError(400, $err);
                 }
             }

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -157,11 +157,12 @@ class AuthenticationController
 
     private function processOneTimeUseTokens(): bool
     {
+        global $max_token_age;
+
         $need_auth = true;
         $tokenId = $this->app->request()->get('token');
         if ($tokenId)
         {
-            global $max_token_age;
             if (!$max_token_age) $max_token_age = 10;
             $token = $this->dataLayer->getOneTimeUseToken($tokenId);
             if (sizeof($token))

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -161,9 +161,9 @@ class AuthenticationController
         $tokenId = $this->app->request()->get('token');
         if ($tokenId)
         {
-            $max_token_age = -10;
+            $max_token_age = 10;
             $token = $this->dataLayer->getOneTimeUseToken($tokenId);
-            if (sizeof($token))
+            if (false && sizeof($token))
             {
                 $token = $token[0];
                 if ($token['AGE'] > $max_token_age)
@@ -197,7 +197,7 @@ class AuthenticationController
             {
                 $err = 'No authorisation token found. ';
                 $err .= 'If this error persists, please try clearing your cookies or using a different browser.';
-                $this->returnError(400, $err);
+                $this->returnError(400, $err, true);
             }
             # Remove tokens more than $max_token_age seconds old, they should have been used
             $this->dataLayer->deleteOldOneTimeUseTokens($max_token_age);

--- a/api/src/Model/Services/AuthenticationData.php
+++ b/api/src/Model/Services/AuthenticationData.php
@@ -28,7 +28,8 @@ class AuthenticationData
 
     function getOneTimeUseToken($tokenId)
     {
-        return $this->db->pq("SELECT o.validity, pe.personid, pe.login, CONCAT(p.proposalcode, p.proposalnumber) as prop 
+        return $this->db->pq("SELECT o.validity, pe.personid, pe.login, CONCAT(p.proposalcode, p.proposalnumber) as prop,
+                    NOW() - o.recordTimeStamp as age
 		    		FROM SW_onceToken o
 		    		INNER JOIN proposal p ON p.proposalid = o.proposalid
 		    		INNER JOIN person pe ON pe.personid = o.personid
@@ -40,10 +41,10 @@ class AuthenticationData
         $this->db->pq("DELETE FROM SW_onceToken WHERE token=:1", array($tokenId));
     }
 
-    function deleteOldOneTimeUseTokens()
+    function deleteOldOneTimeUseTokens($max_token_age)
     {
-        # Remove tokens more than 10 seconds old, they should have been used
-        $this->db->pq("DELETE FROM SW_onceToken WHERE recordTimeStamp < NOW() - INTERVAL 10 SECOND");
+        # Remove tokens more than $max_token_age seconds old, they should have been used
+        $this->db->pq("DELETE FROM SW_onceToken WHERE recordTimeStamp < NOW() - INTERVAL :1 SECOND", array($max_token_age));
     }
 
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1163](https://jira.diamond.ac.uk/browse/LIMS-1163)

**Summary**:

Users complain of not being allowed to print an air waybill after booking a shipment into Diamond.

**Changes**:
- Specify in the error message generated whether this is because the one time token is too old, or non-existent
- Add user agent and timestamp to the error message generated
- Allow increasing of 10 second age limit with an optional config variable

**To test**:
- Generate an AWB for a shipment, check can view it from the shipment page
- Set a $max_token_age = -1 config variable and check the error generated (delete it afterwards)
- View a visit pdf report and CSV download from /visits page, as these also use the sign function
