### PR TITLE
LIMS-1304: Correct the order of before and after snapshots

### DIFF
--- a/client/src/js/templates/dc/action.html
+++ b/client/src/js/templates/dc/action.html
@@ -1,10 +1,10 @@
 <div class="data_collection" dcid="<%-ID%>" type="action">
     <div class="snapshots">
-        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/f/1" title="Crystal Snapshot Before"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>" alt="Crystal Snapshot Before" /></a>
+        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/f/1" title="Crystal Snapshot After"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>" alt="Crystal Snapshot After" /></a>
     </div>
     
     <div class="snapshots">
-        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2/f/1" title="Crystal Snapshot After"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2" alt="Crystal Snapshot After" /></a>
+        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2/f/1" title="Crystal Snapshot Before"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2" alt="Crystal Snapshot Before" /></a>
     </div>
     
     <h1>

--- a/client/src/js/templates/dc/load.html
+++ b/client/src/js/templates/dc/load.html
@@ -1,9 +1,9 @@
 <div class="data_collection clearfix" dcid="<%-ID%>" type="robot">
 	<div class="snapshots">
-        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/f/1" title="Crystal After Before"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>" alt="Crystal After Before" /></a>
+        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/f/1" title="Crystal After After"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>" alt="Crystal After After" /></a>
     </div>
     <div class="snapshots">
-        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2/f/1" title="Crystal Snapshot After"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2" alt="Crystal Snapshot After" /></a>
+        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2/f/1" title="Crystal Snapshot Before"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2" alt="Crystal Snapshot Before" /></a>
     </div>
 
     <h1><%-ST%> - Robot <% print(IMP.toLowerCase()) %></h1>

--- a/client/src/js/templates/dc/load.html
+++ b/client/src/js/templates/dc/load.html
@@ -1,6 +1,6 @@
 <div class="data_collection clearfix" dcid="<%-ID%>" type="robot">
 	<div class="snapshots">
-        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/f/1" title="Crystal After After"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>" alt="Crystal After After" /></a>
+        <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/f/1" title="Crystal Snapshot After"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>" alt="Crystal Snapshot After" /></a>
     </div>
     <div class="snapshots">
         <a href="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2/f/1" title="Crystal Snapshot Before"><img class="lazy" data-src="<%-APIURL%>/image/ai/visit/<%-VIS_LINK%>/aid/<%-ID%>/n/2" alt="Crystal Snapshot Before" /></a>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1304](https://jira.diamond.ac.uk/browse/LIMS-1304)

**Summary**:

The before and after snapshots in robot load, annealing and washing are the correct order in the page but captioned incorrectly. This swaps the captions around for both

**Changes**:
- Swaps captions for before/after crystals

**To test**:
- Confirm that in a robot load action the location of the before/after snapshot images have not moved but the captions now correctly label the left image as `Before`
