### PR TITLE
LIMS-1235: Queries for implicit samples and DCs in project time out

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -18,7 +18,6 @@ class DC extends Page
         'sid' => '\d+',
         'aid' => '\d+',
         'pjid' => '\d+',
-        'imp' => '\d',
         'pid' => '\d+',
         'h' => '\d\d',
         'dmy' => '\d\d\d\d\d\d\d\d',
@@ -71,7 +70,7 @@ class DC extends Page
     #   - a proposal /
     #   - a visit /visit/
     #   - a particular sample id /sid/
-    #   - a project (explicit or implicit) /pjid/(imp/1/)
+    #   - a project (explicit only) /pjid/
     #   - a protein /pid/
     #   Its also searchable (A-z0-9-/) and filterable
     function _data_collections($single = null)
@@ -237,22 +236,10 @@ class DC extends Page
                 $extj[$i] .= " LEFT OUTER JOIN $t[0] prj ON $t[1].$t[2] = prj.$ct INNER JOIN proposal prop ON ses.proposalid = prop.proposalid";
                 $sess[$i] = 'prj.projectid=:' . ($i + 1);
 
-                if ($this->has_arg('imp')) {
-                    if ($this->arg('imp')) {
-                        $extj[$i] .= " LEFT OUTER JOIN crystal cr ON cr.crystalid = smp.crystalid LEFT OUTER JOIN protein pr ON pr.proteinid = cr.proteinid LEFT OUTER JOIN project_has_protein prj2 ON prj2.proteinid = pr.proteinid LEFT OUTER JOIN project_has_blsample prj3 ON prj3.blsampleid = smp.blsampleid";
-                        $sess[$i] = '(prj.projectid=:' . ($i * 3 + 1) . ' OR prj2.projectid=:' . ($i * 3 + 2) . ' OR prj3.projectid=:' . ($i * 3 + 3) . ')';
-                    }
-                }
             }
 
-
-            $n = 4;
-            if ($this->has_arg('imp'))
-                if ($this->arg('imp'))
-                    $n = 12;
-            for ($i = 0; $i < $n; $i++)
+            for ($i = 0; $i < 4; $i++)
                 array_push($args, $this->arg('pjid'));
-
 
             # Proteins
         } else if ($this->has_arg('pid')) {

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -27,7 +27,6 @@ class Sample extends Page
         'ty' => '\w+',
         't' => '\w+',
         'pjid' => '\d+',
-        'imp' => '\d',
         'lt' => '\w+',
         'existing_pdb' => '\d+',
         'pdb_code' => '\w\w\w\w',
@@ -1034,14 +1033,6 @@ class Sample extends Page
                     INNER JOIN session_has_person shp ON shp.sessionid = ses.sessionid AND shp.personid=:" . (sizeof($args) + 1);
 
                 array_push($args, $this->user->personId);
-            }
-
-            if ($this->has_arg('imp')) {
-                if ($this->arg('imp')) {
-                    array_push($args, $this->arg('pjid'));
-                    $join .= ' LEFT OUTER JOIN project_has_protein pji ON pji.proteinid=pr.proteinid';
-                    $where = preg_replace('/\(pj/', '(pji.projectid=:' . sizeof($args) . ' OR pj', $where);
-                }
             }
         }
 

--- a/client/src/js/modules/projects/views/view.js
+++ b/client/src/js/modules/projects/views/view.js
@@ -33,12 +33,10 @@ define(['marionette',
         },
         
         events: {
-            'click @ui.imp': 'toggleImplicit',
             'keypress @ui.user': 'keypressUser',
         },
         
         ui: {
-            imp: 'a.imp',
             user: 'input[name=adduser]',
         },
         
@@ -71,33 +69,16 @@ define(['marionette',
             this.users.queryParams.pjid = this.model.get('PROJECTID')
             this.users.fetch()
             
-            this.implicit = 1
-            
-            this.proteins = new Proteins(null, { queryParams: { pjid: this.model.get('PROJECTID'), imp: this.isImplicit.bind(this) }, state: { pageSize: 5 } })
+            this.proteins = new Proteins(null, { queryParams: { pjid: this.model.get('PROJECTID') }, state: { pageSize: 5 } })
             this.proteins.fetch()
             
-            this.samples = new Samples(null, { queryParams: { pjid: this.model.get('PROJECTID'), imp: this.isImplicit.bind(this) }, state: { pageSize: 5 } })
+            this.samples = new Samples(null, { queryParams: { pjid: this.model.get('PROJECTID') }, state: { pageSize: 5 } })
             this.samples.fetch()
             
-            this.dcs = new DCCol(null, { queryParams: { pjid: this.model.get('PROJECTID'), imp: this.isImplicit.bind(this), pp: 5 } })
+            this.dcs = new DCCol(null, { queryParams: { pjid: this.model.get('PROJECTID'), pp: 5 } })
             this.dcs.fetch()
         },
-        
-        
-        isImplicit: function() {
-            return this.implicit
-        },
-        
-        toggleImplicit: function(e) {
-            e.preventDefault()
-            this.implicit = this.implicit ? 0 : 1
-            this.ui.imp.children('span').text(this.implicit ? 'Implicit' : 'Explicit')
-            this.proteins.fetch()
-            this.samples.fetch()
-            this.dcs.fetch()
-        },
-        
-        
+
         getUsers: function(req, resp) {
             var self = this
             this.allusers.queryParams.s = req.term

--- a/client/src/js/templates/projects/projectview.html
+++ b/client/src/js/templates/projects/projectview.html
@@ -2,8 +2,6 @@
 
 <p class="help">This pages shows details and history for the selected project</p>
 
-<div class="ra"><a href="#" class="button imp" title="Click to change between showing explicity added project members and those implied by added proteins or samples"><i class="fa fa-arrows-alt"></i> <span>Implicit</span> Project Members</a></div>
-
 <div class="form">
     <ul>
         <li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1235](https://jira.diamond.ac.uk/browse/LIMS-1235)

**Summary**:

The list of samples and data collections for a project times out, as it is trying to list both explicitly linked samples and also implicitly linked (via protein) samples. 

**Changes**:
- Remove the option to show implicitly-linked samples and data collections, show only those explicitly linked to the project

**To test**:
- Create a new project, and add some proteins, samples and data collections to it
- Check they each appear on the project page promptly
- Check the implicit/explicit button has been removed
