### PR TITLE
LIMS-1136: Trim preceding spaces from postcode and email address

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2685,10 +2685,10 @@ class Shipment extends Page
             "address_line3" => isset($address_lines[2]) ? $address_lines[2] : null,
             "city" => $user["city"],
             "country" => $user["country"],
-            "post_code" => rtrim($user["postcode"]),
+            "post_code" => trim($user["postcode"]),
             "contact_name" => $user["name"],
             "contact_phone_number" => $user["phone"],
-            "contact_email" => rtrim($user["email"])
+            "contact_email" => trim($user["email"])
         );
         $shipment_data = array(
             "shipment_reference" => $shipment["PROP"],


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1136](https://jira.diamond.ac.uk/browse/LIMS-1136)

**Summary**:

Currently, it is possible for post codes to contain spaces before and after the actual post code. Sending such post codes to the shipping service results in a 422 error.

**Changes**:
- Use `trim` rather than `rtrim`, for post code and email address.

**To test**:
- Book an incoming shipment
- Book an incoming shipment with a space at the start of the post code
- Book an incoming shipment with a space at the start of the email address
