### PR TITLE
LIMS-1319: Show dose for all data collection types

### DIFF
--- a/client/src/js/templates/dc/dc.html
+++ b/client/src/js/templates/dc/dc.html
@@ -26,13 +26,11 @@
         <li data-testid="dc-resolution">Resolution: <%-RESOLUTION%>&#197;</li>
         <li data-testid="dc-wavelength">Wavelength: <%-WAVELENGTH%>&#197;</li>
         <li data-testid="dc-exposure-time">Exposure: <%-EXPOSURETIME%>s</li>
-        <% if (DCT == 'SAD' || DCT == 'OSC' || DCT == 'Diamond Anvil High Pressure') { %>
-            <%if (TOTALABSDOSE) { %>
-                <%if (DCC > 1) { %>
-                <li data-testid="dc-dose">Total Dose:  <%-TOTALDOSE%>MGy</li>
-                <% } else { %>
-                <li data-testid="dc-dose">Dose:  <%-TOTALABSDOSE%>MGy</li>
-        <% } } }%>
+        <%if (DCC > 1 && TOTALDOSE) { %>
+            <li data-testid="dc-dose">Total Dose:  <%-TOTALDOSE%>MGy</li>
+        <% } else if (DCC == 1 && TOTALABSDOSE) { %>
+            <li data-testid="dc-dose">Dose:  <%-TOTALABSDOSE%>MGy</li>
+        <% } %>
         <li data-testid="dc-transmission">Transmission: <%-TRANSMISSION%>%</li>
         <li data-testid="dc-beam-size">Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         <li data-testid="dc-type">Type: <% if (DCT) print(DCT) %></li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1319](https://jira.diamond.ac.uk/browse/LIMS-1319)

**Summary**:

Dose (or total dose) is only shown for some data collection types. We should show it for all, when a value is in the database.

**Changes**:
- Remove check for DC type

**To test**:
- View a characterisation eg /dc/visit/au34221-5/id/13769997, check Dose is displayed (1.00 MGy)
- View an OSC experiment eg /dc/visit/au34221-5/id/13770015, check Dose is displayed
- View a visit with data collection groups, eg /dc/visit/mx34263-56, check Total Dose is displayed
- View a DC without a dose eg /dc/visit/mx23694-117, check no dose is displayed
