### PR TITLE
LIMS-1355: Make OAuth2 support more generic

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -32,7 +32,9 @@
 
     # Follow CAS SSO
     $cas_sso = true;
-    $sso_url = "sso.server.ac.uk";
+    $sso_url = "https://sso.server.ac.uk";
+    # Profile field to use to identify user
+    $sso_user_key = "fedid";
 
     # OIDC (or OAuth2) client ID and secret. Only useful if authentication_type is set to OIDC
     $oidc_client_id = "oidcClientId";

--- a/api/src/Authentication/Type/OIDC.php
+++ b/api/src/Authentication/Type/OIDC.php
@@ -16,7 +16,7 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
         if (is_null($this->providerConfigCache)) {            
 
             $ch = curl_init();
-            curl_setopt($ch, CURLOPT_URL, 'https://' . $sso_url . '/.well-known/openid-configuration');
+            curl_setopt($ch, CURLOPT_URL, $sso_url);
             curl_setopt($ch, CURLOPT_HEADER, 0);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             $response = curl_exec($ch);
@@ -41,6 +41,8 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
 
     private function getUser($token)
     {        
+        global $sso_user_key;
+        
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $this->getProviderConfig()->userinfo_endpoint);
         curl_setopt($ch, CURLOPT_HEADER, 0);
@@ -49,12 +51,12 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
         $response = curl_exec($ch);
         curl_close($ch);
         
-        $response_json = json_decode($response);
-        if (!$response_json || !isset($response_json->id)) {
+        $response_json = json_decode($response, true);
+        if (!$response_json || !isset($response_json[$sso_user_key])) {
             return false;
         }
 
-        return $response_json->id;
+        return $response_json[$sso_user_key];
     }
 
     function authenticate($login, $password) 
@@ -80,7 +82,8 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
 
         return ( $this->getProviderConfig()->authorization_endpoint . 
             '?response_type=code&client_id=' . $oidc_client_id . 
-            '&redirect_uri=' . $redirect_url
+            '&redirect_uri=' . urlencode($redirect_url) .
+            '&scope=openid'
         );
     }
 
@@ -89,16 +92,22 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
         global $cacert, $oidc_client_secret, $oidc_client_id, $cookie_key;
 
         $redirect_url = Utils::filterParamFromUrl($_SERVER["HTTP_REFERER"], "code");
-        
+        $redirect_url = Utils::filterParamFromUrl($redirect_url, "iss");
+        $redirect_url = Utils::filterParamFromUrl($redirect_url, "session_state");
+
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->getProviderConfig()->token_endpoint . 
-            '?grant_type=authorization_code&redirect_uri=' . 
-            $redirect_url . 
-            "&code=" . $code
-        );
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . $this->getProviderConfig()->b64ClientCreds));
+        curl_setopt_array ( $ch, array (
+            CURLOPT_URL => $this->getProviderConfig()->token_endpoint,
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_HEADER => 0,
+            CURLOPT_POST => 1,
+            CURLOPT_POSTFIELDS => array (
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => $redirect_url
+            ),
+            CURLOPT_HTTPHEADER => array('Authorization: Basic ' . $this->getProviderConfig()->b64ClientCreds)
+        ) );
         $response = curl_exec($ch);
         curl_close($ch);
    

--- a/api/src/Utils.php
+++ b/api/src/Utils.php
@@ -34,6 +34,6 @@ class Utils
     {
         // Removes search parameter from URL and returns encoded URL
         $redirect_url = preg_replace('/(&|\?)'.preg_quote($param).'=[^&]*$/', '', $url);
-        return urlencode(preg_replace('/(&|\?)'.preg_quote($param).'=[^&]*&/', '$1', $redirect_url));
+        return preg_replace('/(&|\?)'.preg_quote($param).'=[^&]*&/', '$1', $redirect_url);
     }
 }

--- a/client/src/js/app/views/login.vue
+++ b/client/src/js/app/views/login.vue
@@ -3,7 +3,7 @@
     <hero-title v-show="!skipHome" />
 
     <h1>Login</h1>
-    <p v-if="sso && !authError" class="tw-text-center tw-text-lg">Redirecting to CAS single sign on...</p>
+    <p v-if="sso && !authError" class="tw-text-center tw-text-lg">Redirecting to single sign on...</p>
     <p v-if="authError === 'not-recognised'" class="tw-text-center tw-text-lg">
       <b>User not recognised</b>. If you have logged in with your email address,
       <a :href="logoutUrl" target="_blank">log out of the SSO provider</a> and <a href="/login">log in</a> again with


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1355](https://jira.diamond.ac.uk/browse/LIMS-1355)

**Summary**:

Currently, support for OAuth2 code flow in the OIDC authentication type is tailored to CAS. In order to enable Keycloak compatibility, it must be configurable, down to the claim used for identifying users, as well as ensuring the whole process is not specific to one or other CAS quirk.

*NOTE:* This requires configuration changes to SynchWeb when being deployed. Do not merge this in before altering the configuration to provide a full path (including protocol) for `$sso_url` and adding `$sso_user_key` to the configuration file with the value `id`.

**Changes**:
- Added new configuration key, `$sso_user_key`, allowing deployer to set which one of the claims returned from the upstream auth service will be used for identification (example: `fedid`)
- `$sso_url` now takes the full absolute path to the endpoint descriptor endpoint in the upstream authentication service
- Internal changes to code flow to support Keycloak and other SSO providers

**To test**:
- Add valid client ID/secret to config, set `$cas_sso` to true, set the authentication type to OIDC, and try to log in with either CAS or Keycloak
- Go to a protected page (e.g.: `proposals`) and try to log in, verify that the redirect occurs
