### PR TITLE
LIMS-1425: Show samples with no processing as grey

### DIFF
--- a/client/src/js/modules/shipment/views/plate.js
+++ b/client/src/js/modules/shipment/views/plate.js
@@ -250,7 +250,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                             
                                 this.ctx.fillStyle = sample.get(this.rankOption.value)
                                     ? utils.rainbow(val/4) 
-                                    : (sample.get(this.rankOption.check) > 0 ? 'yellow' : '#dfdfdf')
+                                    : '#dfdfdf'
                                 this.ctx.fill()
 
                             } else {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1425](https://jira.diamond.ac.uk/browse/LIMS-1425)

**Summary**:

When ranking samples on a plate by autoprocessing (AP) resolution or completeness, any samples with failed autoprocessing are currently displayed as yellow. This is confusing, they should just be grey, as for samples without any data.

**Changes**:
- Dont show any samples as 'yellow', just use `#dfdfdf` (grey) for all.

**To test**:
- Go to a plate eg /containers/cid/309483, change the "Display" radio button to "Data Status"
- Take a note of which wells are shown in blue, this means the autoprocessing failed, and which are green, this means the autoprocessing succeeded
- Tick the "Rank By" checkbox, and check the blue wells turn grey, not yellow
- Check the green wells turn red/orange/green as before
