### PR TITLE
LIMS-1192: Fix capillary names

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -355,7 +355,7 @@ class Sample extends Page
                 $isCapillary = sizeof($crystals) > 1 ? true : false;
 
                 foreach ($crystals as $sample) {
-                    $c = array('NAME' => $phase->ACRONYM . '-sample');
+                    $c = $isCapillary ? array('NAME' => $sample->NAME) : array('NAME' => $phase->ACRONYM . '-sample');
                     foreach (array('SPACEGROUP', 'COMMENTS') as $f)
                         $c[$f] = array_key_exists($f, $sample) ? $sample->$f : '';
                     foreach (array('ABUNDANCE', 'THEORETICALDENSITY') as $f)
@@ -412,7 +412,7 @@ class Sample extends Page
                 if (array_key_exists('CAPILLARYID', $ids[$model]) && $capillary->CRYSTALID == null && !$capillary->CONTAINERLESS)
                     $blSamples['capillary'] = array('CONTAINERID' => $ids[$model]['CONTAINERID'], 'CRYSTALID' => $ids[$model]['CAPILLARYID'], 'PROTEINID' => $ids[$model]['CAPILLARYPHASEID'], 'LOCATION' => ++$maxLocation, 'NAME' => $capillary->NAME, 'PACKINGFRACTION' => 1, 'COMMENTS' => array_key_exists('COMMENTS', $capillary) ? $capillary->COMMENTS : '', 'DIMENSION1' => $capillary->OUTERDIAMETER, 'DIMENSION2' => $capillary->INNERDIAMETER, 'DIMENSION3' => $capillary->LENGTH, 'SHAPE' => $capillary->SHAPE, 'LOOPTYPE' => 1);
 
-                $blSamples['sample'] = array('CONTAINERID' => $ids[$model]['CONTAINERID'], 'CRYSTALID' => $ids[$model]['CRYSTALID'], 'PROTEINID' => $ids[$model]['PHASEID'], 'LOCATION' => ++$maxLocation, 'NAME' => $phase->ACRONYM, 'PACKINGFRACTION' => $attrs->PACKINGFRACTION ? $attrs->PACKINGFRACTION : null, 'COMMENTS' => array_key_exists('COMMENTS', $crystal) ? $crystal->COMMENTS : '');
+                $blSamples['sample'] = array('CONTAINERID' => $ids[$model]['CONTAINERID'], 'CRYSTALID' => $ids[$model]['CRYSTALID'], 'PROTEINID' => $ids[$model]['PHASEID'], 'LOCATION' => ++$maxLocation, 'NAME' => $crystal->NAME, 'PACKINGFRACTION' => $attrs->PACKINGFRACTION ? $attrs->PACKINGFRACTION : null, 'COMMENTS' => array_key_exists('COMMENTS', $crystal) ? $crystal->COMMENTS : '');
 
                 foreach ($blSamples as $key => $blSample) {
                     $a = $this->_prepare_sample_args($blSample);

--- a/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
+++ b/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
@@ -533,7 +533,7 @@
                     })
 
                     let crystal = new Crystal({
-                        NAME: self.name,
+                        NAME: item.acronym,
                         COMMENTS: item.comments,
                         THEORETICALDENSITY: item.density,
                         ABUNDANCE: 1
@@ -611,7 +611,7 @@
                 })
 
                 let crystal = new Crystal({
-                    NAME: this.name,
+                    NAME: this.acronym,
                     COMMENTS: this.comments,
                     THEORETICALDENSITY: this.density,
                     ABUNDANCE: 1


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1192](https://jira.diamond.ac.uk/browse/LIMS-1192)

**Summary**:

A recent change (https://github.com/DiamondLightSource/SynchWeb/pull/686) improved the names of samples, but also affected the names of automatically created capillaries. This then broke things further down the chain.

**Changes**:
- Put the crystal name back to how it was for capillaries
- Use the passed in crystal name for the sample name
- Change the crystal name passed in for non-capillary crystals

**To test**:
- Go to cm37261, then go to Phases, pick one. Click "+ New Simple Sample", fill in the form with a memorable acronym, and use one of the Borosilicate capillaries and submit. Then go to Samples, 2 should have been created. One named acronym-sample, and one ending in _CP for the capillary.
- Repeat above but with a new acronym and using the _CP sample as your capillary. Only one new sample should be created, but if you drill down to the instance, it will be in a sample group with the _CP sample.