### PR TITLE
LIMS-277: Fix sample changer view scaling

### DIFF
--- a/client/src/js/modules/dc/views/samplechanger.js
+++ b/client/src/js/modules/dc/views/samplechanger.js
@@ -69,7 +69,7 @@ define(['marionette', 'utils/canvas', 'utils',
             this.rpad = 0 //pad - 25
             
             var sw = 18
-            this.aspectratio = (sw/this.positions) - (this.positions <= 10 ? 0.3 : 0)
+            this.aspectratio = (this.positions <= 10 ? 1.5 : 0.4)
             this.contwidth = (this.positions * sw) + this.pad + this.rpad + 15
             console.log('sc width', this.contwidth, this.aspectratio)
             if (!this.getOption('fullScreen')) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-277](https://jira.diamond.ac.uk/browse/LIMS-277)

**Summary**:

The sample changer view (/dc/sc/visit/<visit>) scales weirdly, depending on the number of pucks available on the beamline.

**Changes**:
- Force one of two possible aspect ratios, either 1.5 (10 pucks or less) or 0.4 (more than 10 pucks)

**To test**:
- Set up 3 beamlines in config.json with 10, 14 and 37 pucks, eg:
```
        "pucks": {
                "i03": 37,
                "i19-1": 14,
                "i19-2": 10
        },
```
- Go to a visit on each beamline, and click on the Sample Changer view, eg /dc/sc/visit/cm37235-3
- Check the view looks reasonable with each number of pucks. If 10 pucks or less, the sample changer view is smaller, if more than 10 pucks, the view should be full width.
- Go back to the visit, if there is a roll out sample changer view from the right hand side of the screen, check that looks ok (appears to be MX, live visits, only)