### PR TITLE
Handle -ve rotations, null overlap in sm/DC

### DIFF
--- a/client/src/js/templates/types/sm/dc/dc.html
+++ b/client/src/js/templates/types/sm/dc/dc.html
@@ -43,8 +43,8 @@
     </ul>
     
     <div class="holder">
-    <% if (AXISRANGE > 0) { %>
-        <% if (OVERLAP != 0) { %>
+    <% if (AXISRANGE) { %>
+        <% if (OVERLAP) { %>
         <h1 title="Click to show EDNA/mosflm/xia2 strategies" class="strat">Strategies<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="strategies"></div>
         <% } else { %>

--- a/client/src/js/templates/types/sm/dc/dc.html
+++ b/client/src/js/templates/types/sm/dc/dc.html
@@ -44,7 +44,7 @@
     
     <div class="holder">
     <% if (parseFloat(AXISRANGE)) { %>
-        <% if (OVERLAP) { %>
+        <% if (parseFloat(OVERLAP)) { %>
         <h1 title="Click to show EDNA/mosflm/xia2 strategies" class="strat">Strategies<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="strategies"></div>
         <% } else { %>

--- a/client/src/js/templates/types/sm/dc/dc.html
+++ b/client/src/js/templates/types/sm/dc/dc.html
@@ -43,7 +43,7 @@
     </ul>
     
     <div class="holder">
-    <% if (AXISRANGE) { %>
+    <% if (parseFloat(AXISRANGE)) { %>
         <% if (OVERLAP) { %>
         <h1 title="Click to show EDNA/mosflm/xia2 strategies" class="strat">Strategies<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="strategies"></div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1232](https://jira.diamond.ac.uk/browse/LIMS-1232)

**Summary**:

I19 is now doing small molecule serial, where every other collection is run with backwards oscillation. Unfortunately, recording this accurately in ISPyB doesn't show the autoprocessing sections in Synchweb.

This changes the check to be truthy (nonzero) instead of purely positive.

Also fixes an adjacent issue where a null value for overlap was passing the intended non-zero check (null != 0). This is made truthy also.

**Changes**:
- Altered data checks to check truthiness instead of comparisons to zero

**To test**:
- Viewing https://ispyb.diamond.ac.uk/dc/visit/cy35300-1/dcg/11242587 should show "Auto Processing" for both collections, instead of the current situation:
![image](https://github.com/DiamondLightSource/SynchWeb/assets/529963/e30ff28f-061a-4384-9400-2a5c6bddd6a7)

