### PR TITLE
LIMS-1369: Make fault report titles editable

### DIFF
--- a/client/src/js/templates/fault/view.html
+++ b/client/src/js/templates/fault/view.html
@@ -1,4 +1,4 @@
-    <h1><span class="title"><%-TITLE%></span></h1>
+    <h1><span class="TITLE"><%-TITLE%></span></h1>
 
     <div class="form">
         <ul class="clearfix">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1369](https://jira.diamond.ac.uk/browse/LIMS-1369)

**Summary**:

Fault report titles should be editable

**Changes**:
- Match the class of the title span to the editable created in modules/fault/views/view.js

**To test**:
- Go to a fault report, edit the title.
- Check it won't let you leave a blank title
- Check you can add a new fault report
