### PR TITLE
LIMS-980: Add all samples to queue should obey filters

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -122,6 +122,7 @@ class Sample extends Page
         'UNQUEUE' => '\d',
         'nodata' => '\d',
         'notcompleted' => '\d',
+        'filter' => '\w+',
 
         // external is a flag to indicate this protein/sample has a user office system id
         // whereas externalid is the actual reference
@@ -594,6 +595,17 @@ class Sample extends Page
 
         $args = array($this->proposalid, $this->arg('cid'), $this->arg('cid'), $this->arg('cid'));
         $where = ' AND c.containerid=:2 AND cq2.completedtimestamp IS NULL';
+
+        if ($this->has_arg('filter')) {
+            $filters = array(
+                'manual' => " AND ss.source='manual'",
+                'auto' => " AND ss.source='auto'",
+                'point' => " AND dp.experimentkind='SAD'",
+                'region' => " AND dp.experimentkind='MESH'",
+            );
+            $where .= $filters[$this->arg('filter')];
+        }
+
         $first_inner_select_where = ' AND s.containerid=:3';
         $second_inner_select_where = ' AND s.containerid=:4';
 

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -567,12 +567,18 @@ define(['marionette',
         queueAllSamples: function(e) {
             e.preventDefault()
 
+            var data = {}
+            current = this.$el.find('.afilt').find('.current')
+            if (current.length > 0) {
+                data.filter = current.attr('id')
+            }
+
             var self = this
             this.$el.addClass('loading');
             Backbone.ajax({
                 url: app.apiurl+'/sample/sub/queue/cid/'+this.model.get('CONTAINERID'),
                 method: "post",
-                data: {},
+                data: data,
                 success: function(resp) {
                     _.each(resp, function (r) {
                         var ss = self.subsamples.fullCollection.findWhere({ BLSUBSAMPLEID: r.BLSUBSAMPLEID })

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -567,7 +567,7 @@ define(['marionette',
         queueAllSamples: function(e) {
             e.preventDefault()
 
-            var data = {}
+            const data = {}
             current = this.$el.find('.afilt').find('.current')
             if (current.length > 0) {
                 data.filter = current.attr('id')


### PR DESCRIPTION
**JIRA ticket**: [LIMS-980](https://jira.diamond.ac.uk/browse/LIMS-980)

**Summary**:

LIMS-219 (https://github.com/DiamondLightSource/SynchWeb/pull/591) added a button to add all subsamples to the queue, but it ignored the current filter, which can be auto/manual/point/region.

**Changes**:
- Get the id of the currently selected filter element and add it to the backend request
- Use the filter supplied to alter the where clause of the query

**To test**:
- Go to a VMXi proposal (eg nt37104), go to Containers, pick one. On the next page mark a point and a region using the "Mark Point" and "Mark Region" buttons. Click "Prepare for Data Collection"
- Filter the available samples using the Point/Region/Auto/Manual buttons, click the Add All to Queue button. Check the right number appear in the queue in the lower half of the page.
- Turn off any filters and Add All again, check every (not complete) sample is added to the queue.
