### PR TITLE
LIMS-14: Show a direct link to the autoprocessing log

### DIFF
--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -22,6 +22,7 @@
         </a>
         <% } %>
 
+        <a class="mainlog button dll" href="<%-APIURL%>/download/ap/log/<%-AID%>"><i class="fa fa-file"></i> Processing Log</a>
         <a class="plot button" href="#"><i class="fa fa-line-chart"></i> Plots</a>
         <a class="view button dll" href="<%-APIURL%>/download/ap/archive/<%-AID%>"><i class="fa fa-archive"></i> Archive</a>
         <a class="apattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-14](https://jira.diamond.ac.uk/browse/LIMS-14)

**Summary**:

Currently it takes 2 clicks to see the processing log, via the "Logs & Files" button. We should add a direct link. We can use the importanceRank field to find the most important file of type 'log'.

**Changes**:
- Add a new button to successful autoprocessing jobs saying "Processing Log".
- Download the first attachment of type 'log' and importanceRank '1'.
- Sort other attachments by importanceRank first, then alphabetically, instead of random.

**To test**:
- Go to a visit, look for a successful fast_dp run, click the "Processing Log" button, check it displays the fast_dp-report.html file
- Repeat the check for other processing pipelines
- Check no button appears for unsuccessful processing jobs
- Check no changes to downstream processing display
- Click on "Logs & Files", check the first files are those with importanceRank 1 (eg fast_dp-report.html, fast_dp.mtz), then the rest are listed alphabetically.
