### PR TITLE
LIMS-1185: Fix incorrect total dose displayed

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -975,7 +975,7 @@ class DC extends Page
 
             // Data collections
             if ($dc['TYPE'] == 'data') {
-                $nf = array(1 => array('AXISSTART'), 2 => array('RESOLUTION', 'TRANSMISSION', 'AXISRANGE', 'TOTALDOSE'), 4 => array('WAVELENGTH', 'EXPOSURETIME'));
+                $nf = array(1 => array('AXISSTART', 'CHISTART', 'PHI', 'OVERLAP'), 2 => array('RESOLUTION', 'TRANSMISSION', 'AXISRANGE', 'TOTALDOSE'), 4 => array('WAVELENGTH', 'EXPOSURETIME'));
 
                 $dc['DIRFULL'] = $dc['DIR'];
                 $dc['DIR'] = preg_replace('/.*\/' . $this->arg('prop') . '-' . $dc['VN'] . '\//', '', $dc['DIR']);

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -975,7 +975,7 @@ class DC extends Page
 
             // Data collections
             if ($dc['TYPE'] == 'data') {
-                $nf = array(1 => array('AXISSTART'), 2 => array('RESOLUTION', 'TRANSMISSION', 'AXISRANGE'), 4 => array('WAVELENGTH', 'EXPOSURETIME'));
+                $nf = array(1 => array('AXISSTART'), 2 => array('RESOLUTION', 'TRANSMISSION', 'AXISRANGE', 'TOTALDOSE'), 4 => array('WAVELENGTH', 'EXPOSURETIME'));
 
                 $dc['DIRFULL'] = $dc['DIR'];
                 $dc['DIR'] = preg_replace('/.*\/' . $this->arg('prop') . '-' . $dc['VN'] . '\//', '', $dc['DIR']);

--- a/client/src/js/templates/dc/dc.html
+++ b/client/src/js/templates/dc/dc.html
@@ -29,7 +29,7 @@
         <% if (DCT == 'SAD' || DCT == 'OSC' || DCT == 'Diamond Anvil High Pressure') { %>
             <%if (TOTALABSDOSE) { %>
                 <%if (DCC > 1) { %>
-                <li data-testid="dc-dose">Total Dose:  <%-TOTALABSDOSE * DCC%>MGy</li>
+                <li data-testid="dc-dose">Total Dose:  <%-TOTALDOSE%>MGy</li>
                 <% } else { %>
                 <li data-testid="dc-dose">Dose:  <%-TOTALABSDOSE%>MGy</li>
         <% } } }%>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1185](https://jira.diamond.ac.uk/browse/LIMS-1185) and [LIMS-1212](https://jira.diamond.ac.uk/browse/LIMS-1212)

**Summary**:

The total dose displayed on data collection groups is incorrect, and also shown to a huge number of decimal places.

**Changes**:
- Limit the totaldose field to 2 decimal places, as done for other fields
- Use the totaldose returned from the backend, which does a sum of the total absorbed dose, rather than getting one value and multiplying by the number of data collections.
- Also limit chi/phi/overlap to 1 decimal place

**To test**:
- View a data collection group, eg /dc/visit/cm33903-5/dcg/10774174, check the dose displayed for each data collection is shown to 2 decimal places. Add together the total dose for the group (11.40MGy)
- Find the same group on the parent view (eg dc/visit/cm33903-5/ty/ page 10), check the total dose displayed is correct (11.40MGy) with 2 decimal places
