### PR TITLE
LIMS-1342: Show regular create AWB form if shipping redirect not enabled

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -92,7 +92,7 @@ function setupApplication($mode): Slim
             'enabled_container_types' => $enabled_container_types,
             'ifsummary' => $ifsummary,
             'synchweb_version' => $synchweb_version,
-            'shipping_service_app_url' => $use_shipping_service_redirect ? $shipping_service_app_url : null,
+            'shipping_service_app_url' => $use_shipping_service_redirect || $use_shipping_service_redirect_incoming_shipments ? $shipping_service_app_url : null,
             'shipping_service_app_url_incoming' => $use_shipping_service_redirect_incoming_shipments ? $shipping_service_app_url : null,
             'redirects' => $redirects
         )));

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1020,10 +1020,11 @@ class Shipment extends Page
         }
 
         $server_port = ($_SERVER['SERVER_PORT']==='443') ? '' : ":{$_SERVER['SERVER_PORT']}";
+        $protocol = isset($_SERVER["HTTPS"]) ? 'https' : 'http';
         $shipment_request_info = array(
             "proposal" => $proposal,
             "external_id" => $external_id,
-            "origin_url" => "https://{$_SERVER['SERVER_NAME']}{$server_port}/shipments/sid/{$shipping_id}",
+            "origin_url" => "{$protocol}://{$_SERVER['SERVER_NAME']}{$server_port}/shipments/sid/{$shipping_id}",
             "packages" => $packages
         );
         $response = $this->shipping_service->create_shipment_request($shipment_request_info);

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -2969,7 +2969,7 @@ class Shipment extends Page
                 // TODO: Use null access operator when we upgrade to PHP 8
                 $error_response = $error_json->content->detail ?? $e->getMessage();
                 $error_status = $error_json->status ? $error_json->status : 400; // Status can be 0
-                $this->_error("Shipping service error: $error_response", $error_status);
+                $this->_error("Shipping service error: " . json_encode($error_response), $error_status);
             }
         }
 

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1218,7 +1218,7 @@ class Shipment extends Page
                         $error_json = json_decode($e->getMessage());
                         $error_response = $error_json->content->detail ?? $e->getMessage();
                         $error_status = $error_json->status ? $error_json->status : 400; // Status can be 0
