### PR TITLE
LIMS-1201: Amend name of XPDF capillary crystal to use user acronym

### DIFF
--- a/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
+++ b/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
@@ -513,7 +513,7 @@
 
                     let capillaryCrystal = new Crystal({
                         CRYSTALID: self.existingCapillaryID,
-                        NAME: self.name + shortName + '_CP',
+                        NAME: item.acronym + shortName + '_CP',
                         THEORETICALDENSITY: self.getCapillaryInfo('density') != null ? self.getCapillaryInfo('density') : null,
                         ABUNDANCE: 1,
                         CONTAINERLESS: self.containerless,
@@ -591,7 +591,7 @@
 
                 let capillaryCrystal = new Crystal({
                     CRYSTALID: this.existingCapillaryID,
-                    NAME: this.name + shortName + '_CP',
+                    NAME: this.acronym + shortName + '_CP',
                     THEORETICALDENSITY: this.getCapillaryInfo('density') != null ? this.getCapillaryInfo('density') : null,
                     ABUNDANCE: 1,
                     CONTAINERLESS: this.containerless,


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1201](https://jira.diamond.ac.uk/browse/LIMS-1201)

**Summary**:

When an i15-1 user creates a new sample using a standard capillary, a Crystal is made to represent the capillary, currently using the UAS acronym, the standard capillary name and the string "_CP".
They would like this changed to use the user-entered acronym rather than the UAS acronym.

**Changes**:
- Replace name (from UAS) with acronym (from user) for both simple sample form and CSV upload

**To test**:
- On the dev db:
   - Go to proposal cm37261, select Phases from the main menu
   - Click on a phase eg H2O.1, then click "New simple sample"
   - Choose "File upload for multiple samples"
   - Select this file [simple_sample_csv_template.csv](https://github.com/DiamondLightSource/SynchWeb/files/14538814/simple_sample_csv_template.csv)
   - Choose a plain capillary eg "Borosilicate 1mm OD", then click "Add Sample".
   - Go to Samples from the main menu, there should be one created called mark2f_Boro_2.0mm_CP, not H2O.1_Boro_2.0mm_CP
   - Go back to Phases, choose a phase, click "New simple sample" again
   - Put in a memorable acronym eg foobar, composition of ABC, density 1 and packing fraction 1
   - Choose a plain capillary eg "Borosilicate 1mm OD", then click "Add Sample".
   - Go to Samples from the main menu, there should be one called foobar_Boro_1mm_CP, not H2O.1_Boro_1mm_CP
