### PR TITLE
LIMS-1174: Handle blank proposal on visits page

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -331,6 +331,8 @@ class Proposal extends Page
             // Ignore session zero for this summary view - they should be included if a proposal is selected
             $where .= " AND s.visit_number > 0";
         } else {
+            if (!$this->has_arg('prop'))
+                $this->_error('No proposal specified');
             $props = $this->db->pq('SELECT proposalid as id FROM proposal WHERE CONCAT(proposalcode, proposalnumber) LIKE :1', array($this->arg('prop')));
             if (!sizeof($props))
                 $this->_error('No such proposal');

--- a/client/src/js/modules/visits/views/visit_list.vue
+++ b/client/src/js/modules/visits/views/visit_list.vue
@@ -166,6 +166,10 @@ export default {
         }
     },
     created() {
+        if(this.proposal === '') {
+            console.log('No proposal found, redirecting');
+            window.location.href = '/proposals/';
+        }
         this.fetchData()
     },
     methods: {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1174](https://jira.diamond.ac.uk/browse/LIMS-1174)
**Github issue**: https://github.com/DiamondLightSource/SynchWeb/issues/133

**Summary**:

If you end up on the visits page without a current proposal, you get a server error. This should be handled more gracefully.

**Changes**:
- Handle the error in PHP
- Redirect to the proposals page in JS

**To test**:
- Log in to Synchweb, but dont choose a proposal. Go to /visits/. It should redirect you to the proposals page.
