### PR TITLE
LIMS-1302 - add visit to container even if UAS fails

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -1198,8 +1198,8 @@ class Proposal extends Page
             $uas = new UAS($auto_user, $auto_pass);
             $code = $uas->update_session($uasSessionId, $data);
 
-            if ($code == 200) {
-                // Update ISPyB records
+            if ($code == 200 || $code == 404) {
+                // Update ISPyB records, even if UAS says session not found
                 $this->db->pq("UPDATE container SET sessionid=:1 WHERE containerid=:2", array($sessionId, $containerId));
                 // For debugging - actually just want to return Success!
                 $result = array(
@@ -1209,13 +1209,11 @@ class Proposal extends Page
                 );
             } else if ($code == 403) {
                 $this->_error('UAS Error - samples and/or investigators not valid. ISPyB/UAS Session ID: ' . $sessionId . ' / ' . $uasSessionId);
-            } else if ($code == 404) {
-                $this->_error('UAS Error - session not found in UAS, Session ID: ' . $sessionId . ' UAS Session ID: ' . $uasSessionId);
             } else {
-                $this->_error('UAS Error - something wrong creating a session for that container ' . $containerId . ', response code was: ' . $code);
+                $this->_error('UAS Error - something went wrong updating a session for that container ' . $containerId . ', response code was: ' . $code);
             }
         } else {
-            error_log("Something wrong - an Auto Collect session exists but with no containers " . $sessionId);
+            error_log("Something went wrong - an Auto Collect session exists but with no containers " . $sessionId);
 
             $this->_error('No valid containers on the existing Auto Collect Session id:', $sessionId);
         }

--- a/api/src/UAS.php
+++ b/api/src/UAS.php
@@ -73,7 +73,7 @@ class UAS
             ),
         ));
 
-        if ($this->code == 200) {
+        if ($this->code != 200) {
             error_log("UAS::update_session error from UAS, code: " . $this->code);
             error_log(print_r($resp), true);
         }

--- a/api/src/UAS.php
+++ b/api/src/UAS.php
@@ -7,10 +7,10 @@ use SynchWeb\Authentication\Type\CAS;
 class UAS
 {
 
-	function __construct($user=null, $pass=null) {
-		global $uas_url, $vmxi_user, $vmxi_pass;
+    function __construct($user=null, $pass=null) {
+        global $uas_url, $vmxi_user, $vmxi_pass;
 
-		$this->url = $uas_url;
+        $this->url = $uas_url;
 
         $cas = new CAS();
 
@@ -33,12 +33,12 @@ class UAS
         }
 
         // print_r(array('sess', $this->session));
-	}
+    }
 
 
 
-	function create_session($data=array()) {
-		$resp = $this->_curl(array(
+    function create_session($data=array()) {
+        $resp = $this->_curl(array(
             'URL' => $this->url.'/uas/rest/v1/session',
             'FIELDS' => $data,
             'HEADERS' => array(
@@ -48,21 +48,21 @@ class UAS
             ),
         ));
 
-		// print_r(array($resp));
+        // print_r(array($resp));
 
         if ($this->code == 200) {
-			$resp = json_decode($resp);
-		} else {
+            $resp = json_decode($resp);
+        } else {
             error_log("UAS::create_session error from UAS, code: " . $this->code);
             error_log(print_r($resp), true);
         }
 
-		return array('code' => $this->code, 'resp' => $resp);
-	}
+        return array('code' => $this->code, 'resp' => $resp);
+    }
 
 
-	function update_session($sessionid, $data=array()) {
-		$resp = $this->_curl(array(
+    function update_session($sessionid, $data=array()) {
+        $resp = $this->_curl(array(
             'URL' => $this->url.'/uas/rest/v1/session/'.$sessionid,
             'FIELDS' => $data,
             'PATCH' => 1,
@@ -78,14 +78,14 @@ class UAS
             error_log(print_r($resp), true);
         }
 
-		// print_r(array($resp));
+        // print_r(array($resp));
 
-		return $this->code;
-	}
+        return $this->code;
+    }
 
-	function close_session($sessionid, $data = array()) {
+    function close_session($sessionid, $data = array()) {
         $data['endAt'] = date('Y-m-d\TH:i:s.000\Z');
-		$resp = $this->_curl(array(
+        $resp = $this->_curl(array(
             'URL' => $this->url.'/uas/rest/v1/session/'.$sessionid,
             'FIELDS' => $data,
             'PATCH' => 1,
@@ -96,11 +96,11 @@ class UAS
             ),
         ));
 
-		return $this->code;
-	}
+        return $this->code;
+    }
 
-	function get_sessions() {
-		 $resp = $this->_curl(array(
+    function get_sessions() {
+         $resp = $this->_curl(array(
             'URL' => $this->url.'/uas/rest/v1/proposal?state=OPEN&fetch=samples&fetch=investigators',
             'GET' => 1,
             'HEADERS' => array(
@@ -110,12 +110,12 @@ class UAS
             ),
         ));
 
-		if ($this->code == 200) {
-			$resp = json_decode($resp);
-		}
+        if ($this->code == 200) {
+            $resp = json_decode($resp);
+        }
 
-		return array('code' => $this->code, 'resp' => $resp);
-	}
+        return array('code' => $this->code, 'resp' => $resp);
+    }
 
 
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1302](https://jira.diamond.ac.uk/browse/LIMS-1302)

**Summary**:

UAS often fails to find sessions it has created in the last few minutes, so when loading the second UDC puck from a shipment, Synchweb doesnt assign the session id to the container, even though it knows the session id and so it must exist.

**Changes**:
- Treat a 404 error the same as a success
- Only log errors from UAS, not only successes (UAS.php line 76)
- Fix indentation to use spaces not tabs

**To test**:
- Hard to test without UAS. Currently UAS has a workaround in so it doesn't return a 404, but that will probably be removed soon.
- I suggest (if approved and if UAS take out their workaround) we roll out to staging, then point the beamline to staging temporarily. We can load multiple pucks from one shipment, which should assign the session id, but will log the error from UAS.
