### PR TITLE
LIMS-1379: Grid scan heatmaps are not snaked correctly

### DIFF
--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -373,7 +373,7 @@ class Download extends Page
 
             $r['FILEFULLPATH'] = preg_replace('/.*\/' . $r['VISIT'] . '\//', '', $r['FILEFULLPATH']);
 
-            foreach (array('DX_MM', 'DY_MM', 'STEPS_X', 'STEPS_Y') as $k) {
+            foreach (array('DX_MM', 'DY_MM', 'STEPS_X', 'STEPS_Y', 'SNAKED') as $k) {
                 $r[$k] = floatval($r[$k]);
             }
         }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1379](https://jira.diamond.ac.uk/browse/LIMS-1379)

**Summary**:

You can view heatmaps for grid scans on plates via the container view, eg https://ispyb.diamond.ac.uk/containers/cid/295986 well 3. But the snaked parameter is being ignored, so alternate rows of the grid scan are flipped from what they should be. This creates a stripy and mirrored effect.

![image](https://github.com/DiamondLightSource/SynchWeb/assets/24956497/d1502958-5ac9-486e-b47d-89b3cb065c9d)


**Changes**:
- Convert the SNAKED parameter to a number, as the javascript checks for `=== 1` (see [here](https://github.com/DiamondLightSource/SynchWeb/blob/master/client/src/js/modules/imaging/views/imageviewer.js#L1176))
  - Could also have changed the javascript but this way is consistent with other fields.

**To test**:
- Go to /containers/cid/295986 well 3, check the stripy and mirrored effect is gone

![image](https://github.com/DiamondLightSource/SynchWeb/assets/24956497/5143da61-dc3c-42aa-a206-05ff3f73cdef)
