### PR TITLE
LIMS-1255: Fix problematic query on visit stats page

### DIFF
--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -152,9 +152,7 @@ class Vstat extends Page
                     FROM datacollection dc 
                     INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                     INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-                    INNER JOIN proposal p ON p.proposalid = s.proposalid
                     INNER JOIN screening sc ON sc.datacollectionid = dc.datacollectionid 
-                    INNER JOIN v_run vr ON s.startdate BETWEEN vr.startdate AND vr.enddate
                     WHERE 1=1 $where
                     GROUP BY dc.datacollectionid, dc.endtime ORDER BY dc.endtime DESC", $args);
 
@@ -163,8 +161,6 @@ class Vstat extends Page
                     INNER JOIN datacollection dc ON r.blsampleid = dc.blsampleid AND r.endtimestamp < dc.starttime 
                     INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                     INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-                    INNER JOIN proposal p ON p.proposalid = s.proposalid
-                    INNER JOIN v_run vr ON s.startdate BETWEEN vr.startdate AND vr.enddate
                     WHERE 1=1 $where 
                     GROUP BY r.endtimestamp ORDER BY r.endtimestamp) inq WHERE dctime < 1000", $args);
 
@@ -178,8 +174,6 @@ class Vstat extends Page
                     INNER JOIN datacollection dc ON dc.datacollectionid = m.datacollectionid
                     INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                     INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-                    INNER JOIN proposal p ON p.proposalid = s.proposalid
-                    INNER JOIN v_run vr ON s.startdate BETWEEN vr.startdate AND vr.enddate
                     WHERE 1=1 $where ORDER BY m.createdtimestamp", $args);
 
             $newargs = array($info['SID'], $info['SID']);

--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -166,16 +166,6 @@ class Vstat extends Page
 
             $sched = array();
 
-            $ctf = $this->db->pq("SELECT TO_CHAR(m.createdtimestamp, 'DD-MM-YYYY HH24:MI:SS') as st, c.astigmatism, c.estimatedresolution, c.estimateddefocus
-                    FROM ctf c
-                    INNER JOIN autoprocprogram app ON app.autoprocprogramid = c.autoprocprogramid
-                    INNER JOIN motioncorrection mc ON mc.motioncorrectionid = c.motioncorrectionid
-                    INNER JOIN movie m ON m.movieid = mc.movieid
-                    INNER JOIN datacollection dc ON dc.datacollectionid = m.datacollectionid
-                    INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
-                    INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-                    WHERE 1=1 $where ORDER BY m.createdtimestamp", $args);
-
             $newargs = array($info['SID'], $info['SID']);
             $missed = $this->db->pq("SELECT COUNT(smp.name) as samplecount,
                 GROUP_CONCAT(smp.name SEPARATOR ', ') as missed
@@ -190,7 +180,6 @@ class Vstat extends Page
         } else {
             $ai = array();
             $cent = array();
-            $ctf = array();
             $missed = array();
 
             $sched = $this->db->pq("SELECT CONCAT(p.proposalcode, p.proposalnumber, '-', s.visit_number) as visit, TO_CHAR(s.enddate, 'DD-MM-YYYY HH24:MI:SS') as en, TO_CHAR(s.startdate, 'DD-MM-YYYY HH24:MI:SS') as st, p.title, s.scheduled, p.proposalcode
@@ -239,21 +228,6 @@ class Vstat extends Page
         $lines = array();
         foreach ($linecols as $c)
             array_push($lines, array('data' => array()));
-
-        $scattercols = array('ASTIGMATISM', 'ESTIMATEDDEFOCUS', 'ESTIMATEDRESOLUTION');
-        $scatters = array();
-        foreach ($scattercols as $c)
-            array_push($scatters, array('data' => array()));
-
-        foreach ($ctf as $c) {
-            foreach ($scattercols as $i => $f) {
-                $scatters[$i]['label'] = $f;
-                if ($i > 0)
-                    $scatters[$i]['yaxis'] = $i + 1;
-                if (floatval($c[$f]) < 1e38)
-                    array_push($scatters[$i]['data'], array($this->jst($c['ST']), floatval(round($c[$f], 4))));
-            }
-        }
 
         $queued = 0;
         $vis_map = array();
@@ -416,7 +390,7 @@ class Vstat extends Page
         $info['start'] = $this->jst($first);
         $info['end'] = $this->jst($last);
 
-        $this->_output(array('info' => $info, 'data' => $data, 'lines' => $lines, 'scatters' => $scatters));
+        $this->_output(array('info' => $info, 'data' => $data, 'lines' => $lines));
     }
 
 

--- a/client/src/js/modules/stats/views/breakdown.js
+++ b/client/src/js/modules/stats/views/breakdown.js
@@ -215,17 +215,7 @@ define(['marionette', 'templates/stats/breakdown.html',
                     yaxes: [{ position: 'right' }, { position: 'right' }, { position: 'right' }],
                 }
 
-                if (this.scatters) {
-
-                    this.options3.series = { 
-                        lines: { show: false },
-                        points: { show: true, radius: 1 }
-                    }
-
-                    this.extra = $.plot(this.$el.find('#dc_hist'), this.model.get('scatters'), this.options3)
-                } else {
-                    this.extra = $.plot(this.$el.find('#dc_hist'), this.model.get('lines'), this.options3)
-                }
+                this.extra = $.plot(this.$el.find('#dc_hist'), this.model.get('lines'), this.options3)
                 this.showSpan()
 
                 console.log('rend bd', this.params, this.first)


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1255](https://jira.diamond.ac.uk/browse/LIMS-1255)

**Summary**:

It was noticed the visit stats page doesn't load for some visits eg https://ispyb.diamond.ac.uk/stats/visit/mx30106-12. This is caused by the CTF query doing unnecessary joins to Proposal and v_run, which are only referenced in $where if a visit is not supplied.
On further inspection, the whole CTF query is not necessary, this is only for EM which is now using PaTo. So I have removed the query and the JS that references the output.

**Changes**:
- Remove unnecessary joins to Proposal and v_run from some queries
- Remove entire CTF query and data manipulation
- Remove references to the 'scatters' data

**To test**:
- Load visit stats page for an mx visit, check everything appears correctly
