### PR TITLE
LIMS-1214: Update composer.json to use Symfony 5.4 components

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -22,8 +22,8 @@
     "ralouphie/getallheaders": "2.0.5",
     "slim/slim": "2.6.2",
     "stomp-php/stomp-php": "3.0.6",
-    "symfony/http-foundation": "^2.8",
-    "symfony/filesystem": "^2.8",
+    "symfony/http-foundation": "^5.4",
+    "symfony/filesystem": "^5.4",
     "mpdf/qrcode": "^1.2",
     "mtcmedia/dhl-api": "dev-master#9b4b6315",
     "maennchen/zipstream-php": "2.1.0"


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1214](https://jira.diamond.ac.uk/browse/LIMS-1214)

**Summary**:

Update composer.json to use Symfony 5.4 components

Composer.json includes two Symfony components, symfony/http-foundation and symfony/filesystem. Both references updated from 2.8 to 5.4, the last Symfony 5.n release. (Now the server runs PHP 7.3.33, composer.json may reference Symfony 5.4 components which require PHP 7.2.5 or later.)

SynchWeb’s Download class uses Filesystem, BinaryFileResponse, and StreamedResponse.

**Changes**:
- Update references to symfony/http-foundation and symfony/filesystem in composer.json.

**To test**:
- Download auto processing output via the “Logs & Files” list.
- Download .zip archive via “Archive” button.