### PR TITLE
LIMS-67: Fix 2 slow queries on imaging admin dashboard

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1811,7 +1811,7 @@ class Shipment extends Page
         array_push($args, $start);
         array_push($args, $end);
 
-        $order = 'c.bltimestamp DESC';
+        $order = 'c.containerid DESC';
 
         if ($this->has_arg('ty')) {
             if ($this->arg('ty') == 'todispose') {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-67](https://jira.diamond.ac.uk/browse/LIMS-67)

**Summary**:

The imaging admin dashboard (/admin/imaging, needs privileges) is very slow to load the containers and inspections tables. This PR is to fix these slow queries, trying not to break anything else.

**Changes**:
- Change default sorting on container table from bltimestamp to containerid. Some sorts are still slow, but at least the default is fast now.
- Remove the join to the massive BLSampleImage table from the Inspections query, instead do that as separate smaller queries afterwards and push them into the result.
- This breaks sorting by the Scored column, but I have added the ability to sort by several other columns as compensation.

**To test**:
- Go to /admin/imaging, check the page loads rapidly.
- Click on one of the plates in the inspection table, check it loads up the Inspections history.
- Click on a well in the plate and add a score (eg 0 - Clear). Go back to the dashboard and check the Scored column has the value 'Yes'.
- Check sorting works on all columns in the Inspections table except Adhoc, Manual and Scored.
- Choose Containers from the main menu, check the containers list loads ok.