### PR TITLE
LIMS-1256: Remove validation from Local Contact field

### DIFF
--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -20,13 +20,6 @@ define(['backbone'], function(Backbone) {
             pattern: 'visit',
         },
 
-        LOCALCONTACT: {
-            required: false,
-            pattern: 'wwsddash'
-        },
-
-
-
         GIVENNAME: {
             required: true,
             pattern: 'wwdash',

--- a/client/src/js/utils/validation.js
+++ b/client/src/js/utils/validation.js
@@ -3,7 +3,6 @@ define(['backbone', 'backbone-validation'], function(Backbone) {
 
     _.extend(Backbone.Validation.patterns, {
         wwsdash: /^(\w|\s|\-)+$/,
-        wwsddash: /^(\w|\s|\-|\.)+$/,
         wwsldash: /^(\w|\s|\-|\/)+$/,
         wwsbdash: /^(\w|\s|\-|\(|\))+$/,
         wwsbddash: /^(\w|\s|\-|\.|\(|\))+$/,
@@ -26,7 +25,6 @@ define(['backbone', 'backbone-validation'], function(Backbone) {
     _.extend(Backbone.Validation.messages, {
         required: 'This field is required',
         wwsdash: 'This field must contain only letters, numbers, spaces, underscores, and dashes',
-        wwsddash: 'This field must contain only letters, numbers, spaces, underscores, dots, and dashes',
         wwsldash: 'This field must contain only letters, numbers, spaces, underscores, slashes, and dashes',
         wwsbdash: 'This field must contain only letters, numbers, spaces, underscores, brackets, and dashes',
         wwsbddash: 'This field must contain only letters, numbers, spaces, underscores, dots, brackets, and dashes',


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1256](https://jira.diamond.ac.uk/browse/LIMS-1256)

**Summary**:

A user couldn't fill in the dispatch request form because the local contact had an "ö" in their name and the form rejected the "ö". As the user cannot edit this field any more, we should remove the validation.

**Changes**:
- Remove validation from local contact field
- Remove wwsddash pattern as it is not used anywhere else

**To test**:
- Do a dispatch request, check the form still submits ok
