### PR TITLE
LIMS-1207 - Improve main menu for mx

### DIFF
--- a/client/src/js/app/components/header.vue
+++ b/client/src/js/app/components/header.vue
@@ -20,7 +20,7 @@
         </p>
       </router-link>
       <router-link
-        v-if="isStaff"
+        v-if="isLoggedIn"
         class="tw-mx-1 tw-text-header-color hover:tw-text-header-hover-color"
         to="/cal"
       >

--- a/client/src/js/modules/contact/views/contacts.js
+++ b/client/src/js/modules/contact/views/contacts.js
@@ -8,7 +8,7 @@ define(['marionette', 'views/table', 'utils/table'], function(Marionette, TableV
   return Marionette.LayoutView.extend({
     className: 'content',
     // TODO - move this into its own template file and use a templateHelper CAN_CREATE for consistency with proteins
-    template: '<div><h1>Home Lab Contacts</h1><p class="help">This page shows registered home laboratory contacts. This information is generally used to return shipments back after an experiment</p><div class="ra"><a class="button add" href="/contacts/add"><i class="fa fa-plus"></i> Add Home Lab Contact</a></div><div class="wrapper"></div></div>',
+    template: '<div><h1>Home Lab Contacts</h1><p class="help">This page shows registered home laboratory contacts. This information is generally used to return shipments back after an experiment</p><div class="ra"><a class="button add" href="/contacts/add"><i class="fa fa-plus"></i> Add Home Lab Contact</a> <a class="button add" href="/migrate"><i class="fa fa-arrow-right"></i> Migrate Lab Contacts</a></div><div class="wrapper"></div></div>',
     regions: { 'wrap': '.wrapper' },
     ui: {
       add: 'a.add',

--- a/client/src/js/modules/types/mx/menu.js
+++ b/client/src/js/modules/types/mx/menu.js
@@ -4,15 +4,14 @@ define([], function() {
         menu: {
             dc: 'View All Data',
             visits: 'Visits',
-            assign: 'Assign Containers',
-            'samples/groups': 'Sample Group Management',
+            contacts: 'Lab Contacts',
             shipments: 'Shipments',
             'dewars/registry': 'Registered Dewars',
             'containers/registry': 'Registered Containers',
             containers: 'Containers',
-            samples: 'Samples',
             proteins: 'Proteins',
-            contacts: 'Lab Contacts',
+            samples: 'Samples',
+            'samples/groups': 'Sample Groups',
             stats: 'Statistics',
         },
 

--- a/client/src/js/modules/types/mx/menu.js
+++ b/client/src/js/modules/types/mx/menu.js
@@ -14,7 +14,6 @@ define([], function() {
             proteins: 'Proteins',
             contacts: 'Lab Contacts',
             stats: 'Statistics',
-            migrate: 'Migrate',
         },
 
         extra: {

--- a/client/src/js/modules/types/mx/menu.js
+++ b/client/src/js/modules/types/mx/menu.js
@@ -4,7 +4,6 @@ define([], function() {
         menu: {
             dc: 'View All Data',
             visits: 'Visits',
-            cal: 'Calendar',
             assign: 'Assign Containers',
             'samples/groups': 'Sample Group Management',
             shipments: 'Shipments',

--- a/client/src/js/templates/header.html
+++ b/client/src/js/templates/header.html
@@ -14,9 +14,7 @@
 <% } %>
 <a class="icon" href="/"><i class="fa fa-home fa-2x"></i> <span class="icon-label">Home</span></a>
 
-<% if (IS_STAFF) { %>
 <a class="icon" href="/cal"><i class="fa fa-calendar fa-2x"></i> <span class="icon-label">Calendar</span></a>
-<% } %>
 <a href="#" title="Logout" class="icon logout"><i class="fa fa-sign-out fa-2x"></i> <span class="icon-label">Logout</span></a>
 
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1207](https://jira.diamond.ac.uk/browse/LIMS-1207)

**Summary**:

The main menu has too many items for MX and is in a weird order.

**Changes**:
- Make the calendar link in the top left be for all, not just staff, and remove the Calendar link in the menu
- Add a link to the migrate page from the lab contacts page, and remove the Migrate link from the menu
- Remove the Assign Container link from the menu, that is linked from each visit
- Re-order the remaining items to flow more naturally (particularly for new users)

**To test**:
- Check Calendar link appears and works for staff and non-staff
- Check "Migrate Lab Contacts" button appears on the Lab Contacts page and works
- Check all items in the main menu work
