### PR TITLE
LIMS-700: Allow bulk editing of protein

### DIFF
--- a/client/src/js/modules/types/mx/samples/mx-puck-samples-table.vue
+++ b/client/src/js/modules/types/mx/samples/mx-puck-samples-table.vue
@@ -30,6 +30,7 @@
           option-value-key="key"
           :options="mappedEditableColumns"
           :value="selectedEditableColumn.key"
+          :isDisabled="disableUpdateSamples"
           outer-class="tw-mr-2"
           input-class="tw-h-8"
           @input="resetSelectedEditableColumn"
@@ -38,6 +39,7 @@
           :is="selectedEditableColumn.componentType"
           v-model="selectedFieldValue"
           :options="selectedEditableColumn.data"
+          :disabled="disableUpdateSamples"
           input-class="tw-h-8"
           outer-class="tw-mx-2 tw-h-full"
           option-text-key="text"
@@ -47,6 +49,7 @@
           name="submit"
           type="submit"
           :class="['button submit tw-mx-2 tw-text-base tw-px-4 tw-py-1 tw-h-8', invalid ? 'tw-border tw-border-red-500 tw-bg-red-500': '']"
+          :disabled="disableUpdateSamples"
           @click.prevent="onUpdateSamples"
         >
           Update Samples
@@ -176,6 +179,9 @@ export default {
     containerId: {
       type: [Number, String, undefined]
     },
+    disableUpdateSamples: {
+      type: Boolean
+    },
     invalid: {
       type: Boolean
     }
@@ -215,7 +221,7 @@ export default {
         data: '',
         inputType: 'text'
       },
-      updateSamplesFieldWithData: debounce(searchText => this.updateSelectedFieldValue(searchText), 1000),
+      updateSamplesFieldWithData: debounce(searchText => this.updateSelectedFieldValue(searchText), 200),
       currentModal: '',
       selectedSample: null,
       displayedModalTitle: ''
@@ -381,7 +387,16 @@ export default {
     },
     mappedEditableColumns() {
       const list = [...this.basicColumns, ...this.extraFieldsColumns, ...this.udcColumns].filter(column => !['STATUS', 'CELLS'].includes(column.key))
-      list.push({
+      list.push(
+      {
+        title: 'Protein Acronym',
+        key: 'PROTEINID',
+        className: '',
+        componentType: 'base-input-select',
+        data: this.greenProteinsList,
+        inputType: 'select'
+      },
+      {
         title: 'Sample Groups',
         key: 'SAMPLEGROUP',
         className: '',
@@ -446,7 +461,7 @@ export default {
         inputType: 'text'
       })
 
-      return sortBy(uniqBy(list, 'key'), 'key')
+      return sortBy(uniqBy(list, 'key'), 'title')
     },
   },
   watch: {

--- a/client/src/js/modules/types/mx/samples/sample-table-mixin.js
+++ b/client/src/js/modules/types/mx/samples/sample-table-mixin.js
@@ -52,6 +52,16 @@ export default {
           SAFETYLEVEL: item.SAFETYLEVEL
         }));
     },
+    greenProteinsList() {
+      return this.$proteins()
+        .filter(item =>
+          item.SAFETYLEVEL === "GREEN"
+        )
+        .map(item => ({
+          value: item.PROTEINID,
+          text: item.ACRONYM,
+        }));
+    },
     experimentKindList() {
       return this.$experimentKindList();
     },

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -172,6 +172,7 @@
           :container-id="containerId"
           :invalid="invalid"
           :currentlyEditingRow="editingSampleLocation"
+          :disableUpdateSamples="disableUpdateSamples"
           @update-editing-row="updateEditingSampleLocation"
           @save-sample="onSaveSample"
           @clone-sample="onCloneSample"
@@ -181,6 +182,7 @@
           @clone-container-column="onCloneColumn"
           @clone-container-row="onCloneRow"
           @bulk-update-samples="onUpdateSamples"
+          @disable-update-samples="disableUpdateSamples"
           @update-samples-with-sample-group="handleSampleFieldChangeWithSampleGroups"
           @save-sample-move="saveSampleMove"
         />
@@ -546,6 +548,7 @@ export default {
       }
     },
     async onUpdateSamples() {
+      this.disableUpdateSamples = true
       const containerId = this.containerId
       this.containerId = null
       await this.$nextTick()
@@ -558,11 +561,18 @@ export default {
         await this.loadSampleGroupInformation()
         await this.$store.commit('notifications/addNotification', {
           title: 'Samples Updated',
-          message: 'Sample has been successfully updated',
+          message: 'Sample(s) have been successfully updated',
           level: 'success'
         })
         this.$refs.containerForm.reset()
+      } else {
+        await this.$store.commit('notifications/addNotification', {
+          title: 'Error:',
+          message: 'Sample(s) have not been updated, please see the errors at the bottom of the page.',
+          level: 'error'
+        })
       }
+      this.disableUpdateSamples = false
     },
     updateEditingSampleLocation(value) {
       this.editingSampleLocation = value


### PR DESCRIPTION
**JIRA ticket**: [LIMS-700](https://jira.diamond.ac.uk/browse/LIMS-700)
**JIRA ticket**: [LIMS-691](https://jira.diamond.ac.uk/browse/LIMS-691)
**Github issue**: https://github.com/DiamondLightSource/SynchWeb/issues/552

**Summary**:

Improve the behaviour of the bulk editor.

**Changes**:
- Disable the bulk editor dropdown, textbox and submit button until the previous request has finished
- Shorten the debounce time on updating the samples to make the form respond quicker
- Add (green only) protein acronym to the fields that can be bulk edited
- Sort the fields alphabetically by name rather than "field name"
- Correct the message displayed when samples are updated successfully
- Add an error notification if samples are not updated

**To test**:
- Make a new puck with some samples in, save it, and then view it
- Check the bulk editor appears with the dropdown in alphabetical order (ie Barcode before Cell A)
- Select Comment and type a new comment, check it appears promptly next to each sample
- Open the dev tools, click the Update Samples button a few times, check only one PUT request is sent
- Select Protein Acronym, choose a new acronym, click Update Samples, then refresh the page to check the change has persisted
- Check the success message appears and says "Sample(s) have been successfully updated"
- Choose "Screening Method", then select "Better Than", but dont choose a minimum resolution. Click Update Samples, and check a notification appears at the top to say there was an error, and validation messages appear at the bottom.
- Go to proposal mx31800, find a container to bulk edit (or make a new one), choose Protein Acronym, check that Diazocine does not appear in the list as it is a YELLOW sample
- Go to a container that has had data collected on it, check the bulk editor is hidden
