### PR TITLE
LIMS-1422: Reprocessing dialog edits the end value unpredictably

### DIFF
--- a/client/src/js/modules/dc/views/distl.js
+++ b/client/src/js/modules/dc/views/distl.js
@@ -27,7 +27,7 @@ define(['marionette', 'modules/dc/models/distl', 'utils',
       },
 
       plotSelected: function(e, ranges) {
-          this.trigger('plot:select', Math.floor(ranges.xaxis.from), Math.ceil(ranges.xaxis.to))
+          this.trigger('plot:select', Math.round(ranges.xaxis.from), Math.round(ranges.xaxis.to))
       },
 
       plotUnselected: function(e) {

--- a/client/src/js/modules/dc/views/reprocess2.js
+++ b/client/src/js/modules/dc/views/reprocess2.js
@@ -110,13 +110,19 @@ define(['backbone', 'marionette', 'views/dialog',
             var si = parseInt(this.model.get('SI'))
             var ni = parseInt(this.model.get('NUMIMG'))
 
-            if (this.ui.st.val() > (si+ni-1)) this.ui.st.val(si+ni-1)
-            if (this.ui.st.val() < si) this.ui.st.val(si)
+            if (this.ui.st.val()) {
+                if (this.ui.st.val() > (si+ni-1)) this.ui.st.val(si+ni-1)
+                if (this.ui.st.val() < si) this.ui.st.val(si)
+            }
 
-            if (this.ui.en.val() > (si+ni-1)) this.ui.en.val(si+ni-1)
-            if (this.ui.en.val() < si) this.ui.en.val(si)
+            if (this.ui.en.val()) {
+                if (this.ui.en.val() > (si+ni-1)) this.ui.en.val(si+ni-1)
+                if (this.ui.en.val() < si) this.ui.en.val(si)
+            }
 
-            this.plotview.setSelection(parseInt(this.ui.st.val()), parseInt(this.ui.en.val()))
+            if (this.ui.st.val() && this.ui.en.val()) {
+                this.plotview.setSelection(parseInt(this.ui.st.val()), parseInt(this.ui.en.val()))
+            }
         },
 
         initialize: function(options) {
@@ -348,7 +354,7 @@ define(['backbone', 'marionette', 'views/dialog',
                 }, this)
 
                 $.when.apply($, reqs).done(function() {
-                    app.alert({ message: jobs+' reprocessing job(s) successfully submitted'})
+                    app.message({ message: jobs+' reprocessing job(s) successfully submitted'})
                     _.each(rps, function(rp) {
                         self._enqueue({ PROCESSINGJOBID: rp.get('PROCESSINGJOBID') })
                     })
@@ -426,7 +432,7 @@ define(['backbone', 'marionette', 'views/dialog',
                         reqs.push(reprocessingsweeps.save())
 
                         $.when.apply($, reqs).done(function() {
-                            app.alert({ message: '1 reprocessing job successfully submitted'})
+                            app.message({ message: '1 reprocessing job successfully submitted'})
                             self._enqueue({ PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID') })
                         })
                     },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1422](https://jira.diamond.ac.uk/browse/LIMS-1422)

**Summary**:

The reprocessing dialog tries to help by autofilling the end value, but sometimes that concats a 1 to the start, sometimes adds a 1 to the number resulting in impossible parameters.

As discussed on Slack at https://diamondlightsource.slack.com/archives/CKS8PRR0Q/p1722949258543509

**Changes**:
- Use Math.round instead of Math.floor or Math.ceil to ensure the image numbers are not affected randomly
- Only autocorrect the start/end image numbers if something has been filled in, rather than putting something in before the user has a chance
- Make the "submitted successfully" message be in green not red.

**To test**:
First, check the current behaviour.
- Open https://ispyb.diamond.ac.uk/dc/visit/mx23694-118/id/14808375 in a 1920 pixel width Firefox window
- Click the reprocess (cog) icon
- Type a 1 in the Start field, notice how a 1 appears in the End field
- Change the End field to 110, see if it magically changes to 111. If it doesn't, try other numbers, it seems to be a property of the browser and window size. In Chrome, on that data collection, 111 changes to 112.
- Type a number over 3600 in the End field, it should change to 3600
- Click "Integrate" to submit the job, the message window is red

Now load the same page on a dev instance with this PR
- Type a 1 in the Start field, nothing should yet appear in the End field
- Type 110 in the End field, check it doesn't change
- Type a number over 3600 in the End field, it should still change to 3600
- Click "Integrate" to submit the job, the message window should be green