### PR TITLE
LIMS-1334: Allow selection of plate samples already in a group

### DIFF
--- a/client/src/js/app/store/modules/store.menus.js
+++ b/client/src/js/app/store/modules/store.menus.js
@@ -7,11 +7,13 @@ import TomoMenu from 'modules/types/tomo/menu.js'
 import XpdfMenu from 'modules/types/xpdf/menu.js'
 import GenProcMenu from 'modules/types/genproc/menu.js'
 import ConexsMenu from 'modules/types/conexs/menu.js'
+import EmMenu from 'modules/types/em/menu.js'
 
 const menuStore = {
     namespaced: true,
     state: () => ({
       menus: {
+        'em': EmMenu,
         'gen': GenMenu,
         'mx': MxMenu,
         'pow': PowMenu,

--- a/client/src/js/modules/samples/components/sample-group-create-and-edit.vue
+++ b/client/src/js/modules/samples/components/sample-group-create-and-edit.vue
@@ -71,6 +71,7 @@
             v-else-if="selectedContainerType.NAME && selectedContainerType.NAME.toLowerCase() !== 'puck'"
             :container-type="selectedContainerType"
             :valid-samples="validSamples"
+            :manually-selected-samples="manuallySelectedSamples"
             :container-identifier="selectedContainerName"
             color-attribute="VALID"
             added-color-attribute="ADDED"
@@ -218,11 +219,14 @@ export default {
     validSamples() {
       if (this.selectedContainerId) {
         const selectedContainer = this.selectedSamplesInGroups[this.selectedContainerId] || []
-        const difference = differenceBy(selectedContainer, this.selectedContainerAddedSamples, 'BLSAMPLEID')
-        return [...this.selectedContainerAddedSamples, ...difference]
+        const uniqueSelectedContainer = uniqBy(selectedContainer.concat(this.selectedContainerAddedSamples), 'BLSAMPLEID')
+        return uniqueSelectedContainer
       }
 
       return []
+    },
+    manuallySelectedSamples() {
+      return this.selectedSamplesInGroups[this.selectedContainerId] || []
     }
   },
   created: function () {

--- a/client/src/js/modules/shipment/components/plate-view.vue
+++ b/client/src/js/modules/shipment/components/plate-view.vue
@@ -76,6 +76,10 @@ export default {
       type: Array,
       default: () => ([])
     },
+    manuallySelectedSamples: {
+      type: Array,
+      default: () => ([])
+    },
     addedColorAttribute: {
       type: String,
       default: ''
@@ -425,7 +429,7 @@ export default {
         }
       }
       else {
-        if (this.selectedDrops.includes(itemsWithSample[0])) {
+        if (this.manuallySelectedSamples.some(e => Number(e.LOCATION) === itemsWithSample[0])) {
           this.$emit('unselect-cell', itemsWithSample)
           this.currentSelectedDropIndex = -1
         }

--- a/client/src/js/modules/types/em/menu.js
+++ b/client/src/js/modules/types/em/menu.js
@@ -1,0 +1,21 @@
+define([], function() {
+    return {
+        menu: {
+            dc: 'View All Data',
+            visits: 'Visits',
+            cal: 'Calendar',
+            shipments: 'Shipments',
+            contacts: 'Lab Contacts',
+            'dewars/registry': 'Registered Dewars',
+            stats: 'Statistics',
+            migrate: 'Migrate',
+        },
+        extra: {
+            //projects: 'Projects',
+        },
+        admin: {
+            'dewars/overview': { title: 'Logistics', icon: 'fa-truck', permission: 'all_dewars' },
+            faults: { title: 'Fault Reports', icon: 'fa-tasks' },
+        },
+    }
+})

--- a/client/src/js/modules/types/mx/samples/valid-container-graphic.vue
+++ b/client/src/js/modules/types/mx/samples/valid-container-graphic.vue
@@ -18,6 +18,7 @@
           :samples="samples"
           :selectedDrops="selectedDrops"
           :selectedSamples="validSamples"
+          :manuallySelectedSamples="manuallySelectedSamples"
           color-scale="rgb"
           :colorAttribute="colorAttribute"
           :addedColorAttribute="addedColorAttribute"
@@ -50,6 +51,10 @@ export default {
       default: []
     },
     validSamples: {
+      type: Array,
+      default: []
+    },
+    manuallySelectedSamples: {
       type: Array,
       default: []
     },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1334](https://jira.diamond.ac.uk/browse/LIMS-1334)

**Summary**:

Allow a plate sample that is already in a group to be selected for adding to a new group

**Changes**:
- Maintain a list of manually selected samples, pass that down to the plate view
- Use this list to decide whether a click is a select or deselect
- Use uniqBy instead of concatenating a difference list to return valid samples (this list includes those already in groups)

**To test**:
- Open proposal nt37104, go to Sample Groups, then Create Sample Group
- Select a shipment and a plate (with no coloured samples)
- Select a few samples and create a group with a name, check the view on the Sample Groups page that this has worked correctly
- Go back to Create Sample Group, use the same shipment and plate, some samples should now be blue to show they are already in a group
- Check that clicking on blue samples turns them green, and clicking again turns them blue again
- Select some previously blue samples and some previously grey samples and create a group.
- Use the row select, column select, and select all buttons to create more groups. Each should toggle green and blue or grey.
- Check each group has been created with the correct samples.
-