### PR TITLE
LIMS-904: Improve help text for internal transfer requests

### DIFF
--- a/api/assets/emails/html/dewar-transfer.html
+++ b/api/assets/emails/html/dewar-transfer.html
@@ -3,7 +3,7 @@
 
 		<div class="inset" style="margin: 1%; padding: 1%; margin-bottom: 2%; border-radius: 5px; background: #82d180">
 			<h2>Local Contact: <?php echo $data['LOCALCONTACT'] ?> <?php echo $data['LCEMAIL'] ?></h2>
-			<p><?php echo $data['GIVENNAME'] ?> <?php echo $data['FAMILYNAME'] ?> from visit <?php echo $data['VISIT'] ?> requested an internal transfer for his/her dewar(s). Please print this e-mail and affix it on the shipping case.</p>
+			<p><?php echo $data['GIVENNAME'] ?> <?php echo $data['FAMILYNAME'] ?> from visit <?php echo $data['VISIT'] ?> requested an internal transfer for his/her dewar(s).</p>
 		</div>
 		
 		<table class="details" style="background: #f4f4f4; margin: 1%">
@@ -52,11 +52,6 @@
 				<tr>
 					<td style="padding: 1.5%; font-weight: bold">Lab / Company Name</td>
 					<td><?php echo $data['LABNAME'] ?></td>
-				</tr>
-
-				<tr>
-					<td style="padding: 1.5%; font-weight: bold">Comments</td>
-					<td><?php echo nl2br($data['COMMENTS']) ?></td>
 				</tr>
 			</tbody>
 		</table>

--- a/api/assets/emails/html/storage-rack.html
+++ b/api/assets/emails/html/storage-rack.html
@@ -13,7 +13,7 @@
 				</ul>
 			<?php } ?>
 			<p>Please either fill out the dewar dispatch form if you would like your dewar to be returned to you:<br /><a href="https://ispyb.diamond.ac.uk/dewars/dispatch/<?php echo $data['DEWARID'] ?>">https://ispyb.diamond.ac.uk/dewars/dispatch/<?php echo $data['DEWARID'] ?></a></p>
-			<p>Or fill out the dewar transfer form if you would like it to be transferred to another beamline for another visit:<br /><a href="https://ispyb.diamond.ac.uk/dewars/transfer/<?php echo $data['DEWARID'] ?>">https://ispyb.diamond.ac.uk/dewars/transfer/<?php echo $data['DEWARID'] ?></a></p>
+			<p>Or fill out the dewar transfer form if you require more data collection time:<br /><a href="https://ispyb.diamond.ac.uk/dewars/transfer/<?php echo $data['DEWARID'] ?>">https://ispyb.diamond.ac.uk/dewars/transfer/<?php echo $data['DEWARID'] ?></a></p>
 			<p>Your dewar will be topped up with liquid nitrogen in the meantime.</p>
 		</div>
 

--- a/client/src/js/templates/shipment/transfer.html
+++ b/client/src/js/templates/shipment/transfer.html
@@ -81,7 +81,7 @@
             <li class="head">Next Visit Details</li>
             <li>
                 <label>Next Visit
-                    <span class="small">The next visit the dewar is going to be used for</span>
+                    <span class="small">Select "-" to return the dewar to the responsive scheduling queue</span>
                 </label>
                 <select name="NEXTVISIT"></select>
             </li>
@@ -98,14 +98,6 @@
                     <span class="small">Next beamline</span>
                 </label>
                 <input type="text" name="NEXTLOCATION" />
-            </li>
-
-
-            <li>
-                <label>Comments
-                    <span class="small">Comment for the shipment</span>
-                </label>
-                <textarea name="COMMENTS"></textarea>
             </li>
 
             <button name="submit" value="1" type="submit" class="button submit">Request Dewar Transfer</button>

--- a/client/src/js/templates/shipment/transfer.html
+++ b/client/src/js/templates/shipment/transfer.html
@@ -81,7 +81,7 @@
             <li class="head">Next Visit Details</li>
             <li>
                 <label>Next Visit
-                    <span class="small">Select "-" to return the dewar to the responsive scheduling queue</span>
+                    <span class="small">Leave blank to return the dewar to the responsive scheduling queue</span>
                 </label>
                 <select name="NEXTVISIT"></select>
             </li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-904](https://jira.diamond.ac.uk/browse/LIMS-904)

**Summary**:

Give users a bit more guidance if they require more data collection time.

**Changes**:
- Edited the post-visit email to say "Or fill out the dewar transfer form if you require more data collection time:" instead of "Or fill out the dewar transfer form if you would like it to be transferred to another beamline for another visit"
- Removed instruction to print this email
- Edited the transfer request form help text under 'Next Visit' to say 'Select "-" to return the dewar to the responsive scheduling queue'
- Removed the comments field from the transfer request form, as they are not recorded anywhere

**To test**:
- Fill out a dewar transfer request, check there is no comments field, check it correctly sends an email
