### PR TITLE
LIMS-1368: Fix incorrectly summed dose for DC groups when filtered

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -574,7 +574,7 @@ class DC extends Page
                     max(dc.c2lens) as c2lens,
                     max(dc.objaperture) as objaperture,
                     max(dc.magnification) as magnification,
-                    sum(dc.totalabsorbeddose) as totaldose,
+                    dose.total as totaldose,
                     CAST(dc.totalabsorbeddose AS DECIMAL(5, 2)) as totalabsdose,
                     max(d.detectormanufacturer) as detectormanufacturer,
                     max(d.detectormodel) as detectormodel,
@@ -659,6 +659,9 @@ class DC extends Page
                 SELECT $extcg $fields 
                 FROM datacollection dc
                 INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
+                INNER JOIN (
+                    select datacollectiongroupid, sum(totalabsorbeddose) as total from datacollection group by datacollectiongroupid) dose
+                    ON dc.datacollectiongroupid = dose.datacollectiongroupid
                 INNER JOIN blsession ses ON ses.sessionid = dcg.sessionid
                 $sample_joins[0]
                 LEFT OUTER JOIN datacollectioncomment dcc ON dc.datacollectionid = dcc.datacollectionid


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1368](https://jira.diamond.ac.uk/browse/LIMS-1368)

**Summary**:

When data collection groups are shown, the total dose is displayed by summing the dose for each data collection. But when you filter the view by "Auto Integrated", the extra joins to AutoProcIntegration etc mean extra rows are summed.

**Changes**:
- Join to a subquery of simply dataCollectionGroupId and sum(totalAbsorbedDose) for each data collection group
- Use the number from the subquery

**To test**:
- Go to /samples/sid/5653602, look at the first data collection, the Total Dose should be 21.75MGy
- Click the Auto Integrated filter, the total dose should not change
- Check the same is true for the Data Collections and Full Collections filters
- Go to /samples/sid/5653041 and check the Phasing filter
- Go to /dc/visit/mx35120-12, look at the top data collection, check the Total Dose doesn't change with the Auto Integrated filter on/off
- Go to /dc/visit/mx35120-12/dcg/12149523, check the dose for each data collection says 10.88MGy and doesn't change with the Auto Integrated filter on/off
