### PR TITLE
LIMS-1240: Dont use shortComments LIKE 'EDNA%'

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -818,7 +818,7 @@ class Sample extends Page
                 LEFT OUTER JOIN screening sc ON dc.datacollectionid = sc.datacollectionid
                 LEFT OUTER JOIN screeningoutput so ON sc.screeningid = so.screeningid
                 
-                LEFT OUTER JOIN screeningstrategy st ON st.screeningoutputid = so.screeningoutputid AND sc.shortcomments LIKE '%EDNA%'
+                LEFT OUTER JOIN screeningstrategy st ON st.screeningoutputid = so.screeningoutputid AND sc.programversion = 'EDNA MXv1'
                 LEFT OUTER JOIN screeningstrategywedge ssw ON ssw.screeningstrategyid = st.screeningstrategyid
                 
                 LEFT OUTER JOIN autoprocintegration ap ON ap.datacollectionid = dc.datacollectionid
@@ -1208,7 +1208,7 @@ class Sample extends Page
                                   LEFT OUTER JOIN screening sc ON dc.datacollectionid = sc.datacollectionid
                                   LEFT OUTER JOIN screeningoutput so ON sc.screeningid = so.screeningid
                                   
-                                  LEFT OUTER JOIN screeningstrategy st ON st.screeningoutputid = so.screeningoutputid AND sc.shortcomments LIKE '%EDNA%'
+                                  LEFT OUTER JOIN screeningstrategy st ON st.screeningoutputid = so.screeningoutputid AND sc.programVersion = 'EDNA MXv1'
                                   LEFT OUTER JOIN screeningstrategywedge ssw ON ssw.screeningstrategyid = st.screeningstrategyid
                                   
                                   LEFT OUTER JOIN autoprocintegration ap ON ap.datacollectionid = dc.datacollectionid

--- a/api/src/Page/Stats.php
+++ b/api/src/Page/Stats.php
@@ -260,8 +260,12 @@ class Stats extends Page
             
             $t = $this->has_arg('t') ? $this->arg('t') : 'ai';
             
-            if (array_key_exists($t, $types)) $this->$types[$t]();
-            else $this->_error('No such stat type');                 
+            if (array_key_exists($t, $types)) {
+                $func = $types[$t];
+                $this->$func();
+            } else {
+                $this->_error('No such stat type');
+            }
         }
                                  
                                  
@@ -275,7 +279,7 @@ class Stats extends Page
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                 INNER JOIN blsession ses ON ses.sessionid = dcg.sessionid
                 INNER JOIN v_run vr ON (ses.startdate BETWEEN vr.startdate AND vr.enddate)
-                WHERE s.shortcomments LIKE 'EDNA%' AND TIMESTAMPDIFF('SECOND', dc.endtime, s.bltimestamp) < 10000
+                WHERE s.shortcomments LIKE 'Strategy%' AND TIMESTAMPDIFF('SECOND', dc.endtime, s.bltimestamp) between 0 and 10000
                 AND ses.beamlinename in ('$bls')
                 GROUP BY s.shortcomments, vr.run
                 ORDER BY vr.run


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1240](https://jira.diamond.ac.uk/browse/LIMS-1240)

**Summary**:

We no longer populate the Screening.shortComments with 'EDNA Strategy 1', instead we just use 'Strategy 1'. Using the program version is more generic for getting any EDNA strategy, or use 'Strategy%' when comparing EDNA strategies.

**Changes**:
- Use programVersion instead of shortComments to search for EDNA results
- Fix accessing pipeline stats
- Search for 'Strategy%' instead of 'EDNA%' in pipeline stats, which has been used since 2018.

**To test**:
- Go to a container with samples that have been screened, eg /containers/cid/301095, inspect the GET to /api/sample, check that some of the samples have non-null values for SCRESOLUTION and SCCOMPLETENESS
- Go to Stats, then Pipeline Stats (this should take you to /statistics/pl). Check some average processing times appear for the last few years, for different strategies.
