### PR TITLE
LIMS-1161: Widen main view from 10/12 to 11/12

### DIFF
--- a/client/src/js/app/layouts/main.vue
+++ b/client/src/js/app/layouts/main.vue
@@ -20,7 +20,7 @@
       Main panel to store proposal menu, messages and content
       Sets the main width of the content area on screen
     -->
-    <div class="tw-w-full tw-px-2 lg:tw-w-10/12 lg:tw-mx-auto">
+    <div class="tw-w-full tw-px-2 lg:tw-w-11/12 lg:tw-mx-auto">
       <navbar-menu
         :proposal-menu="proposalMenu"
         :extras-menu="extraMenu"

--- a/client/src/js/app/layouts/maintenance.vue
+++ b/client/src/js/app/layouts/maintenance.vue
@@ -5,7 +5,7 @@
       class="tw-flex tw-justify-between tw-items-center tw-h-10 tw-bg-header-background"
     />
 
-    <div class="tw-w-10/12 tw-mx-auto">
+    <div class="tw-w-11/12 tw-mx-auto">
       <!-- Sets the main width of the content on screen -->
       <h1 class="tw-mt-4 tw-py-4 tw-text-xl">
         The site is currently undergoing maintenance


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1161](https://jira.diamond.ac.uk/browse/LIMS-1161)

**Summary**:

The Synchweb main view uses 10/12 (83.33%) of the width of the browser for large screen sizes (lg:tw-w-10/12). This wastes a lot of screen space, so have upped it to 11/12 (91.67%). (Full screen display looks weird)

**Changes**:
- Change main view from 10/12 width to 11/12 width
- Apply same change to 'maintenance mode' view

**To test**:
- Check main synchweb view looks ok in large browser
- Check full width is still used for small browsers / mobile.
