### PR TITLE
LIMS-1383, LIMS-160, LIMS-269: Improve reprocessing

### DIFF
--- a/client/src/js/modules/dc/views/reprocess.js
+++ b/client/src/js/modules/dc/views/reprocess.js
@@ -153,7 +153,7 @@ define(['marionette',
             opts: 'div.options',
             ind: 'input[name=individual]',
             mul: 'span.multi',
-            met: 'select[name=method]',
+            pipeline: 'select[name=pipeline]',
         },
 
         buttons: {
@@ -207,7 +207,7 @@ define(['marionette',
             })
 
             data.int = integrate
-            data.recipes = this.ui.met.val()
+            data.recipes = this.ui.pipeline.val()
 
             _.each(['a', 'b', 'c', 'alpha', 'beta', 'gamma', 'res', 'sg'], function(f, i) {
                 data[f] = this.$el.find('input[name='+f+']').val().replace(/\s/g, '')
@@ -243,7 +243,7 @@ define(['marionette',
             this.ui.cell.hide()
 
             _.each(['xia2 3dii', 'xia2 dials'], function(t,i) {
-                this.ui.met.append('<option value="'+(i+1)+'">'+t+'</option>')
+                this.ui.pipeline.append('<option value="'+(i+1)+'">'+t+'</option>')
             }, this)
 
             this.distlview = new DCDistlsView({ collection: this.collection })

--- a/client/src/js/modules/mc/views/datacollections.js
+++ b/client/src/js/modules/mc/views/datacollections.js
@@ -16,12 +16,13 @@ define(['backbone', 'marionette',
     'utils',
 
     'templates/mc/datacollections.html',
+    'collections/spacegroups',
     ], function(Backbone, Marionette, DCDISTLView, Pages, Search, 
         ReprocessOverview, Reprocessing, Reprocessings, 
         ReprocessingParameter, ReprocessingParameters,
         ReprocessingImageSweep, ReprocessingImageSweeps,
         KVCollection, utils,
-        template) {
+        template, Spacegroups) {
 
 
     var DCsDISTLView = Marionette.CollectionView.extend({
@@ -64,6 +65,7 @@ define(['backbone', 'marionette',
             indexingMethod: 'select[name=method]',
             opts: 'div.options',
             sm: 'input[name=sm]',
+            sg: 'select[name=sg]',
         },
 
         templateHelpers: function() {
@@ -78,6 +80,12 @@ define(['backbone', 'marionette',
             for (param of this.xia2params()) {
                 this.$el.find('input[name='+param+'], select[name='+param+']').prop('disabled', !isXia2)
             }
+        },
+
+        showSpaceGroups: async function() {
+            this.spacegroups = new Spacegroups(null, { state: { pageSize: 9999 } })
+            await this.spacegroups.fetch();
+            this.ui.sg.html('<option value=""> - </option>'+this.spacegroups.opts())
         },
 
         toggleOpts: function(e) {
@@ -133,7 +141,7 @@ define(['backbone', 'marionette',
                         PARAMETERVALUE: cell.join(',')
                     }))
 
-                    var sg = self.$el.find('input[name=sg]').val().replace(/\s/g, '')
+                    var sg = self.$el.find('select[name=sg]').val().replace(/\s/g, '')
                     if (sg) reprocessingparams.add(new ReprocessingParameter({ 
                         PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID'),
                         PARAMETERKEY: 'spacegroup', 
@@ -224,6 +232,9 @@ define(['backbone', 'marionette',
 
             this.rps.show(new ReprocessOverview({ collection: this.reprocessings, embed: true, results: true }))
 
+            // asynchronously load space groups into the select menu
+            this.showSpaceGroups()
+
             this.pipelines = new Pipelines([
                 { NAME: 'Xia2 DIALS', VALUE: 'xia2-dials' },
                 { NAME: 'Xia2 3dii', VALUE: 'xia2-3dii' },
@@ -249,7 +260,7 @@ define(['backbone', 'marionette',
                 this.$el.find('input[name='+f+']').val(ap.get('CELL')['CELL_'+k.toUpperCase()])
             }, this)
 
-            this.$el.find('input[name=sg]').val(ap.get('SG'))
+            this.$el.find('select[name=sg]').val(ap.get('SG'))
         },
 
         onDestroy: function() {

--- a/client/src/js/templates/dc/reprocess.html
+++ b/client/src/js/templates/dc/reprocess.html
@@ -3,20 +3,20 @@
 	</p>
 
     <div class="ra">
-        <a href="/mc/visit/<%-VISIT%>" class="button" title="Multicrystal Integrator"><i class="fa fa-diamond"></i> <span>Multi Crystal</span></a>
+        <a href="/mc/visit/<%-VISIT%>" class="button multicrystal" title="Multicrystal Integrator"><i class="fa fa-diamond"></i> <span>Multi Crystal</span></a>
     </div>
 	<div class="data_collection">
         <label><input type="checkbox" name="individual" /> Process Individually</label>
 
         <span class="multi form">
             | 
-            Pipeline :<select name="method"></select>
+            Pipeline :<select name="pipeline"></select>
             High Res :<input type="text" name="res" /> &#197; |
             <a href="#" class="button sgm">Space Group / Cell</a> 
-            <a href="#" class="button opt">Options</a>
-            <br />
             <!-- Comments: <input type="text" name="comments" class="full" /> -->
         </span>
+        <a href="#" class="button opt">Xia2 Options</a>
+        <br />
     </div>
 
     <div class="cell data_collection">
@@ -31,7 +31,12 @@
 
 
     <div class="options data_collection">
-        <label><input type="checkbox" name="sm" value="1" /> Small Molecule</label>
+        <label>Small Molecule<input type="checkbox" name="sm" value="1" /></label>
+        <label>CC Half :<input type="text" name="cc_half" /></label>
+        <label>Unmerged &lt;I/sigI&gt; :<input type="text" name="isigma" /></label>
+        <label>Merged &lt;I/sigI&gt; :<input type="text" name="misigma" /></label>
+        <label>Spot Finding Threshold :<input type="text" name="sigma_strong" /></label>
+        <label>Indexing Method: <select name="method"></select></label>
     </div>
 
 

--- a/client/src/js/templates/dc/reprocess_dc.html
+++ b/client/src/js/templates/dc/reprocess_dc.html
@@ -6,7 +6,7 @@
 </h1>
 
 <div class="ind data_collection">
-    Pipeline <select name="method"></select>
+    Pipeline <select name="pipeline"></select>
     High Res <input type="text" name="res" /> &#197; | 
     <a href="#" class="button sg">Space Group / Cell</a> <br />
 </div>

--- a/client/src/js/templates/mc/datacollections.html
+++ b/client/src/js/templates/mc/datacollections.html
@@ -1,7 +1,7 @@
 <h1>Data Collections for <%-VISIT%></h1>
 
-    <p class="help">Use this page to reintegrate multiple data collections together</p>
-    <p class="help">Select data sets to integrate by dragging accross the per-image analysis plot below. This selects which images of the data set to integrate</p>
+    <p class="help">Use this page to reintegrate multiple data collections together.</p>
+    <p class="help">Select data sets to integrate by dragging across the per-image analysis plot below. This selects which images of the data set to integrate.</p>
 
     <div class="filter filter-nohide">
     	<div class="srch"></div>
@@ -18,7 +18,7 @@
             <label>Auto Processed <select name="cells"></select></label>
         </div>
 
-        <lable>Pipeline <select name="method"></select></lable>
+        <label>Pipeline <select name="pipeline"></select></label>
         <label>Spacegroup: <input type="text" name="sg" /></label>
 
         <label>a <input type="text" name="a" /></label>
@@ -31,10 +31,16 @@
         <label>High Resolution <input type="text" name="res" /></label>
 
         <a href="#" class="button integrate" title="Integrate the selected data collections"><i class="fa fa-cog"></i> Integrate</a>
+        <a href="#" class="button opt">Xia2 Options</a>
     </div>
 
     <div class="options data_collection">
-        <label><input type="checkbox" name="sm" value="1" /> Small Molecule</label>
+        <label>Small Molecule<input type="checkbox" name="sm" value="1" /></label>
+        <label>CC Half :<input type="text" name="cc_half" /></label>
+        <label>Unmerged &lt;I/sigI&gt; :<input type="text" name="isigma" /></label>
+        <label>Merged &lt;I/sigI&gt; :<input type="text" name="misigma" /></label>
+        <label>Spot Finding Threshold :<input type="text" name="sigma_strong" /></label>
+        <label>Indexing Method: <select name="method"></select></label>
     </div>
 
     <div class="dcs"></div>

--- a/client/src/js/templates/mc/datacollections.html
+++ b/client/src/js/templates/mc/datacollections.html
@@ -19,7 +19,7 @@
         </div>
 
         <label>Pipeline <select name="pipeline"></select></label>
-        <label>Spacegroup: <input type="text" name="sg" /></label>
+        <label>Spacegroup: <select name="sg"></select></label>
 
         <label>a <input type="text" name="a" /></label>
         <label>b <input type="text" name="b" /></label>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1383](https://jira.diamond.ac.uk/browse/LIMS-1383)
**JIRA ticket**: [LIMS-160](https://jira.diamond.ac.uk/browse/LIMS-160)
**JIRA ticket**: [LIMS-269](https://jira.diamond.ac.uk/browse/LIMS-269)

**Summary**:

Fix 3 tickets all related to reprocessing, fixing a bug and adding extra features. While we look at it, improve the GUI a bit.

**Changes**:
- Rename method elements to pipeline
- Add dropdown options for indexing method (uses xia2 keyword `method` hence renaming above)
- Rename Options button as Xia2 Options, grey out the options if a non-xia2 pipeline is chosen
- Add options for Xia2 keywords `cc_half`, `isigma`, `misigma`, `sigma_strong` and `method`
- Add a blank option for space group, otherwise P1 is the default
- Close Reprocessing dialog if the Multicrystal button is clicked
- Do all the above for the Multicrystal reprocessing page
- Make Xia2 Options be a button which opens the options on the Multicrystal reprocessing page

**To test**:
- As Zocalo gets the reprocessing parameters from the live db, update config.php to have live db credentials
- Copy these variables from the production config.php: `$zocalo_mx_reprocess_queue`, `$zocalo_server`, `$zocalo_username` and `$zocalo_password`
- Xia2 can be pretty slow so you only need to select 1-200 images for each job
- Keep the dev console open, then you can see the processingJobId returned from the database. Then you can run these queries when you have submitted a job to see if the parameters have been successfully added
```
select * from ProcessingJob where processingJobId = 123456789;
select * from ProcessingJobParameter where processingJobId = 123456789;
select * from AutoProcProgram where processingJobId = 123456789;
```
- Go to proposal mx23694 and choose a dataset for which the autoprocessing ran successfully, but no reprocessing has been done (to make it easier to keep track)
- Click the "cog" icon to open the Reprocessing dialog. Check the "Space Group / Cell" and "Xia2 Options" buttons open further options. Check the space group is blank by default
- Change the pipeline to fast_dp and check the Xia2 options are greyed out. Click Integrate and check fast_dp runs
- Change the pipeline to Xia2 DIALS, check the Xia2 options are enabled. Put some numbers in each, choose an indexing method (eg fft3d), select a subset of images to speed it up (eg 1-200). Match the space group to that of a previous Xia2 Dials run, and click Integrate, check it runs.
- When it completes, view the Logs and Files and view the xia2.txt file. Check the command line that is printed within that, it should show the parameters you selected
- Click the "plus" sign on the right of the reprocessing dialog, to add another processing job to the dialog. Select "Process individually", you should get a pipeline selection for each job, as well as a space group / cell button. The Xia2 options wont grey out now, as one of the jobs could be Xia2. Select 100 images in each job and Integrate. When the jobs complete, check any Xia2 options are shown in the command line as before
- Click the Multicrystal button on the top right of the Reprocessing dialog. Check the Reprocessing dialog closes as you go to the new page
- Check space group is now a drop down, with a blank first option
- Check the Xia2 Options button opens more options, which are greyed out when fast_dp or autoPROC is selected
- Drag across some images on one or more data collections, put in some options and press Integrate
- When that has completed, you should see it somewhere on the top half of the page, check the arguments are what you submitted
- Dont forget to roll back config.php to have dev db credentials
