### PR TITLE
LIMS-117: Fix grid scan coordinates for snaked scans

### DIFF
--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -442,8 +442,8 @@ define(['jquery', 'marionette',
                         ystep = k % this.grid.get('STEPS_Y')
 
                         if (this.grid.get('SNAKED') === 1) {
-                             if (xstep % 2 === 1) ystep = (this.grid.get('STEPS_Y')-1) - ystep
-                         }
+                            if (xstep % 2 === 1) ystep = (this.grid.get('STEPS_Y')-1) - ystep
+                        }
 
                         x = xstep * sw + sw/2 + (this.offset_w*this.scale)/2
                         y = ystep * sh + sh/2 + (this.offset_h*this.scale)/2
@@ -453,7 +453,7 @@ define(['jquery', 'marionette',
                         ystep = Math.floor(k / this.grid.get('STEPS_X'))
 
                         if (this.grid.get('SNAKED') === 1) {
-                             if (ystep % 2 === 1) xstep = (this.grid.get('STEPS_X')-1) - xstep
+                            if (ystep % 2 === 1) xstep = (this.grid.get('STEPS_X')-1) - xstep
                         }
 
                         x = xstep * sw + sw/2 + (this.offset_w*this.scale)/2
@@ -500,9 +500,15 @@ define(['jquery', 'marionette',
             if (this.vertical) {
                 xp = Math.floor(pos / this.grid.get('STEPS_Y'))
                 yp = pos % this.grid.get('STEPS_Y')
+                if (this.grid.get('SNAKED') === 1) {
+                    if (xp % 2 === 1) yp = (this.grid.get('STEPS_Y')-1) - yp
+                }
             } else {
                 xp = pos % this.grid.get('STEPS_X')
                 yp = Math.floor(pos / this.grid.get('STEPS_X'))
+                if (this.grid.get('SNAKED') === 1) {
+                    if (yp % 2 === 1) xp = (this.grid.get('STEPS_X')-1) - xp
+                }
             }
 
             var rad = Math.PI/180


### PR DESCRIPTION
**JIRA ticket**: [LIMS-117](https://jira.diamond.ac.uk/browse/LIMS-117)

**Summary**:

The x/y/z coordinates displayed for a grid scan previously assumed the scan was not snaked.

**Changes**:
- Fix xp or yp for snaked scans for horizontal or vertical scans
- Minor whitespace change

**To test**:
- Go to a snaked grid scan (eg /dc/visit/cm33903-1/id/10333286), click on a grid box in the first row, check the x coordinate. Click on the box below, check the x coordinate is the same
- Repeat for a hyperion scan (eg /dc/visit/cm33866-5/id/12600850)
- Repeat for a vertical scan (eg /dc/visit/cm33851-1/id/10034039)
