### PR TITLE
LIMS-1276: Add printed date to shipping labels

### DIFF
--- a/api/assets/pdf/shipment_label.php
+++ b/api/assets/pdf/shipment_label.php
@@ -10,10 +10,9 @@
                 <li><span class="bold">Outbound Address label:</span> To be attached to the outside of your transport container for shipment to facility</li>
                 <li><span class="bold">Return Address Label:</span> The return address for your shipment (Please include this in your shipment, e.g. put it behind the outward bound address or in the transport container)</li>
             </ol>
+            Please remove old paperwork immediately after you receive your dewar back from Diamond.
         </div>
 
-
-        <br />
         <br />
 
         <p class="ca bold red">1. Dewar Tracking Label</p>
@@ -49,10 +48,6 @@
                     <td class="grey px150">Safety Level</td>
                     <td><?php echo $ship['SAFETYLEVEL'] ?></td>
                 </tr>
-                <tr>
-                    <td class="grey px150">No. Parcels</td>
-                    <td><?php echo sizeof($dewars) ?></td>
-                </tr>
             </table>
 
             <table class="center px500">
@@ -68,6 +63,10 @@
                     <td class="grey px150">Local Contact</td>
                     <td><?php echo $d['BEAMLINEOPERATOR'] ?></td>
                 </tr>
+                <tr>
+                    <td class="grey px150">Printed on</td>
+                    <td><?php echo date('j M o') ?></td>
+                </tr>
             </table>
 
             <div class="float-left px150 title-wrapper">
@@ -79,7 +78,7 @@
                 <?php foreach(explode(',', $d['CONTAINERSBARCODE']) as $bar_code) { ?>
                     <div class="container-item"><?php echo strlen($bar_code) > 15 ? substr($bar_code,0,14).'+' : $bar_code ?></div>
                 <?php }?>
-                <?php if ($d['CONTAINERS'] > 10) { ?>
+                <?php if ($d['CONTAINERS'] > count(explode(',', $d['CONTAINERSBARCODE']))) { ?>
                     <div class="container-item"><?php echo " plus " . ($d['CONTAINERS'] - count(explode(',', $d['CONTAINERSBARCODE']))) . " more" ?></div>
                 <?php }?>
             </div>
@@ -157,6 +156,10 @@
                     <tr>
                         <td class="grey px150">Local Contact</td>
                         <td><?php echo $d['BEAMLINEOPERATOR'] ?></td>
+                    </tr>
+                    <tr>
+                        <td class="grey px150">Printed on</td>
+                        <td><?php echo date('j M o') ?></td>
                     </tr>
                 </table>
 
@@ -249,6 +252,10 @@
                     <tr>
                         <td class="grey px150">Transport Value</td>
                         <td><?php echo $d['TRANSPORTVALUE'] ?></td>
+                    </tr>
+                    <tr>
+                        <td class="grey px150">Printed on</td>
+                        <td><?php echo date('j M o') ?></td>
                     </tr>
                 </table>
 

--- a/api/assets/pdf/shipment_label.php
+++ b/api/assets/pdf/shipment_label.php
@@ -8,7 +8,7 @@
             <ol>
                 <li><span class="bold">Dewar Label:</span> affix this label to your dewar which ensures it can be identified at all times at the facility</li>
                 <li><span class="bold">Outbound Address label:</span> To be attached to the outside of your transport container for shipment to facility</li>
-                <li><span class="bold">Return Address Label:</span> The return address for your shipment (Please include this in your shipment, e.g. put it behind the outward bound address or in the transport container)</li>
+                <li><span class="bold">Return Address Label:</span> The return address for your shipment (Please include this in your shipment, e.g. put it behind the outbound label or in the transport container)</li>
             </ol>
             Please remove old paperwork immediately after you receive your dewar back from Diamond.
         </div>

--- a/api/assets/pdf/styles.css
+++ b/api/assets/pdf/styles.css
@@ -123,7 +123,7 @@ table {
 }
 
 ol {
-    margin-left: 25px;
+    margin-left: 10px;
 }
 
 .bold {

--- a/api/src/Page/PDF.php
+++ b/api/src/Page/PDF.php
@@ -159,7 +159,7 @@ class PDF extends Page
 
         $this->ship = $ship;
 
-        $this->dewars = $this->db->pq("SELECT bl.beamlinename, bl.beamlineoperator, TO_CHAR(bl.startdate, 'DD-MM-YYYY') as st, d.transportvalue, d.customsvalue, d.code, d.barcode, count(cq.containerqueueid) as auto, count(c.containerid) as containers, GROUP_CONCAT(COALESCE(cr.barCode, c.code) LIMIT 10) as containersBarCode
+        $this->dewars = $this->db->pq("SELECT bl.beamlinename, bl.beamlineoperator, TO_CHAR(bl.startdate, 'DD-MM-YYYY') as st, d.transportvalue, d.customsvalue, d.code, d.barcode, count(cq.containerqueueid) as auto, count(c.containerid) as containers, GROUP_CONCAT(COALESCE(cr.barCode, c.code) LIMIT 8) as containersBarCode
                 FROM dewar d 
                 LEFT OUTER JOIN blsession bl ON d.firstexperimentid = bl.sessionid 
                 LEFT OUTER JOIN container c ON c.dewarid = d.dewarid


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1276](https://jira.diamond.ac.uk/browse/LIMS-1276)

**Summary**:

Add a bit more information to the dewar shipment label

**Changes**:
- Add instruction to remove old paperwork
- Remove "No of Parcels" from dewar label
- Add "Printed on" date to each page
- Limit number of puck names printed to 8, to prevent going onto another page
- Decrease indent on instruction list

**To test**:
- Go to a shipment, check the label looks sensible, compare with [shipping-label.pdf](https://github.com/DiamondLightSource/SynchWeb/files/14958921/shipping-label.pdf)
- Go to a shipment with more than 8 pucks (eg /shipments/sid/54450), check only the first 8 are printed, and "plus 3 more" (or however many)
