### PR TITLE
LIMS-1315 - Restore EM menu in dropdown

### DIFF
--- a/client/src/js/app/store/modules/store.menus.js
+++ b/client/src/js/app/store/modules/store.menus.js
@@ -7,11 +7,13 @@ import TomoMenu from 'modules/types/tomo/menu.js'
 import XpdfMenu from 'modules/types/xpdf/menu.js'
 import GenProcMenu from 'modules/types/genproc/menu.js'
 import ConexsMenu from 'modules/types/conexs/menu.js'
+import EmMenu from 'modules/types/em/menu.js'
 
 const menuStore = {
     namespaced: true,
     state: () => ({
       menus: {
+        'em': EmMenu,
         'gen': GenMenu,
         'mx': MxMenu,
         'pow': PowMenu,

--- a/client/src/js/modules/types/em/menu.js
+++ b/client/src/js/modules/types/em/menu.js
@@ -1,0 +1,21 @@
+define([], function() {
+    return {
+        menu: {
+            dc: 'View All Data',
+            visits: 'Visits',
+            cal: 'Calendar',
+            shipments: 'Shipments',
+            contacts: 'Lab Contacts',
+            'dewars/registry': 'Registered Dewars',
+            stats: 'Statistics',
+            migrate: 'Migrate',
+        },
+        extra: {
+            //projects: 'Projects',
+        },
+        admin: {
+            'dewars/overview': { title: 'Logistics', icon: 'fa-truck', permission: 'all_dewars' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+        },
+    }
+})


### PR DESCRIPTION
**NOTE**: (PR title should be of the form ticket:short description, e.g. TICKET-123: Add more templates)

**JIRA ticket**: [LIMS-1315](https://jira.diamond.ac.uk/browse/LIMS-1315)

**Summary**:

This pull request restores the dropdown menu in EM proposals, which was erroneously deleted beforehand.

**Changes**:
- EM menu files restored

**To test**:
- Select proposal `bi37694`, open the dropdown, verify that all EM-related options (shipments, etc.) are displayed

NOTE: this is merged directly to master as a hotfix for release `2024-R2.2`, and will be merged into future prerelease branches.
