### PR TITLE
LIMS-1370: Handle errors from the shipping service

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1113,7 +1113,7 @@ class Shipment extends Page
             $shipment_id = $response['shipmentId'];
             $this->shipping_service->dispatch_shipment($shipment_id, false);
         } catch (Exception $e) {
-            throw new Exception("Error returned from shipping service: " . $e . "\nShipment data: " . json_encode($shipment_data));
+            throw new Exception($e->getMessage());
         }
 
         return $shipment_id;
@@ -1226,12 +1226,13 @@ class Shipment extends Page
                 } else {
                     try {
                         $shipment_id = $this->_dispatch_dewar_in_shipping_service($data, $dew);
+                        if (Utils::getValueOrDefault($shipping_service_links_in_emails)) {
+                            $data['AWBURL'] = $this->shipping_service->get_awb_pdf_url($shipment_id);
+                        }
                     } catch (Exception $e) {
-                        error_log($e);
-                        $data['AWBURL'] = "";
-                    }
-                    if (Utils::getValueOrDefault($shipping_service_links_in_emails)) {
-                        $data['AWBURL'] = $this->shipping_service->get_awb_pdf_url($shipment_id);
+                        $error_json = json_decode($e->getMessage());
+                        $error_response = $error_json->detail;
+                        $this->_error($error_response, 400);
                     }
                 }
             }

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1230,8 +1230,9 @@ class Shipment extends Page
                             $data['AWBURL'] = $this->shipping_service->get_awb_pdf_url($shipment_id);
                         }
                     } catch (Exception $e) {
+                        error_log($e);
                         $error_json = json_decode($e->getMessage());
-                        $error_response = $error_json->content->detail;
+                        $error_response = $error_json->content->detail ?? $e->getMessage();
                         $error_status = $error_json->status ? $error_json->status : 400;
                         $this->_error($error_response, $error_status);
                     }

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1231,8 +1231,9 @@ class Shipment extends Page
                         }
                     } catch (Exception $e) {
                         $error_json = json_decode($e->getMessage());
-                        $error_response = $error_json->detail;
-                        $this->_error($error_response, 400);
+                        $error_response = $error_json->content->detail;
+                        $error_status = $error_json->status ? $error_json->status : 400;
+                        $this->_error($error_response, $error_status);
                     }
                 }
             }

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -93,7 +93,7 @@ class ShippingService
                 "Response: " . json_encode($response) . PHP_EOL .
                 "Request data:" . json_encode($data)
             );
-            throw new \Exception(json_encode($response));
+            throw new \Exception(json_encode(array('status' => $status_code, 'content' => $response)));
         }
         return $response;
     }

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -93,7 +93,7 @@ class ShippingService
                 "Response: " . json_encode($response) . PHP_EOL .
                 "Request data:" . json_encode($data)
             );
-            throw new \Exception(json_encode(array('status' => $status_code, 'content' => $response)));
+            throw new \Exception(json_encode($response));
         }
         return $response;
     }

--- a/api/src/Shipment/ShippingService.php
+++ b/api/src/Shipment/ShippingService.php
@@ -56,7 +56,7 @@ class ShippingService
             array(
                 CURLOPT_RETURNTRANSFER => TRUE,
                 CURLOPT_HTTPHEADER => $base_headers,
-                CURLOPT_TIMEOUT => 5
+                CURLOPT_TIMEOUT => 10
             )
         );
         switch ($type) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1370](https://jira.diamond.ac.uk/browse/LIMS-1370)

**Summary**:

With `$use_shipping_service = True;` but `$use_shipping_service_redirect = False;`, if the shipping service returns an error, we should display the message detail in Synchweb.

**Changes**:
- Dont try and get the AWB number if there was an error from the shipping service
- Pass the error message back to the GUI as a JSON encoded string, so it appears in the GUI

**To test**:
- NB this is a user dewar so only test on backup db, without sending emails
- Set `$use_shipping_service = True;` but `$use_shipping_service_redirect = False;`
- Go to a shipment that has already been dispatched by the shipping service, eg /shipments/sid/60942
- Click on the little house icon to request the dewar be returned, click "Request Dewar Dispatch"
- Check if a "friendly" message appears at the top of the page, saying "Cannot update a shipment that has already been dispatched"
- Go to a shipment that has not been dispatched eg /shipments/sid/63609, repeat the test, check it all works this time and appears on sample-shipping-staging.
