### PR TITLE
LIMS-1200: CSV file upload ignores first sample

### DIFF
--- a/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
+++ b/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
@@ -725,7 +725,7 @@
                             if(self.commaInComments)
                                 self.csvErrors.push("Column count is greater than expected, you likely have a comma in a comment. Please remove any additional commas")
 
-                            if(self.csvData.length === 1 && self.csvErrors.length === 0){
+                            if(self.csvData.length < 1 && self.csvErrors.length === 0){
                                 self.csvErrors.push("Only headers have been submitted, please add some sample information")
                             }
 

--- a/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
+++ b/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
@@ -492,8 +492,6 @@
                 let self = this
 
                 this.csvData.forEach(function(item, index){
-                    if(index === 0)
-                        return;
 
                     console.log(item)
                     var shortName = ''


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1200](https://jira.diamond.ac.uk/browse/LIMS-1200)

**Summary**:

One way to create multiple simple samples (for XPDF) is to upload a CSV file. A header row is compulsory and provided in the template, and is stripped by the CSV file library. However, the Synchweb code also strips the first subsequent row, meaning the first user sample is ignored.

**Changes**:
- No longer ignore the first row of the CSV file

**To test**:
- On the dev db:
   - Go to proposal cm37261
   - Select Phases from the main menu
   - Click on a phase eg H2O.1
   - Click "Add new simple sample"
   - Choose "File upload for multiple samples"
   - Select this file [simple_sample_csv_template.csv](https://github.com/DiamondLightSource/SynchWeb/files/14538814/simple_sample_csv_template.csv)
   - Choose a plain capillary eg "Borosilicate 1mm OD"
   - Click "Add Sample".
   - Go to Samples from the main menu, see if all 4 were added

