### PR TITLE
LIMS-1371, LIMS-1372: Add search and 'My Groups' to Sample Groups page

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -143,6 +143,7 @@ class Sample extends Page
         'SCREENINGMETHOD' => '\w+',
         'SCREENINGCOLLECTVALUE' => '\d+',
         'SAMPLEGROUP' => '\d+',
+        'currentuser' => '\d',
         'INITIALSAMPLEGROUP' => '\d+',
         'STRATEGYOPTION' => '',
         'MINIMUMRESOLUTION' => '\d+(.\d+)?',
@@ -2578,6 +2579,16 @@ class Sample extends Page
         $from_table = '';
         $group_by = '';
 
+        if ($this->has_arg('currentuser') && $this->arg('currentuser') == 1) {
+            $where .= ' AND bsg.ownerid = :' . (sizeof($args) + 1);
+            array_push($args, $this->user->personId);
+        }
+        if ($this->has_arg('s')) {
+            $st = sizeof($args) + 1;
+            $where .= " AND bsg.name LIKE CONCAT('%',:" . $st . ",'%')";
+            array_push($args, $this->arg('s'));
+        }
+
         // Check if we are grouping the result by BlSAMPLEID or BLSAMPLEGROUPID.
         // This is currently being used by xpdf when fetching the list of sample group samples.
         if ($this->has_arg('groupSamplesType') && $this->arg('groupSamplesType') === 'BLSAMPLEGROUPID') {
@@ -2660,7 +2671,8 @@ class Sample extends Page
     function _create_sample_group()
     {
         $name = $this->has_arg('NAME') ? $this->arg('NAME') : NULL;
-        $this->db->pq("INSERT INTO blsamplegroup (blsamplegroupid, name, proposalid) VALUES(NULL, :1, :2)", array($name, $this->proposalid));
+        $this->db->pq("INSERT INTO blsamplegroup (blsamplegroupid, name, proposalid, ownerid) VALUES(NULL, :1, :2, :3)",
+            array($name, $this->proposalid, $this->user->personId));
         return $this->db->id();
     }
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1371](https://jira.diamond.ac.uk/browse/LIMS-1371)
**JIRA ticket**: [LIMS-1372](https://jira.diamond.ac.uk/browse/LIMS-1372)

**Summary**:

The sample groups page needs 2 new features:

1. The ability to search sample groups by name
2. The ability to only show sample groups created by the current user

**Changes**:
- Record the current user in the new BLSampleGroup.ownerId field (when deployed)
- Add a new query parameters for filtering by current user, and adjust the WHERE part of the query to match
- Add a new query parameter for the search text, and adjust the WHERE part of the query to match
- Add a checkbox at the top left for filtering by the current user
- Add a search box to the top right for searching by name
- Put a watch (and debounce) on the search box to make it respond quickly

**To test**:
- Make sure the BLSampleGroup.ownerId field has been deployed to prod before approving this PR
- Log into a proposal with existing groups eg mx23694, and make a new sample group
- Go to sample group management (/samples/groups), filter by "My Sample Groups" and check the new group shows.
- Uncheck the box, check all groups show
- Check the search field behaves as expected, including when cleared
- Check an instance of an xpdf sample (eg /instances/sid/5234805) to check it stills shows as expected, as they use the same endpoint
