### PR TITLE
LIMS-1170: Don't use thumbnails of crystal snapshot images

### DIFF
--- a/api/src/Page/Image.php
+++ b/api/src/Page/Image.php
@@ -133,10 +133,9 @@ class Image extends Page
             if ($n < sizeof($images)) {
                 $this->_browser_cache();
                 $ext = pathinfo($images[$n], PATHINFO_EXTENSION);
-                $file = $this->has_arg('f') ? $images[$n] : str_replace('.'.$ext, 't.'.$ext, $images[$n]);
-                if (file_exists($file)) {
+                if (file_exists($images[$n])) {
                     $this->app->contentType('image/'.$ext);
-                    readfile($file);
+                    readfile($images[$n]);
                 } else {
                     $this->_error('Not found', 'That image is no longer available');
                 }
@@ -161,11 +160,10 @@ class Image extends Page
             if ($n < sizeof($images)) {
                 $ext = pathinfo($images[$n], PATHINFO_EXTENSION);
 
-                $file = $this->has_arg('f') ? $images[$n] : str_replace('.'.$ext, 't.'.$ext, $images[$n]);
-                if (file_exists($file)) {
+                if (file_exists($images[$n])) {
                     $this->_browser_cache();
                     $this->app->contentType('image/'.$ext);
-                    readfile($file);
+                    readfile($images[$n]);
 
                 } else {
                     $this->_error('Not found', 'That image is no longer available');


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1170](https://jira.diamond.ac.uk/browse/LIMS-1170)

**Summary**:

Use full-sized crystal snapshot image files, not thumbnails.

Note that I have only touched the crystal snapshot image handling, not [the diffraction preview image handling](https://github.com/benjaminhwilliams/SynchWeb/blob/1eb0710e31bf045bf4f8608c8c67264a21d5e234/api/src/Page/Image.php#L261), which also uses a thumbnail image, which is generated upstream by a different mechanism to the snapshot image thumbnails.

**Changes**:
- Remove ternary operation to switch between reading the full-sized image and the thumbnail.  Always use the full-sized image.

**To test**:
- Find a data collection that has multiple image snapshots (each DC can have up to four).
- Open all views that display a data collection pane.  Check that the snapshot image is displayed correctly.
- Click on the snapshot image.  Check that you can still roll through the full selection of available snapshot images.
- Repeat the above for a robot load pane.
