### PR TITLE
LIMS-1026: Don't round everything to 5 decimal places

### DIFF
--- a/api/src/Database/Type/MySQL.php
+++ b/api/src/Database/Type/MySQL.php
@@ -458,8 +458,6 @@ class MySQL extends DatabaseParent {
                         {
                             if ($val !== null)
                             {
-                                if (gettype($val) == gettype(0.1))
-                                    $val = round($val, 5);
                                 $val = strval($val);
                             }
                             if ($upperCaseKeys)


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1026](https://jira.diamond.ac.uk/browse/LIMS-1026)

**Summary**:

Floats from the database are rounded to 5 decimal places, then rounded again when displayed. See eg https://ispyb.diamond.ac.uk/dc/visit/mx33658-13/id/11629518 which has wavelength of 0.953745 rounded first to 0.95375 then again to 0.9538.

**Changes**:
- Delete the code that rounds unnecessarily

**To test**:
- Go to https://ispyb.diamond.ac.uk/dc/visit/mx33658-13/id/11629518, check wavelength is displayed correctly as 0.9537A.
- Check no other numbers are shown with extra precision
