### PR TITLE
LIMS-1350: Display crystal snapshots even if zipped

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -963,7 +963,7 @@ class DC extends Page
                 $dc['VIS'] = $this->arg('prop') . '-' . $dc['VN'];
 
             foreach (array('X1', 'X2', 'X3', 'X4') as $x) {
-                $dc[$x] = file_exists($dc[$x]) ? 1 : 0;
+                $dc[$x] = file_exists($dc[$x]) || file_exists($dc[$x].'.gz') ? 1 : 0;
             }
 
             // Data collections
@@ -1081,8 +1081,9 @@ class DC extends Page
             $sn = 0;
             $images = array();
             foreach (array('X1', 'X2', 'X3', 'X4') as $j => $im) {
-                array_push($images, file_exists($dc[$im]) ? 1 : 0);
-                if ($im == 'X1' && file_exists($dc[$im]))
+                $exists = file_exists($dc[$im]) || file_exists($dc[$im].'.gz');
+                array_push($images, $exists ? 1 : 0);
+                if ($im == 'X1' && $exists)
                     $sn = 1;
                 unset($dc[$im]);
             }

--- a/api/src/Page/Image.php
+++ b/api/src/Page/Image.php
@@ -162,7 +162,10 @@ class Image extends Page
                     $this->_browser_cache();
                     $this->app->contentType('image/'.$ext);
                     readfile($images[$n]);
-
+                } else if (file_exists($images[$n].'.gz')) {
+                    $this->_browser_cache();
+                    $this->app->contentType('image/'.$ext);
+                    readgzfile($images[$n].'.gz');
                 } else {
                     $this->_error('Not found', 'That image is no longer available');
                 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1350](https://jira.diamond.ac.uk/browse/LIMS-1350)

**Summary**:

Some crystal snapshots have been zipped (as .gz) on disk. They should still be viewable.
(NB this is not to do with diffraction images)

**Changes**:
- Check for .gz files when saying whether snapshots exist
- Serve up zipped files if only they exist

**To test**:
- Go to a data collection where the snapshots have been zipped, eg /dc/visit/lb18145-238/id/8295770 (snapshots at /dls/i03/data/2022/lb18145-238/jpegs/TestProteinaseK/ProtK-x0638/ProtK-x0638_1_1_*.png.gz)
- Check thumbnail snapshot appears, and when clicked, all 4 full size images are viewable by pressing right arrow
- Check the images are cached in the browser if you scroll through them more than once
- Go to a recent data collection where the snapshots are not zipped, repeat the checks
