### PR TITLE
LIMS-1432: Add shelxt downstream view

### DIFF
--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -53,9 +53,13 @@ class Shelxt extends DownstreamPlugin {
 
     function images($n = 0) {
         $png = $this->_get_shelxt_results_png();
-        $the_actual_path = $png[0]["FILEPATH"] . "/" . $png[0]["FILENAME"];
-        // TODO handle that being null
-        return $the_actual_path;
+        if (sizeof($png)) {
+            $the_actual_path = $png[0]["FILEPATH"] . "/" . $png[0]["FILENAME"];
+            return $the_actual_path;
+        } else {
+            return;
+        }
+
     }
 
     function mapmodel($n = 0, $map = false) {

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -53,6 +53,17 @@ class Shelxt extends DownstreamPlugin {
         $dat['BLOBS'] = 1;
         $dat['SOLUTIONS'] = json_decode($json_data);
 
+        // scaling_id should always be present, but just in case...
+        if ($this->process['PARAMETERS']['scaling_id']) {
+            $integrator = $this->_lookup_autoproc(
+                null,
+                $this->process['PARAMETERS']['scaling_id']
+            );
+            if ($integrator) {
+                $dat['PARENTAUTOPROCPROGRAM'] = $integrator['PROCESSINGPROGRAMS'];
+                $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+            }
+        }
         $results = new DownstreamResult($this);
         $results->data = $dat;
 

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -73,8 +73,7 @@ class Shelxt extends DownstreamPlugin {
     function images($n = 0) {
         $png = $this->_get_shelxt_results_png();
         if (sizeof($png)) {
-            $the_actual_path = $png[0]["FILEPATH"] . "/" . $png[0]["FILENAME"];
-            return $the_actual_path;
+            return $png[0]["FILEPATH"] . "/" . $png[0]["FILENAME"];
         } else {
             return;
         }

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -54,7 +54,7 @@ class Shelxt extends DownstreamPlugin {
         $dat['SOLUTIONS'] = json_decode($json_data);
 
         // scaling_id should always be present, but just in case...
-        if (in_array('scaling_id', $this->process['PARAMETERS']) {
+        if (in_array('scaling_id', $this->process['PARAMETERS'])) {
             $integrator = $this->_lookup_autoproc(
                 null,
                 $this->process['PARAMETERS']['scaling_id']

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -54,7 +54,7 @@ class Shelxt extends DownstreamPlugin {
         $dat['SOLUTIONS'] = json_decode($json_data);
 
         // scaling_id should always be present, but just in case...
-        if ($this->process['PARAMETERS']['scaling_id']) {
+        if (in_array('scaling_id', $this->process['PARAMETERS']) {
             $integrator = $this->_lookup_autoproc(
                 null,
                 $this->process['PARAMETERS']['scaling_id']

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SynchWeb\Downstream\Type;
+
+use SynchWeb\Downstream\DownstreamPlugin;
+use SynchWeb\Downstream\DownstreamResult;
+
+class Shelxt extends DownstreamPlugin {
+    var $has_images = true;
+    var $friendlyname = 'Shelxt';
+    var $has_mapmodel = array(1, 2);
+
+    function _get_shelxt_results_json() {
+        $appid = array($this->autoprocprogramid);
+        $filepath = $this->db->pq(
+            "SELECT app.filePath from autoprocprogramattachment app where autoprocprogramid = :1 and filename = \"shelxt_results.json\" ", 
+            $appid
+        );
+        return $filepath;
+    }
+
+    function _get_shelxt_results_png() {
+        $appid = array($this->autoprocprogramid);
+        $filepath = $this->db->pq(
+            "SELECT app.filepath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like \"%.png%\" ", 
+            $appid
+        );
+        return $filepath;
+    }
+
+    function results() {
+        $json_filepath = $this->_get_shelxt_results_json();
+        $json_path = $json_filepath[0]["FILEPATH"] . "/shelxt_results.json" ;
+        if (sizeof($json_filepath)) {
+            $json_data = file_get_contents($json_path);
+        } else {
+            $json_data = file_get_contents("/dls/i19-1/data/2024/cm37266-1/processed/laserShaping/data/cryst7_after/EuSample_1/985d2624-9254-4d00-b122-5849f3af4462/shelxt/" . "shelxt_results2.json");
+        }
+        $dat = array();
+        $dat['BLOBS'] = 1;
+        $dat['STATS'] = array();
+        $dat['PLOTS'] = array();
+        $dat['PKLIST'] = array();
+        $dat['PARENTAUTOPROCPROGRAM'] = "Shelxt";
+        $dat['PARENTAUTOPROCPROGRAMID'] = "";
+        $dat['SOLUTIONS'] = json_decode($json_data);
+
+        $results = new DownstreamResult($this);
+        $results->data = $dat;
+
+        return $results;
+    }
+
+    function images($n = 0) {
+        $png = $this->_get_shelxt_results_png();
+        $the_actual_path = $png[0]["FILEPATH"] . "/" . $png[0]["FILENAME"];
+        // TODO handle that being null
+        return $the_actual_path;
+    }
+
+    function mapmodel($n = 0, $map = false) {
+        $pdb = $this->_get_attachments('final.pdb');
+        if (!$pdb) {
+            return;
+        }
+
+        if ($map) {
+            $mtz = $this->_get_attachments('final.mtz');
+            if (!$mtz) {
+                return;
+            }
+
+            return $this->convert_mtz(
+                $mtz['FILE'],
+                $this->autoprocprogramid,
+                $this->type,
+                $pdb['FILE'],
+                $map
+            );
+        } else {
+            return $pdb['FILE'];
+        }
+    }
+}

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -34,7 +34,7 @@ class Shelxt extends DownstreamPlugin {
         if (sizeof($json_filepath)) {
             $json_data = file_get_contents($json_path);
         } else {
-            $json_data = file_get_contents("/dls/i19-1/data/2024/cm37266-1/processed/laserShaping/data/cryst7_after/EuSample_1/985d2624-9254-4d00-b122-5849f3af4462/shelxt/" . "shelxt_results2.json");
+            $json_data = "[]";
         }
         $dat = array();
         $dat['BLOBS'] = 1;

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -13,7 +13,7 @@ class Shelxt extends DownstreamPlugin {
     function _get_shelxt_results_json() {
         $appid = array($this->autoprocprogramid);
         $filepath = $this->db->pq(
-            "SELECT app.filePath from autoprocprogramattachment app where autoprocprogramid = :1 and filename = \"shelxt_results.json\" ", 
+            "SELECT app.filePath from autoprocprogramattachment app where autoprocprogramid = :1 and filename = 'shelxt_results.json' ", 
             $appid
         );
         return $filepath;
@@ -22,7 +22,7 @@ class Shelxt extends DownstreamPlugin {
     function _get_shelxt_results_png() {
         $appid = array($this->autoprocprogramid);
         $filepath = $this->db->pq(
-            "SELECT app.filepath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like \"%.png%\" ", 
+            "SELECT app.filepath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like '%.png%' ", 
             $appid
         );
         return $filepath;
@@ -31,7 +31,7 @@ class Shelxt extends DownstreamPlugin {
     function _get_pdb() {
         $appid = array($this->autoprocprogramid);
         $filepath = $this->db->pq(
-            "SELECT app.filepath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like \"%.pdb%\" ", 
+            "SELECT app.filepath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like '%.pdb%' ", 
             $appid
         );
         if (sizeof($filepath)) {

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -43,8 +43,8 @@ class Shelxt extends DownstreamPlugin {
 
     function results() {
         $json_filepath = $this->_get_shelxt_results_json();
-        $json_path = $json_filepath[0]["FILEPATH"] . "/shelxt_results.json" ;
         if (sizeof($json_filepath)) {
+            $json_path = $json_filepath[0]["FILEPATH"] . "/shelxt_results.json" ;
             $json_data = file_get_contents($json_path);
         } else {
             $json_data = "[]";

--- a/client/src/js/modules/dc/views/downstream.js
+++ b/client/src/js/modules/dc/views/downstream.js
@@ -7,11 +7,12 @@ define(['backbone', 'marionette',
     'modules/dc/views/dimple',
     'modules/dc/views/mrbump',
     'modules/dc/views/bigep',
+    'modules/dc/views/shelxt',
     'templates/dc/downstreamerror.html'
 
     ], function(Backbone, Marionette, TabView, DownStreams, DownstreamWrapper, 
         TableView, 
-        FastEP, DIMPLE, MrBUMP, BigEP, downstreamerror) {
+        FastEP, DIMPLE, MrBUMP, BigEP, Shelxt, downstreamerror) {
 
     var DownstreamsCollection = Backbone.Collection.extend()
 
@@ -61,6 +62,7 @@ define(['backbone', 'marionette',
                 'Autobuild': BigEP,
                 'Crank2': BigEP,
                 'AutoSHARP': BigEP,
+                'Shelxt': Shelxt,
             }
             
             if (model.get('PROCESS').PROCESSINGSTATUS != 1) {

--- a/client/src/js/modules/dc/views/mapmodelview.js
+++ b/client/src/js/modules/dc/views/mapmodelview.js
@@ -33,7 +33,9 @@ define(['marionette',
         loadMaps: function() {
             this.mapsToLoad = this.downstream.get('FEATURES').MAPMODEL[1];
             this.mapsLoaded = 0
-            this.doLoadMaps(1, this.onMapsLoaded.bind(this))
+            if (this.mapsToLoad > 0) {
+                this.doLoadMaps(1, this.onMapsLoaded.bind(this))
+            }
         },
         
 

--- a/client/src/js/modules/dc/views/shelxt.js
+++ b/client/src/js/modules/dc/views/shelxt.js
@@ -1,0 +1,59 @@
+define([
+    'marionette', 'templates/dc/dc_shelxt.html', 'utils', 'utils/xhrimage', 'jquery.mp'
+], function(Marionette, template, utils, XHRImage) {
+    
+    return Marionette.ItemView.extend({
+        template: template,
+        className: 'clearfix',
+    
+        ui: {
+            //plot: '.plot_dimple',
+            solutions: '.solutions',
+            blob: '.blobs img',
+            blobs: '.blobs',
+        },
+        
+        showBlob: function() {
+            this.ui.blob.attr('src', this.blob.src).show()
+            this.ui.blobs.addClass('loaded').removeClass('pending')
+        },
+
+        onDomRefresh: function() {
+            this.ui.blobs.magnificPopup({
+                delegate: 'a', type: 'image',
+                gallery: {
+                    enabled: true,
+                    navigateByImgClick: true,
+                }
+            })
+
+            this.ui.blob.hide()
+            console.log("is this thing on?");
+            console.log(this.model);
+            if (this.model.get('BLOBS') > 0) {
+                this.blob = new XHRImage()
+                this.blob.onload = this.showBlob.bind(this)
+                this.ui.blobs.addClass('pending')
+                this.blob.load(app.apiurl+'/processing/downstream/images/'+this.model.get('AID'))
+            }
+
+            if (app.mobile()) {
+                //this.ui.plot.width(0.93*(this.options.holderWidth-14))
+            } else {
+              //this.ui.rstats.width(0.20*(this.options.holderWidth-14))
+                this.ui.solutions.width(0.47*(this.options.holderWidth-14))
+                //this.ui.solutions.height(this.ui.solutions.width()*0.41-80)
+             }
+
+            //this.ui.blobs.css('min-height', this.ui.plot.width()*0.41-80)
+            
+            //var data = [{ data: this.model.get('PLOTS').FVC, label: 'Rfree vs. Cycle' },
+            //            { data: this.model.get('PLOTS').RVC, label: 'R vs. Cycle' }]
+            //var pl = $.extend({}, utils.default_plot, { series: { lines: { show: true }}})
+            //$.plot(this.ui.plot, data, pl)
+            
+        },
+    
+    })
+
+})

--- a/client/src/js/modules/dc/views/shelxt.js
+++ b/client/src/js/modules/dc/views/shelxt.js
@@ -27,8 +27,6 @@ define([
             })
 
             this.ui.blob.hide()
-            console.log("is this thing on?");
-            console.log(this.model);
             if (this.model.get('BLOBS') > 0) {
                 this.blob = new XHRImage()
                 this.blob.onload = this.showBlob.bind(this)

--- a/client/src/js/modules/dc/views/shelxt.js
+++ b/client/src/js/modules/dc/views/shelxt.js
@@ -7,7 +7,6 @@ define([
         className: 'clearfix',
     
         ui: {
-            //plot: '.plot_dimple',
             solutions: '.solutions',
             blob: '.blobs img',
             blobs: '.blobs',
@@ -37,21 +36,9 @@ define([
                 this.blob.load(app.apiurl+'/processing/downstream/images/'+this.model.get('AID'))
             }
 
-            if (app.mobile()) {
-                //this.ui.plot.width(0.93*(this.options.holderWidth-14))
-            } else {
-              //this.ui.rstats.width(0.20*(this.options.holderWidth-14))
+            if (!app.mobile()) {
                 this.ui.solutions.width(0.47*(this.options.holderWidth-14))
-                //this.ui.solutions.height(this.ui.solutions.width()*0.41-80)
              }
-
-            //this.ui.blobs.css('min-height', this.ui.plot.width()*0.41-80)
-            
-            //var data = [{ data: this.model.get('PLOTS').FVC, label: 'Rfree vs. Cycle' },
-            //            { data: this.model.get('PLOTS').RVC, label: 'R vs. Cycle' }]
-            //var pl = $.extend({}, utils.default_plot, { series: { lines: { show: true }}})
-            //$.plot(this.ui.plot, data, pl)
-            
         },
     
     })

--- a/client/src/js/modules/types/sm/dc/views/apstatusitem.js
+++ b/client/src/js/modules/types/sm/dc/views/apstatusitem.js
@@ -9,12 +9,23 @@ define(['modules/dc/views/apstatusitem'], function(APStatusItem) {
                     '<i class="fa icon green fa-check alt="Completed"></i>',
                     '<i class="fa icon red fa-times alt="Failed"></i>']
 
-            _.each(['autoproc','downstream'], function(ty, id) {
-                this.ui.holder.eq(id).empty()
-                _.each(res[ty], function(ap, n) {
-                    if(ap != 0)
-                        this.ui.holder.eq(id).append(n+' '+val[ap]+' ')
-                }, this)
+            _.each({ap: 'autoproc',dp: 'downstream'}, function(ty, id) {
+                this.ui[id].empty()
+                var allResults = []
+                if (res[ty]) {
+                    _.each(res[ty], function(ap, n) {
+                        var ress = {}
+                        _.each(ap, function(a) {
+                            if (!(a in ress)) ress[a] = 0
+                            ress[a]++
+                        })
+                        allResults.push(n+': '+_.map(ress, function(c, st) { return c > 1 ? '<span class="count">'+c+'x</span> '+val[st] : val[st]}).join(' '))
+                    }, this)
+
+                    this.ui[id].append(allResults.join('<span class="separator">|</span>'))
+                } else {
+                    this.ui[id].append('No processing results')
+                }
             }, this)
         },
     })

--- a/client/src/js/templates/dc/dc_shelxt.html
+++ b/client/src/js/templates/dc/dc_shelxt.html
@@ -1,0 +1,32 @@
+<div>
+    <div class="blobs">
+        <% _.each(_.range(BLOBS), function(i) { %>
+        <a href="<%-APIURL%>/processing/downstream/images/<%-AID%>?n=<% print(i) %>" title="Dimple Blob <% print(i+1) %>">
+            <% if (i == 0) { %>
+                <img alt="Dimple Blob 1" />
+            <% } %>
+        </a>
+        <% }) %>
+        
+    </div>
+
+    <table class="rstats">
+        <% if (SOLUTIONS.length) { %>
+            <% _.each(SOLUTIONS, function(r, i) { %>
+            <tr>
+                <% _.each(r, function(j) { %>
+                <td><%-j%></td>
+                <% }) %>
+            </tr>
+            <% }) %>
+        <% } else { %>
+            <tr>
+                <td>Solutions</td>
+            </tr>
+            <tr>
+                <td>No Solutions Found</td>
+            </tr>
+        <% } %>
+    </table>
+    
+</div>

--- a/client/src/js/templates/dc/dc_shelxt.html
+++ b/client/src/js/templates/dc/dc_shelxt.html
@@ -1,9 +1,9 @@
 <div>
     <div class="blobs">
         <% _.each(_.range(BLOBS), function(i) { %>
-        <a href="<%-APIURL%>/processing/downstream/images/<%-AID%>?n=<% print(i) %>" title="Dimple Blob <% print(i+1) %>">
+        <a href="<%-APIURL%>/processing/downstream/images/<%-AID%>?n=<% print(i) %>" title="Solution <% print(i+1) %>">
             <% if (i == 0) { %>
-                <img alt="Dimple Blob 1" />
+                <img alt="Solution 1" />
             <% } %>
         </a>
         <% }) %>

--- a/client/src/js/templates/dc/dc_shelxt.html
+++ b/client/src/js/templates/dc/dc_shelxt.html
@@ -1,7 +1,7 @@
 <div>
     <div class="blobs">
         <% _.each(_.range(BLOBS), function(i) { %>
-        <a href="<%-APIURL%>/processing/downstream/images/<%-AID%>?n=<% print(i) %>" title="Solution <% print(i+1) %>">
+        <a href="<%-APIURL%>/processing/downstream/images/<%-AID%>?n=<%-i%>" title="Solution <%-i+1%>">
             <% if (i == 0) { %>
                 <img alt="Solution 1" />
             <% } %>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1432](https://jira.diamond.ac.uk/browse/LIMS-1432)

**Summary**:

Add support for shelxt downstream results. 

**Changes**:
- add a Shelxt extension of `DownStreamPlugin`
- add the mapping to this plugin
- add a `dc_shelxt.html`
- add the accompanying javascript

(loosely based on dimple but with several differences)

**To test**:
- head to https://ispyb.diamond.ac.uk/dc/visit/cm37266-1/id/13371207
- confirm a list of solutions appears
- confirm a 2d molecular view appears
- confirm that map/model viewer leads to a 3d render of a molecule

I will add a screenshot once the restore database synch is run later today.