### PR TITLE
LIMS-1396: Use shipping service callback URL to only send emails once shipment is booked

### DIFF
--- a/api/assets/emails/html/dewar-dispatch-lite.html
+++ b/api/assets/emails/html/dewar-dispatch-lite.html
@@ -1,4 +1,4 @@
-<h1 style="font-size: 16px; font-weight: normal; border-bottom: 1px solid #000; margin: 1%; margin-bottom: 1.5%">Dewar ready to leave diamond</h1>
+<h1 style="font-size: 16px; font-weight: normal; border-bottom: 1px solid #000; margin: 1%; margin-bottom: 1.5%">Dewar ready to leave Diamond</h1>
 
 <div class="inset" style="margin: 1%; padding: 1%; margin-bottom: 2%; border-radius: 5px; background: #82d180">
 	Goods Handling, please arrange dispatch of the following Dewar.

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -116,7 +116,10 @@ class AuthenticationController
             ($parts[0] == 'shipment' && $parts[1] == 'containers' && $parts[2] == 'notify' && in_array($_SERVER["REMOTE_ADDR"], $auto)) ||
 
                 # Allow barcode reader ips unauthorised access to add container history
-            ($parts[0] == 'shipment' && $parts[1] == 'containers' && $parts[2] == 'history' && in_array($_SERVER["REMOTE_ADDR"], $bcr))
+            ($parts[0] == 'shipment' && $parts[1] == 'containers' && $parts[2] == 'history' && in_array($_SERVER["REMOTE_ADDR"], $bcr)) ||
+
+                # Allow shipping service to update dewar status
+            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirmdispatch')
             )
             {
                 $need_auth = false;

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1322,6 +1322,8 @@ class Shipment extends Page
                 array($dew['DEWARID'], $dewar_location)
             );
 
+            $this->db->pq("UPDATE shipping set shippingstatus='dispatch-requested' WHERE shippingid=:1", array($dew['SHIPPINGID']));
+
             // Update dewar transport history with provided location.
             $this->db->pq(
                 "INSERT INTO dewartransporthistory (dewartransporthistoryid,dewarid,dewarstatus,storagelocation,arrivaldate)

--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -37,7 +37,7 @@ define(['backbone'], function(Backbone) {
         },
 
         EMAILADDRESS: {
-            required: true,
+            required: function () {return this.dispatchDetailsRequired},
             pattern: 'email',
         },
 

--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -25,11 +25,6 @@
             <% } %>
 
             <li>
-                <label>Email Address<span class="small">The contact email for the Dewar return</span></label>
-                <input type="email" name="EMAILADDRESS" data-testid="dispatch-email-address"/>
-            </li>
-
-            <li>
                 <label>Laboratory Country
                     <span class="small">The contact's laboratory country</span>
                 </label>
@@ -128,6 +123,11 @@
                 </label>
                 <input type="text" name="GIVENNAME" data-testid="dispatch-given-name"/>
                 <input type="text" name="FAMILYNAME" data-testid="dispatch-family-name"/>
+            </li>
+
+            <li>
+                <label>Email Address<span class="small">The contact email for the Dewar return</span></label>
+                <input type="email" name="EMAILADDRESS" data-testid="dispatch-email-address"/>
             </li>
 
             <li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1396](https://jira.diamond.ac.uk/browse/LIMS-1396)

**Summary**:

Currently, when a user is redirected to the shipping service, Synchweb sends the email and marks the dewar as 'dispatch-requested' instantly, as it doesn't know if/when they have completed the form.
The shipping service now accepts a callback URL, so we can send that in and it will POST to the address with some data about the completed shipment.

**Changes**:
- Create new non-authenticated endpoint at /api/shipment/dewars/confirmdispatch/did/{dewarid}/token/{token}
- Create pseudo-random token and store in Dewar.extra column as JSON
- Pass callback URL including token to shipping service
- Don't update dewar status and history when first redirecting to shipping service
- Add function at new endpoint to check token, then update dewar status and history, and send email to stores and return lab contact
- Hide email address in dispatch form before redirection to shipping service as it will not be used

**To test**:
- Make sure `$use_shipping_service = True;`, `$use_shipping_service_redirect = True;` and `$shipping_service_api_url = "https://sample-shipping-staging.diamond.ac.uk/api";`
- Use a dev instance that can send emails (or dump to file as at https://confluence.diamond.ac.uk/x/i_CVCQ)
- Go to a UK shipment, request dispatch without clicking "Use Facility Account", so it doesnt use the shipping service. Fill in the form and submit, check the dewar & shipping status are both dispatch-requested, the history has a line added, but the tracking number has not been filled in (as it doesn't exist). Check an email has been sent immediately.
- Repeat for a non-UK shipment, also without the shipping service
- Now try with a UK shipment and click "Use Facility Account". Click "Proceed" to the shipping service, but before filling in the form, check the shipment in another tab, it should not say dispatch-requested, and no email should have been sent. Now fill in the shipping service form and submit, click "Exit" back to Synchweb and the dewar & shipping status should both be dispatch-requested, an email should have been sent, and the tracking number should be in Synchweb too.
- Check the email carefully, it should have a link to the AWB in the shipping service, check this works.
