### PR TITLE
LIMS-1246: Allow users with all_dewars permission to view all shipments

### DIFF
--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -366,6 +366,9 @@ class Page
                     {
                         if (sizeof(array_intersect($vis, $this->visits)))
                             $auth = True;
+                        if ($this->user->hasPermission('all_shipments'))
+                            // allow to see anything without an id or a visit
+                            $auth = True;
                     }
 
                     // No id or visit, anyone ok to view

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -366,7 +366,7 @@ class Page
                     {
                         if (sizeof(array_intersect($vis, $this->visits)))
                             $auth = True;
-                        if ($this->user->hasPermission('all_shipments'))
+                        if ($this->user->hasPermission('all_dewars'))
                             // allow to see anything without an id or a visit
                             $auth = True;
                     }

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -170,7 +170,7 @@ class Proposal extends Page
                 $where .= " AND (shp.personid=:" . (sizeof($args) + 1) . " OR s.beamlinename in ('" . implode("','", $bls) . "'))";
                 array_push($args, $this->user->personId);
             }
-        } else if ($this->user->hasPermission('all_shipments')) {
+        } else if ($this->user->hasPermission('all_dewars')) {
             // allow to see shipments on all proposals
         } else {
             $where = " INNER JOIN session_has_person shp ON shp.sessionid = s.sessionid  " . $where;
@@ -921,7 +921,7 @@ class Proposal extends Page
 
                 $where .= " AND ses.beamlinename in ('" . implode("','", $bls) . "')";
             }
-        } else if ($field == 'SHIPPINGID' && $this->user->hasPermission('all_shipments')) {
+        } else if ($field == 'SHIPPINGID' && $this->user->hasPermission('all_dewars')) {
             // allow to see shipments
         } else {
             $where = " INNER JOIN session_has_person shp ON shp.sessionid = ses.sessionid  " . $where;

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -170,6 +170,8 @@ class Proposal extends Page
                 $where .= " AND (shp.personid=:" . (sizeof($args) + 1) . " OR s.beamlinename in ('" . implode("','", $bls) . "'))";
                 array_push($args, $this->user->personId);
             }
+        } else if ($this->user->hasPermission('all_shipments')) {
+            // allow to see shipments on all proposals
         } else {
             $where = " INNER JOIN session_has_person shp ON shp.sessionid = s.sessionid  " . $where;
             $where .= " AND shp.personid=:" . (sizeof($args) + 1);
@@ -919,6 +921,8 @@ class Proposal extends Page
 
                 $where .= " AND ses.beamlinename in ('" . implode("','", $bls) . "')";
             }
+        } else if ($field == 'SHIPPINGID' && $this->user->hasPermission('all_shipments')) {
+            // allow to see shipments
         } else {
             $where = " INNER JOIN session_has_person shp ON shp.sessionid = ses.sessionid  " . $where;
             $where .= " AND shp.personid=:" . (sizeof($args) + 1);

--- a/client/src/js/app/components/header.vue
+++ b/client/src/js/app/components/header.vue
@@ -50,7 +50,6 @@
       </router-link>
     </div>
     <div
-      v-if="isStaff"
       class="tw-flex"
     >
       <!-- Only show those links with correct permission -->

--- a/client/src/js/modules/types/em/menu.js
+++ b/client/src/js/modules/types/em/menu.js
@@ -15,7 +15,7 @@ define([], function() {
         },
         admin: {
             'dewars/overview': { title: 'Logistics', icon: 'fa-truck', permission: 'all_dewars' },
-            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks', permission: 'fault_view' },
         },
     }
 })

--- a/client/src/js/modules/types/gen/menu.js
+++ b/client/src/js/modules/types/gen/menu.js
@@ -13,7 +13,7 @@ define([], function() {
         },
         
         admin: {
-            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks', permission: 'fault_view' },
 
         },
     }

--- a/client/src/js/modules/types/mx/menu.js
+++ b/client/src/js/modules/types/mx/menu.js
@@ -28,8 +28,8 @@ define([], function() {
             'stats/overview/beamlines': { title: 'Reporting', icon: 'fa-line-chart', permission: 'all_prop_stats' },
             'admin/imaging': { title: 'Imaging', icon: 'fa-image', permission: 'imaging_dash' },
             'dewars/overview': { title: 'Logistics', icon: 'fa-truck', permission: 'all_dewars' },
-            statistics: { title: 'Stats', icon: 'fa-pie-chart' },
-            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+            statistics: { title: 'Stats', icon: 'fa-pie-chart', permission: 'mx_admin' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks', permission: 'fault_view' },
         },
     }
 })

--- a/client/src/js/modules/types/pow/menu.js
+++ b/client/src/js/modules/types/pow/menu.js
@@ -18,7 +18,7 @@ define([], function() {
         },
         
         admin: {
-            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks', permission: 'fault_view' },
         },
     }
     

--- a/client/src/js/modules/types/saxs/menu.js
+++ b/client/src/js/modules/types/saxs/menu.js
@@ -20,7 +20,7 @@ define([], function() {
         admin: {
             'runs/overview': { title: 'Run Overview', icon: 'fa-bar-chart', permission: 'all_breakdown' },
             'dewars/overview': { title: 'Logistics', icon: 'fa-truck', permission: 'all_dewars' },
-            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks', permission: 'fault_view' },
         },
     }
     

--- a/client/src/js/modules/types/sp/menu.js
+++ b/client/src/js/modules/types/sp/menu.js
@@ -14,7 +14,7 @@ define([], function() {
         },
         
         admin: {
-            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks', permission: 'fault_view' },
         },
     }
     


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1246](https://jira.diamond.ac.uk/browse/LIMS-1246)

**Summary**:

Members of goods handling have the "all_dewars" permission in ISPyB. We should allow them to see all shipments, and print the shipping labels. They should also see the "Logistics" page (/dewars/overview) with the truck icon in the top right.

Unfortunately this PR also allows them to see:
- A list of all proposals (could be removed but seems useful so they can navigate to a specific shipment)
- A list of all samples for a proposal
- A list of all proteins for a proposal
- A list of all lab contacts for a proposal
- Registered dewars and containers for a proposal

Does not allow them to see:
- Any visits or data collections
- Any containers
- Any details on samples, proteins, lab contacts

**Changes**:
- Set $auth to be true if the user has all_dewars permission, and the page has a prop= property and no id= or visit= properties
- Show all proposals if user has all_dewars permission
- Allow lookup of proposal for Shipping page if user has all_dewars permission
- Remove the isStaff filter on the admin menu in the top right, replace with individual permissions for each icon. Most villages only have fault reports so can be set to fault_view. 

**To test**:
- Log in as someone from goods handling, test you can navigate via a proposal to a shipment and print shipping labels
- Test a direct link to a shipment as someone from goods handling
- Test you cannot see visits or data collections
- Log in as a 'normal' user, test you can only get to shipments from your proposal
- Test a direct link to a shipment you should not be able to see
- Log in as staff, test you can see everything as normal