### PR TITLE
LIMS-1002: Fix error when creating new laboratory

### DIFF
--- a/api/src/Controllers/UserController.php
+++ b/api/src/Controllers/UserController.php
@@ -275,13 +275,8 @@ class UserController extends Page
         $person = $this->userData->getUser($this->user->personId, $this->proposalid, $this->arg('PERSONID'));
         $person = $person[0];
         $this->_output((array) $person);
-        $laboratory = null;
-        if ($person['LABORATORYID'])
-        {
-            $laboratory = $this->userData->getLaboratory($person['LABORATORYID'])[0];
-        }
 
-        $this->userData->updateLaboratory(
+        $laboratoryId = $this->userData->updateLaboratory(
             $this->arg('PERSONID'),
             $this->argOrNull('LABNAME'),
             $this->argOrNull('ADDRESS'),
@@ -290,7 +285,7 @@ class UserController extends Page
             $this->argOrNull('COUNTRY'),
             $person['LABORATORYID']
         );
-        $laboratory = $this->userData->getLaboratory($person['LABORATORYID']);
+        $laboratory = $this->userData->getLaboratory($laboratoryId);
         $this->_output((array) $laboratory[0]);
     }
 

--- a/api/src/Model/Services/UserData.php
+++ b/api/src/Model/Services/UserData.php
@@ -340,6 +340,7 @@ class UserData
                 ->whereIdEquals("personid", $personId)
                 ->update("person");
         }
+        return $laboratoryId;
     }
 
     function addGroupUser($personId, $gid)

--- a/api/tests/Controllers/UserControllerTest.php
+++ b/api/tests/Controllers/UserControllerTest.php
@@ -374,7 +374,7 @@ final class UserControllerTest extends TestCase
         $this->dataLayerStub->expects($this->exactly(2))->method('getUser')->with(231312, null, 88)->willReturn($results);
         $this->dataLayerStub->expects($this->exactly(1))->method('updateUser');
         $this->dataLayerStub->expects($this->exactly(1))->method('getLaboratory')->with(666)->willReturn($labResults);
-        $this->dataLayerStub->expects($this->exactly(1))->method('updateLaboratory');
+        $this->dataLayerStub->expects($this->exactly(1))->method('updateLaboratory')->willReturn(666);
 
         $this->userController->_update_user();
     }

--- a/api/tests/Controllers/UserControllerTest.php
+++ b/api/tests/Controllers/UserControllerTest.php
@@ -373,7 +373,7 @@ final class UserControllerTest extends TestCase
         
         $this->dataLayerStub->expects($this->exactly(2))->method('getUser')->with(231312, null, 88)->willReturn($results);
         $this->dataLayerStub->expects($this->exactly(1))->method('updateUser');
-        $this->dataLayerStub->expects($this->exactly(2))->method('getLaboratory')->with(666)->willReturn($labResults);
+        $this->dataLayerStub->expects($this->exactly(1))->method('getLaboratory')->with(666)->willReturn($labResults);
         $this->dataLayerStub->expects($this->exactly(1))->method('updateLaboratory');
 
         $this->userController->_update_user();


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1002](https://jira.diamond.ac.uk/browse/LIMS-1002)

**Summary**:

When updating a user to have a laboratory when previously they didn't have one, although the laboratory is created, an error is logged.

**Changes**:
- Make the updateLaboratory function return the laboratoryId instead of nothing
- Use that laboratoryId to get the rest of the info to output to the user
- Remove unused code getting the laboratory earlier

**To test**:
- Find a personId that has no laboratoryId, eg personId 13000, login gnj59924
- Login to a synchweb dev instance as this person, and get the authentication headers
- Open a python terminal and do:
```
>>> import requests
>>> headers = {"Authorization": "Bearer eyJ..."} # using headers from Synchweb
>>> r = requests.patch("http://server:port/api/users/13000", headers=headers, json={"LABNAME": "test"})
>>> r.json()
{'NAME': 'test', 'ADDRESS': None, 'CITY': None, 'POSTCODE': None, 'COUNTRY': None}
```
- This only errors the first time, as the laboratoryId is created and set ok, but the server logs an error and no json is returned at the moment. If you want to re-test, you need to clear the laboratoryId, eg
```
UPDATE Person SET laboratoryId = NULL WHERE personId=13000;
```
- NB I don't know how to trigger this code from Synchweb, only via the python, but it obviously did happen, as logged in the ticket.
