### PR TITLE
[LIMS-1288] SynchWeb link to PATo with undefined session

### DIFF
--- a/client/src/js/modules/types/em/dc/redirect.vue
+++ b/client/src/js/modules/types/em/dc/redirect.vue
@@ -21,9 +21,25 @@ export default {
     },
     'computed': {
         redirectUrl: function () {
+            let redirectLocation = this.$store.state.appOptions.redirects.em;
             const visitStr = this.collection.queryParams.visit;
-            const [proposal, visit] = visitStr.split("-");
-            return `${this.$store.state.appOptions.redirects.em}/proposals/${proposal}/sessions/${visit}`
+
+            if (visitStr) {
+                const [proposal, visit] = visitStr.split("-");
+                redirectLocation += `/proposals/${proposal}/sessions/${visit}`;
+            } else {
+                const pathParams = window.location.pathname.split("/");
+                const lastParam = pathParams[pathParams.length - 1].split("-");
+
+                if(lastParam.length === 2) {
+                    redirectLocation += `/proposals/${lastParam[0]}`
+                    if(!isNaN(lastParam[1])) {
+                        redirectLocation += `/sessions/${lastParam[1]}`;
+                    }
+                }
+            }
+
+            return redirectLocation;
         }
     },
 }

--- a/client/src/js/modules/types/em/dc/redirect.vue
+++ b/client/src/js/modules/types/em/dc/redirect.vue
@@ -29,7 +29,7 @@ export default {
                 redirectLocation += `/proposals/${proposal}/sessions/${visit}`;
             } else {
                 const pathParams = window.location.pathname.split("/");
-                const lastParam = pathParams[pathParams.length - 1].split("-");
+                const lastParam = pathParams.pop().split("-");
 
                 if(lastParam.length === 2) {
                     redirectLocation += `/proposals/${lastParam[0]}`


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1288](https://jira.diamond.ac.uk/browse/LIMS-1288)

**Summary**:

When visiting an EM DC page for a null session, currently, the proposal or visit are not properly included in the URL. This fixes this by only including the session in URL if the session is valid, and in case both the proposal/session are not available through a prop or the URL, the redirect points to PATo's home page.

**Changes**:
- Add conditional checks to build the redirection URL dynamically, taking into consideration the session/proposal validity.

**To test**:
- Visit an EM DC page pointing to a null session (/dc/visit/ic37826-null) and check that only the proposal is included in the redirect
- Visit a regular EM DC page (/dc/visit/bi23047-119) and check that both the session number and proposal are included in the redirect
