### PR TITLE
LIMS-303: Show visits from other villages on user calendar

### DIFF
--- a/client/src/js/modules/calendar/views/calendar-view.vue
+++ b/client/src/js/modules/calendar/views/calendar-view.vue
@@ -244,7 +244,7 @@ export default {
           all: 1,
         }
 
-        queryParams.ty = this.proposalType
+        if (app.staff) queryParams.ty = this.proposalType
         if (this.selectedBeamline !== 'all') queryParams.bl = this.selectedBeamline
 
         const visitsCollection = new Visits(null, {
@@ -477,10 +477,14 @@ export default {
   },
   watch: {
     currentYear: {
-      handler: 'fetchVisitsCalendar'
+      handler: function(newVal, oldVal) {
+          if (oldVal != null) this.fetchVisitsCalendar()
+      }
     },
     currentMonth: {
-      handler: 'fetchVisitsCalendar'
+      handler: function(newVal, oldVal) {
+          if (oldVal != null) this.fetchVisitsCalendar()
+      }
     }
   }
 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-303](https://jira.diamond.ac.uk/browse/LIMS-303)

**Summary**:

The Calendar view currently only shows visits from the same beamline 'type' as the active proposal. Users would like to be able to see their visits from all villages. Don't apply to staff as the visit list becomes unwieldy.

Also, the visit list is requested 3 times when the page is first loaded.

**Changes**:
- Only specify the beamline type if a staff member is logged in
- Dont fetch the new visit list when the current year/month is first set, there is an explicit fetch in the `mounted()` function

**To test**:
- Log in as a staff member, check the calendar page displays as before, but there is only one request to `/api/proposal/visits`
- Log in as a user who has visits in different villages (eg ygr68196), check the calendar page now shows all visits from different beamline types (eg i04, m02)
