### PR TITLE
LIMS-667: Make the Requested Imager a required field if a plate is being created

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -125,16 +125,27 @@
                 />
               </validation-provider>
 
-              <base-input-select
-                v-model="REQUESTEDIMAGERID"
-                outer-class="tw-mb-2 tw-py-2"
-                label="Requested Imager"
-                description="Imager this container should go into"
-                name="REQUESTERIMAGER"
-                :options="imagingImagers"
-                option-value-key="IMAGERID"
-                option-text-key="NAME"
-              />
+              <validation-provider
+                v-if="plateType === 'plate'"
+                v-slot="{ errors }"
+                tag="div"
+                class="tw-mb-2 tw-py-2"
+                rules="required"
+                name="Requested Imager"
+              >
+
+                <base-input-select
+                  v-model="REQUESTEDIMAGERID"
+                  outer-class="tw-mb-2 tw-py-2"
+                  label="Requested Imager"
+                  description="Imager this container should go into"
+                  name="REQUESTERIMAGER"
+                  :options="imagingImagers"
+                  option-value-key="IMAGERID"
+                  option-text-key="NAME"
+                  :error-message="errors[0]"
+                />
+              </validation-provider>
 
               <base-input-select
                 v-model="SCHEDULEID"


### PR DESCRIPTION
**JIRA ticket**: [LIMS-667](https://jira.diamond.ac.uk/browse/LIMS-667)

**Summary**:
If the user creates a plate without a requested imager, then the plate does not get assigned an imaging schedule when it is read by our Formulatrix system and is not imaged.

**Changes**:
- Set a validation provider for the requested imager field, but only if the container type is plate (requested imager field is only shown if container type is plate)

**To test**:
- Go to Add Container page, create a puck with at least one sample, check it is allowed without a Requested Imager
- Try to create a plate (eg container type CrystalQuickX) with at least one sample, without selecting an imager, check it is not allowed and the user is directed to the error
- Choose an imager and check the plate is created successfully
