### PR TITLE
LIMS-697: Use more specific PVs for puck names

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -374,10 +374,9 @@
                                            ),
     );
 
-    # Map of beamlinename to pv prefix
-    $bl_pv_map = array(
-        'i02' => 'BL02I',
-        'i03' => 'BL03I',
+    # Map of beamlinename to puck name pv
+    $bl_puck_names = array(
+        'i03' => "BL03I-MO-ROBOT-01:PUCK_%'02d_NAME"
     );
 
     # Dials server values

--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -376,7 +376,7 @@
 
     # Map of beamlinename to puck name pv
     $bl_puck_names = array(
-        'i03' => "BL03I-MO-ROBOT-01:PUCK_%'02d_NAME"
+        'i03' => "BL03I-MO-ROBOT-01:PUCK_%02d_NAME"
     );
 
     # Dials server values

--- a/api/src/Controllers/AssignController.php
+++ b/api/src/Controllers/AssignController.php
@@ -103,22 +103,21 @@ class AssignController extends Page
     # BL03I-MO-ROBOT-01:PUCK_01_NAME
     function getPuckNames()
     {
-        global $bl_pv_map;
+        global $bl_puck_names;
         session_write_close();
         if (!$this->has_arg('prop'))
             $this->_error('No proposal specified');
 
         if (!$this->has_arg('bl'))
             $this->_error('No beamline specified');
-        if (!array_key_exists($this->arg('bl'), $bl_pv_map))
+        if (!array_key_exists($this->arg('bl'), $bl_puck_names))
             $this->_error('No such beamline');
-        $pv_prefix = $bl_pv_map[$this->arg('bl')];
+        $pv_names = $bl_puck_names[$this->arg('bl')];
 
         $pvs = array();
         for ($i = 1; $i < 38; $i++)
         {
-            $id = $i < 10 ? '0' . $i : $i;
-            array_push($pvs, $pv_prefix . '-MO-ROBOT-01:PUCK_' . $id . '_NAME');
+            array_push($pvs, sprintf($pv_names, $i));
         }
 
         $rows = $this->assignData->getContainerBarcodesForProposal($this->proposalid);
@@ -132,7 +131,8 @@ class AssignController extends Page
         $vals = $this->pv(array_values($pvs), true, true);
         foreach ($vals as $k => $v)
         {
-            if (preg_match('/PUCK_(\d+)_NAME/', $k, $mat))
+            $zero_id = array_search($k, $pvs);
+            if ($zero_id !== false)
             {
                 if (is_array($v) && sizeof($v))
                 {
@@ -140,7 +140,7 @@ class AssignController extends Page
                 }
                 else
                     $val = '';
-                array_push($return, array('id' => intval($mat[1]), 'name' => $val));
+                array_push($return, array('id' => $zero_id+1, 'name' => $val));
             }
         }
 

--- a/api/tests/Controllers/AssignControllerTest.php
+++ b/api/tests/Controllers/AssignControllerTest.php
@@ -48,10 +48,9 @@ final class AssignControllerTest extends TestCase
         global $ip2bl;
         $ip2bl = array(103 => 'i03');
 
-        global $bl_pv_map;
-        $bl_pv_map = array(
-            'i02' => 'BL02I',
-            'i03' => 'BL03I',
+        global $bl_puck_names;
+        $bl_puck_names = array(
+            'i03' => "BL03I-MO-ROBOT-01:PUCK_%'02d_NAME",
         );
         global $bl_pv_env;
         $bl_pv_env = 'EPICS_CA_ADDR_LIST_TEST=666.45.678.9';

--- a/api/tests/Controllers/AssignControllerTest.php
+++ b/api/tests/Controllers/AssignControllerTest.php
@@ -240,7 +240,7 @@ final class AssignControllerTest extends TestCase
         $this->assignController->args['prop'] = 3;
         $this->assignController->args['bl'] = 'i03';
         $this->assignController->proposalid = 3;
-        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('PUCK_1_NAME' => 'puck1', 'PUCK_12_NAME' => 'puck12'));
+        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('BL03I-MO-ROBOT-01:PUCK_01_NAME' => 'puck1', 'BL03I-MO-ROBOT-01:PUCK_12_NAME' => 'puck12'));
         $this->dataLayerStub->expects($this->exactly(1))->method('getContainerBarcodesForProposal')->with(3)->willReturn(array(['BARCODE' => 1230, 'BL' => 'test03']));
 
         $this->assignController->getPuckNames();
@@ -253,7 +253,7 @@ final class AssignControllerTest extends TestCase
         $this->assignController->args['prop'] = 3;
         $this->assignController->args['bl'] = 'i03';
         $this->assignController->proposalid = 3;
-        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('PUCK_1_NAME' => array(11), 'PUCK_12_NAME' => array(12)));
+        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('BL03I-MO-ROBOT-01:PUCK_01_NAME' => array(11), 'BL03I-MO-ROBOT-01:PUCK_12_NAME' => array(12)));
         $this->dataLayerStub->expects($this->exactly(1))->method('getContainerBarcodesForProposal')->with(3)->willReturn(array(['BARCODE' => 1230, 'BL' => 'test03']));
 
         $this->assignController->getPuckNames();
@@ -266,7 +266,7 @@ final class AssignControllerTest extends TestCase
         $this->assignController->args['prop'] = 3;
         $this->assignController->args['bl'] = 'i03';
         $this->assignController->proposalid = 3;
-        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('PUCK_1_NAME' => array(11), 'PUCK_12_NAME' => array(1230)));
+        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('BL03I-MO-ROBOT-01:PUCK_01_NAME' => array(11), 'BL03I-MO-ROBOT-01:PUCK_12_NAME' => array(1230)));
         $this->dataLayerStub->expects($this->exactly(1))->method('getContainerBarcodesForProposal')->with(3)->willReturn(array(['BARCODE' => 1230, 'BL' => 'test03']));
 
         $this->assignController->getPuckNames();
@@ -280,7 +280,7 @@ final class AssignControllerTest extends TestCase
         $this->assignController->args['bl'] = 'i03';
         $this->assignController->proposalid = 3;
         $this->assignController->staff = true;
-        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('PUCK_1_NAME' => array(11), 'PUCK_12_NAME' => array(1231)));
+        $this->assignController->shouldReceive('pv')->times(1)->andReturn(array('BL03I-MO-ROBOT-01:PUCK_01_NAME' => array(11), 'BL03I-MO-ROBOT-01:PUCK_12_NAME' => array(1231)));
         $this->dataLayerStub->expects($this->exactly(1))->method('getContainerBarcodesForProposal')->with(3)->willReturn(array(['BARCODE' => 1230, 'BL' => 'test03']));
 
         $this->assignController->getPuckNames();


### PR DESCRIPTION
**Github issue**: https://github.com/DiamondLightSource/SynchWeb/issues/53
**JIRA ticket**: [LIMS-697](https://jira.diamond.ac.uk/browse/LIMS-697)

**Summary**:

@jlmuir points out that not all facilities have a one-to-one mapping of beamlines to pv prefixes (DLS included). As the `$bl_pv_map` variable is only used in one place, we should replace it with a template for the specific PVs it is used for.

**Changes**:
- Remove `$bl_pv_map` variable
- Remove DLS-specific hardcoded PV names
- Add `$bl_puck_names` variable for a template for the puck names PV

**To test**:
- Go to the assign container page for a visit (eg /assign/visit/cm37235-1) and check the loaded pucks are displayed next to the puck number (eg CPS-0001 below)
![image](https://github.com/DiamondLightSource/SynchWeb/assets/24956497/3656d12d-1494-472e-abb9-af25816ecc40)

