### PR TITLE
LIMS-1289: Fix sample and pdb count on proteins page

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -180,7 +180,7 @@ class Sample extends Page
         array('/proteins(/:pid)', 'get', '_proteins'),
         array('/proteins', 'post', '_add_protein'),
         array('/proteins/:pid', 'patch', '_update_protein'),
-        array('/proteins/distinct', 'get', '_disinct_proteins'),
+        array('/proteins/distinct', 'get', '_distinct_proteins'),
 
         array('/proteins/lattice(/:lid)', 'get', '_protein_lattices'),
         array('/proteins/lattice', 'post', '_add_protein_lattice'),
@@ -1759,10 +1759,10 @@ class Sample extends Page
                                 IF(pr.externalid IS NOT NULL, 1, 0) as external,
                                 HEX(pr.externalid) as externalid,
                                 pr.density,
-                                count(php.proteinid) as pdbs,
+                                count(distinct php.pdbid) as pdbs,
                                 pr.safetylevel,
-                                count(dc.datacollectionid) as dcount,
-                                count(b.blsampleid) as scount
+                                count(distinct dc.datacollectionid) as dcount,
+                                count(distinct b.blsampleid) as scount
 
                                 FROM protein pr
                                 LEFT OUTER JOIN concentrationtype ct ON ct.concentrationtypeid = pr.concentrationtypeid
@@ -1792,7 +1792,7 @@ class Sample extends Page
 
     # ------------------------------------------------------------------------
     # Return distinct proteins for a proposal
-    function _disinct_proteins()
+    function _distinct_proteins()
     {
         if (!$this->has_arg('prop'))
             $this->_error('No proposal specified');


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1289](https://jira.diamond.ac.uk/browse/LIMS-1289)

**Summary**:

The values for the numbers of samples and PDBs on the Proteins page are incorrect.

**Changes**:
- Use distinct to only count unique samples, PDBs and data collections
- Fix typo in function name

**To test**:
- Go to a proposal (eg cm37235) then go to the Proteins page, check no protein is listed as having thousands of samples or PDBs
- Click through to each protein and check the number of PDBs and samples match those shown on the proteins page
- Check each protein page displays correctly
- Add a new container to a shipment, check the list of (distinct) proteins populates correctly
