### PR TITLE
LIMS-1435: Put CCP4 location into config variable

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -153,6 +153,9 @@
     # Server log location
     $server_log = '/dls_sw/<%=BEAMLINENAME%>/logs/gda-server.log';
 
+    # Path to ccp4 location
+    $ccp4_location = '/dls_sw/apps/ccp4/latest/ccp4-9';
+
     # Email addresses, comma separate for multiple recepients
     # - Email templates in assets/emails in plain and html/ format
 

--- a/api/scripts/mtz2map.sh
+++ b/api/scripts/mtz2map.sh
@@ -2,19 +2,6 @@
 
 cd /tmp
 
-# If you are running with the module system, load ccp4
-#. /etc/profile.d/modules.sh
-#module load ccp4
-
-# If not, define the environment variables required below
-#export CCP4_MASTER=/dls_sw/apps/ccp4/<ccp4 version>
-export CCP4_MASTER=/dls_sw/apps/ccp4/latest/ccp4-8.0
-export CINCL=$CCP4_MASTER/include
-export CLIBD=$CCP4_MASTER/lib/data
-
-export CCP4_SCR=/tmp
-export root=$CCP4_MASTER/bin
-
 if [ -f $1 ]; then
 	mtz=$1
 else
@@ -40,6 +27,14 @@ else
 		exit
 	fi
 fi
+
+#export CCP4_MASTER=/dls_sw/apps/ccp4/<ccp4 version>
+export CCP4_MASTER=$5
+export CINCL=$CCP4_MASTER/include
+export CLIBD=$CCP4_MASTER/lib/data
+
+export CCP4_SCR=/tmp
+export root=$CCP4_MASTER/bin
 
 if [ $3 == 'dimple' ]; then
 

--- a/api/src/Downstream/DownstreamProcessing.php
+++ b/api/src/Downstream/DownstreamProcessing.php
@@ -217,15 +217,14 @@ abstract class DownstreamPlugin implements DownstreamPluginInterface {
      * @param string $pdb The input pdb file to generate the map around
      */
     function convert_mtz($mtz, $aid, $program, $pdb, $map = 0) {
+        global $ccp4_location;
         exec(
             '/bin/bash ./scripts/mtz2map.sh ' .
-                $mtz .
-                ' ' .
-                $aid .
-                ' ' .
-                $program .
-                ' ' .
-                $pdb,
+                $mtz . ' ' .
+                $aid . ' ' .
+                $program . ' ' .
+                $pdb . ' ' .
+                $ccp4_location,
             $output,
             $res
         );


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1435](https://jira.diamond.ac.uk/browse/LIMS-1435)

**Summary**:

CCP4 has been updated, so the old path no longer works, meaning dimple maps show no electron density. The path shouldn't be hard-coded though.

**Changes**:
- Add `$ccp4_location` config variable
- Pass that variable into the `mtz2map.sh` script

**To test**:
- Add the config variable with `$ccp4_location = '/dls_sw/apps/ccp4/latest/ccp4-9';`
- Open a data collection with a dimple result, eg /dc/visit/nt37104-106/id/14642946
- Click on the Downstream Processing bar to show the dimple results, then click "Map / Model Viewer"
- Check the electron density is shown in blue in the centre of the image
![image](https://github.com/user-attachments/assets/f23c58e5-bddd-4764-8270-a466c9f62915)
- Check you can move/rotate the image

