### PR TITLE
LIMS-44: Speed up visit query

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -177,7 +177,12 @@ class DC extends Page
         $info = array();
         # Visits
         if ($this->has_arg('visit')) {
-            $info = $this->db->pq("SELECT TO_CHAR(s.startdate, 'HH24') as sh, TO_CHAR(s.startdate, 'DDMMYYYY') as dmy, s.sessionid, s.beamlinename as bl FROM blsession s INNER JOIN proposal p ON (p.proposalid = s.proposalid) WHERE CONCAT(p.proposalcode, p.proposalnumber, '-', s.visit_number) LIKE :1", array($this->arg('visit')));
+            $pattern = '/([A-z]+)(\d+)-(\d+)/';
+            preg_match($pattern, $this->arg('visit'), $matches);
+            if (!sizeof($matches))
+                $this->_error('No such visit');
+
+            $info = $this->db->pq("SELECT TO_CHAR(s.startdate, 'HH24') as sh, TO_CHAR(s.startdate, 'DDMMYYYY') as dmy, s.sessionid, s.beamlinename as bl FROM blsession s INNER JOIN proposal p ON (p.proposalid = s.proposalid) WHERE p.proposalcode=:1 AND p.proposalnumber=:2 AND s.visit_number=:3", array($matches[1], $matches[2], $matches[3]));
 
             if (!sizeof($info)) {
                 $this->_error('No such visit');


### PR DESCRIPTION
**JIRA ticket**: [LIMS-44](https://jira.diamond.ac.uk/browse/LIMS-44)

**Summary**:

The lookup of sessionid from proposal-visit is written sub-optimally, so it has to perform a full table scan on BLSession. This changes speeds up the block of code from 40ms to 1ms.

**Changes**:
- Use regex to split the visit string into proposal code, proposal number and visit number
- Query the db with those separately

**To test**:
- Go to any visit page (eg /dc/visit/mx23694-112) and check it loads correctly, showing data collections from that visit and only from that visit
- Go to the View All Data page (/dc) and check it loads correctly
