### PR TITLE
LIMS-851: Display beam centre (and warnings) for i19

### DIFF
--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -33,8 +33,6 @@
         <a class="view button" title="Lookup Unit Cell" href="/cell/a/<%-CELL.CELL_A%>/b/<%-CELL.CELL_B%>/c/<%-CELL.CELL_C%>/al/<%-CELL.CELL_AL%>/be/<%-CELL.CELL_BE%>/ga/<%-CELL.CELL_GA%>"><i class="fa fa-search"></i> Lookup Cell</a>
     </p>
 
-    <!-- Beam Centre information and movement warning not useful for i19 small molecule experiment type -->
-    <% if (PROPOSAL_TYPE != 'sm') { %>
     <table class="reflow bc">
         <thead>
             <tr>
@@ -65,7 +63,6 @@
 
     <% if (BEAM.REFINEDYBEAM > 0 && (Math.abs(BEAM.XBEAM-BEAM.REFINEDYBEAM) > 0.5 || Math.abs(BEAM.YBEAM-BEAM.REFINEDXBEAM) > 0.5)) { %>
     <p class="message alert">WARNING: Beam centre has moved significantly during refinement! (>0.5mm)</p>
-    <% } %>
     <% } %>
 
     <table class="reflow cell">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-851](https://jira.diamond.ac.uk/browse/LIMS-851)

**Summary**:

Beam centre(starting and refined) display (and warnings if different) were disabled for "sm" beamlines (I19 at DLS) in https://github.com/DiamondLightSource/SynchWeb/pull/81. We want to put them back in.

**Changes**:
- Remove "if  type != sm" clause

**To test**:
- Go to a data collection with beam centre (eg /dc/visit/cy29890-8/id/12536146), check it displays in the auto processing stats
- Go to an old data collection with start beam centre of 0,0 ( eg /dc/visit/cm26454-1/id/4563855), check a warning appears saying the beam centre has moved significantly