-                        $this->_error("Shipping service error: $error_response", $error_status);
+                        $this->_error("Shipping service error: " . json_encode($error_response), $error_status);
                     }
                     if (Utils::getValueOrDefault($shipping_service_links_in_emails)) {
                         $data['AWBURL'] = "{$shipping_service_app_url}/shipment-requests/{$shipment_id}/outgoing";

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -90,7 +90,7 @@ class ShippingService
                 "Shipping service unexpected status code." . PHP_EOL .
                 "Request: $type $url" . PHP_EOL .
                 "Status code: $status_code" . PHP_EOL .
-                "Response: $response" . PHP_EOL .
+                "Response: " . json_encode($response) . PHP_EOL .
                 "Request data:" . json_encode($data)
             );
             throw new \Exception(json_encode(array('status' => $status_code, 'content' => $response)));

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -112,6 +112,7 @@ define(['backbone',
             terms: '.terms',
             termsq: '.terms-quote',
             shipmentCountry: 'select[name=SHIPMENTCOUNTRY]',
+            countrySelect: '.countrySelect',
 
             createAWBForm: '.createAWBForm',
         },
@@ -140,10 +141,11 @@ define(['backbone',
         toggleFacilityCourier: function() {
 
             if (app.options.get("shipping_service_app_url_incoming")) {
+                this.ui.countrySelect.show()
                 const shipmentCountry = this.ui.shipmentCountry.val();
                 if (
-                        app.options.get('facility_courier_countries').indexOf(shipmentCountry) > -1
-                        || app.options.get('facility_courier_countries_nde').indexOf(shipmentCountry) > -1
+                    app.options.get('facility_courier_countries').indexOf(shipmentCountry) > -1
+                    || app.options.get('facility_courier_countries_nde').indexOf(shipmentCountry) > -1
                 ) {
                     if (this.terms.get('ACCEPTED')) {
                         this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
@@ -309,6 +311,7 @@ define(['backbone',
             this.ui.submit.hide()
             this.ui.qwrap.hide()
             this.ui.terms.hide()
+            this.ui.countrySelect.hide()
 
             if (
                 app.options.get('facility_courier_countries').length

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -136,57 +136,52 @@ define(['backbone',
 
         _lcFields: ['PHONENUMBER', 'EMAILADDRESS', 'LABNAME', 'ADDRESS', 'CITY', 'POSTCODE','COUNTRY', 'GIVENNAME', 'FAMILYNAME'],
 
+
+        updateFormAsTermsAccepted: function() {
+            this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
+            this.ui.acc_msg.text('Paid for by Facility')
+            this.ui.facc.hide()
+            this.ui.quote.hide()
+            this.ui.submit.show()
+            this.ui.termsq.hide()
+            this.ui.terms.show()
+            this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
+        },
+
         toggleFacilityCourier: function() {
+            this.ui.createAWBForm.show()
+            this.setPickupDetailsRequired(true)
+            this.setEmailRequired(true)
             if (app.options.get("shipping_service_app_url_incoming")) {
                 if (
                     app.options.get('facility_courier_countries').indexOf(this.lc.get('COUNTRY')) > -1
                     || app.options.get('facility_courier_countries_nde').indexOf(this.lc.get('COUNTRY')) > -1
                 ) {
                     if (this.terms.get('ACCEPTED')) {
-                        this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
-                        this.ui.acc_msg.text('Paid for by Facility')
-                        this.ui.facc.hide()
-                        this.ui.quote.hide()
-                        this.ui.submit.show()
-                        this.ui.termsq.hide()
-                        this.ui.terms.show()
-                        this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
+                        this.updateFormAsTermsAccepted()
                         this.setPickupDetailsRequired(false)
                         this.setEmailRequired(false)
                         this.ui.createAWBForm.hide()
                         this.ui.submit.text("Proceed")
                     } else {
                         this.ui.facc.show()
-                        this.ui.createAWBForm.show()
-                        this.setPickupDetailsRequired(true)
-                        this.setEmailRequired(true)
                     }
                 } else {
                     this.ui.facc.hide()
-                    this.ui.createAWBForm.show()
-                    this.setPickupDetailsRequired(true)
-                    this.setEmailRequired(true)
                 }
-
             } else {
                 if (
                     app.options.get('facility_courier_countries').indexOf(this.lc.get('COUNTRY')) > -1 ||
                     app.options.get('facility_courier_countries_nde').indexOf(this.lc.get('COUNTRY')) > -1
                 ) {
                     if (this.terms.get('ACCEPTED')) {
-                        this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
-                        this.ui.acc_msg.text('Paid for by Facility')
-                        this.ui.facc.hide()
-                        this.ui.quote.hide()
-                        this.ui.submit.show()
-                        this.ui.termsq.hide()
-                        this.ui.terms.show()
-                        this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
+                        this.updateFormAsTermsAccepted()
                     } else {
                         this.ui.facc.show()
                     }
                 } else {
                     this.ui.facc.hide()
+
                 }
             }
         },

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -168,6 +168,8 @@ define(['backbone',
                     }
                 } else {
                     this.ui.facc.hide()
+                    this.ui.quote.show()
+                    this.ui.submit.hide()
                 }
             } else {
                 if (
@@ -181,7 +183,8 @@ define(['backbone',
                     }
                 } else {
                     this.ui.facc.hide()
-
+                    this.ui.quote.show()
+                    this.ui.submit.hide()
                 }
             }
         },

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -138,37 +138,59 @@ define(['backbone',
         _lcFields: ['PHONENUMBER', 'EMAILADDRESS', 'LABNAME', 'ADDRESS', 'CITY', 'POSTCODE','COUNTRY', 'GIVENNAME', 'FAMILYNAME'],
 
         toggleFacilityCourier: function() {
-            const shipmentCountry = this.ui.shipmentCountry.val();
-            if (
-                app.options.get("shipping_service_app_url_incoming") && (
-                    app.options.get('facility_courier_countries').indexOf(shipmentCountry) > -1
-                    || app.options.get('facility_courier_countries_nde').indexOf(shipmentCountry) > -1
-                )
-            ) {
-                if (this.terms.get('ACCEPTED')) {
-                    this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
-                    this.ui.acc_msg.text('Paid for by Facility')
-                    this.ui.facc.hide()
-                    this.ui.quote.hide()
-                    this.ui.submit.show()
-                    this.ui.termsq.hide()
-                    this.ui.terms.show()
-                    this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
-                    this.setPickupDetailsRequired(false)
-                    this.setEmailRequired(false)
-                    this.ui.createAWBForm.hide()
-                    this.ui.submit.text("Proceed")
+
+            if (app.options.get("shipping_service_app_url_incoming")) {
+                const shipmentCountry = this.ui.shipmentCountry.val();
+                if (
+                        app.options.get('facility_courier_countries').indexOf(shipmentCountry) > -1
+                        || app.options.get('facility_courier_countries_nde').indexOf(shipmentCountry) > -1
+                ) {
+                    if (this.terms.get('ACCEPTED')) {
+                        this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
+                        this.ui.acc_msg.text('Paid for by Facility')
+                        this.ui.facc.hide()
+                        this.ui.quote.hide()
+                        this.ui.submit.show()
+                        this.ui.termsq.hide()
+                        this.ui.terms.show()
+                        this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
+                        this.setPickupDetailsRequired(false)
+                        this.setEmailRequired(false)
+                        this.ui.createAWBForm.hide()
+                        this.ui.submit.text("Proceed")
+                    } else {
+                        this.ui.facc.show()
+                        this.ui.createAWBForm.show()
+                        this.setPickupDetailsRequired(true)
+                        this.setEmailRequired(true)
+                    }
                 } else {
-                    this.ui.facc.show()
+                    this.ui.facc.hide()
                     this.ui.createAWBForm.show()
                     this.setPickupDetailsRequired(true)
                     this.setEmailRequired(true)
                 }
+
             } else {
-                this.ui.facc.hide()
-                this.ui.createAWBForm.show()
-                this.setPickupDetailsRequired(true)
-                this.setEmailRequired(true)
+                if (
+                    app.options.get('facility_courier_countries').indexOf(this.lc.get('COUNTRY')) > -1 ||
+                    app.options.get('facility_courier_countries_nde').indexOf(this.lc.get('COUNTRY')) > -1
+                ) {
+                    if (this.terms.get('ACCEPTED')) {
+                        this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
+                        this.ui.acc_msg.text('Paid for by Facility')
+                        this.ui.facc.hide()
+                        this.ui.quote.hide()
+                        this.ui.submit.show()
+                        this.ui.termsq.hide()
+                        this.ui.terms.show()
+                        this.shipment.validation.DELIVERYAGENT_AGENTCODE.required = false
+                    } else {
+                        this.ui.facc.show()
+                    }
+                } else {
+                    this.ui.facc.hide()
+                }
             }
         },
 
@@ -282,7 +304,7 @@ define(['backbone',
         
         onRender: function() {
             this.$el.hide()
-            this.ui.createAWBForm.hide()
+            this.ui.createAWBForm.show()
             this.ui.facc.hide()
             this.ui.submit.hide()
             this.ui.qwrap.hide()

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -140,8 +140,10 @@ define(['backbone',
         toggleFacilityCourier: function() {
             const shipmentCountry = this.ui.shipmentCountry.val();
             if (
-                app.options.get('facility_courier_countries').indexOf(shipmentCountry) > -1
-                || app.options.get('facility_courier_countries_nde').indexOf(shipmentCountry) > -1 
+                app.options.get("shipping_service_app_url_incoming") && (
+                    app.options.get('facility_courier_countries').indexOf(shipmentCountry) > -1
+                    || app.options.get('facility_courier_countries_nde').indexOf(shipmentCountry) > -1
+                )
             ) {
                 if (this.terms.get('ACCEPTED')) {
                     this.$el.find('.DELIVERYAGENT_AGENTCODE').hide()
@@ -493,7 +495,7 @@ define(['backbone',
                 success: function(resp) {
                     if (
                         app.options.get("shipping_service_app_url_incoming")
-                        && (Number(self.terms.get('ACCEPTED')) === 1) // terms.ACCPETED could be undefined, 1, or "1"
+                        && (Number(self.terms.get('ACCEPTED')) === 1) // terms.ACCEPTED could be undefined, 1, or "1"
                         && app.options.get("facility_courier_countries").includes(self.ui.shipmentCountry.val())
                     ) {
                         self.shipment.fetch().done((shipment) => {

--- a/client/src/js/templates/shipment/createawb.html
+++ b/client/src/js/templates/shipment/createawb.html
@@ -12,7 +12,7 @@
             <span class="DEWARS floated"></span>
         </li>
     
-        <li>
+        <li class="countrySelect">
             <span class="label">Country
                 <br />
                 <span class="small">The country the shipment is being sent from</span>

--- a/client/src/js/templates/shipment/createawb.html
+++ b/client/src/js/templates/shipment/createawb.html
@@ -12,14 +12,11 @@
             <span class="DEWARS floated"></span>
         </li>
     
-        <li class="countrySelect">
-            <span class="label">Country
-                <br />
-                <span class="small">The country the shipment is being sent from</span>
-            </span>
-            <select name="SHIPMENTCOUNTRY"></select>
+        <li>
+            <span class="label">Laboratory Country</span>
+            <span class="COUNTRY"></span> <span class="free"></span>
         </li>
-    
+
         <li>
             <span class="label">DHL Account Number</span>
             <span class="DELIVERYAGENT_AGENTCODE"><%-DELIVERYAGENT_AGENTCODE%></span> <a href="#" class="facc button"><i class="fa fa-envelope"></i> Use Facility Account</a> <span class="acc_msg"></span>
@@ -91,10 +88,6 @@
             <span class="POSTCODE"></span>
         </li>
 
-        <li>
-            <span class="label">Laboratory Country</span>
-            <span class="COUNTRY"></span> <span class="free"></span>
-        </li>
     </ul>
 </div>
         

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -28,13 +28,16 @@
                 <label>Email Address<span class="small">The contact email for the Dewar return</span></label>
                 <input type="email" name="EMAILADDRESS" data-testid="dispatch-email-address"/>
             </li>
-            <li>
-                <label>Destination country
-                    <span class="small">The country the Dewar is being dispatched to</span>
-                </label>
-                <select name="DISPATCHCOUNTRY"></select>
-            </li>
 
+            <li>
+                <label>Laboratory Country
+                    <span class="small">The contact's laboratory country</span>
+                </label>
+                <select name="COUNTRY" data-testid="dispatch-lab-country">
+                    <option value="United Kingdom">United Kingdom</option>
+                    <option value="Other">Other</option>
+                </select>
+            </li>
         </ul>
         <ul class="courierSection">
             
@@ -158,16 +161,6 @@
                     <span class="small">Laboratory Post Code</span>
                 </label>
                 <input type="text" name="POSTCODE" data-testid="dispatch-post-code"/>
-            </li>
-
-            <li>
-                <label>Laboratory Country
-                    <span class="small">The contact's laboratory country</span>
-                </label>
-                <select name="COUNTRY" data-testid="dispatch-lab-country">
-                    <option value="United Kingdom">United Kingdom</option>
-                    <option value="Other">Other</option>
-                </select>
             </li>
 
              <li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1342](https://jira.diamond.ac.uk/browse/LIMS-1342)

**Summary**:

[ULIMS-50](https://jira.diamond.ac.uk/browse/ULIMS-50) introduced changes to the create AWB form. These changes should have no effect if 
`$use_shipping_service_redirect_incoming_shipments = False;`
in config.php.

**Changes**:
- Add a condition on `shipping_service_app_url_incoming`, which depends on `$use_shipping_service_redirect_incoming_shipments`

**To test**:
- Set `$use_shipping_service_redirect_incoming_shipments = false;`, then
    - create a shipment from the UK, click Create DHL Air Waybill, check a full form appears, with Get Quote at the bottom
    - click Use Facility Account, check the form stays, but Get Quote changes to Create Air Waybill
    - create a shipment from Aruba, click Create DHL Air Waybill, check a full form appears, with Get Quote at the bottom
    - check the Use Facility Account button is hidden
 - Set `$use_shipping_service_redirect_incoming_shipments = true;` and `$shipping_service_app_url = "something.diamond.ac.uk";`, then
    - create a shipment from the UK, click Create DHL Air Waybill, check a full form appears, and also a dropdown with options for UK or other
    - click Use Facility Account, check the form disappears, leaving only a Proceed button
    - create a shipment from Aruba, click Create DHL Air Waybill, check a full form appears, with Get Quote at the bottom
    - check the Use Facility Account button is hidden