### PR TITLE
LIMS-1003: Fix searching of container inspections

### DIFF
--- a/api/src/Page/Imaging.php
+++ b/api/src/Page/Imaging.php
@@ -376,6 +376,11 @@ class Imaging extends Page
                 $where .= " AND i.state='Completed'";
         }
 
+        if ($this->has_arg('s')) {
+            $where .= " AND (CONCAT(p.proposalcode, p.proposalnumber) LIKE CONCAT('%', :" . (sizeof($args) + 1) . ", '%') OR c.code LIKE CONCAT('%', :" . (sizeof($args) + 2) . ", '%'))";
+            array_push($args, $this->arg('s'), $this->arg('s'));
+        }
+
         $tot = $this->db->pq("SELECT count(i.containerinspectionid) as tot FROM containerinspection i
               INNER JOIN container c ON c.containerid = i.containerid
               INNER JOIN dewar d ON d.dewarid = c.dewarid
@@ -420,12 +425,6 @@ class Imaging extends Page
             $dir = $this->has_arg('order') ? ($this->arg('order') == 'asc' ? 'ASC' : 'DESC') : 'ASC';
             if (array_key_exists($this->arg('sort_by'), $cols))
                 $order = $cols[$this->arg('sort_by')] . ' ' . $dir;
-        }
-
-        if ($this->has_arg('s')) {
-            $where .= " AND (LOWER(CONCAT(p.proposalcode, p.proposalnumber)) LIKE LOWER(CONCAT(CONCAT('%', :" . (sizeof($args) + 1) . "), '%')) OR LOWER(c.code) LIKE LOWER(CONCAT(CONCAT('%', :" . (sizeof($args) + 2) . "), '%')))";
-            array_push($args, $this->arg('s'));
-            array_push($args, $this->arg('s'));
         }
 
         if ($this->has_arg('ty')) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1003](https://jira.diamond.ac.uk/browse/LIMS-1003)

**Summary**:

If you go to the imaging admin page and (under inspections) type something in the search bar, you either get every container ever or an error 500.
The `paginate` function expects the last 2 values in `$args` to be the start and end of the range required. The search code was adding to `$args` after the start/end values had been added, so if you searched for a number, you just got every container ever, and if you searched for text you got an error about a "non-numeric value".

**Changes**:
- Move the code for searching higher up, before the counting of results.
- Simplify the search code by removing unnecessary `LOWER()` and `CONCAT()` calls, and appending the search text to $args twice in one go.

**To test**:
- Go to the imaging admin page (/admin/imaging/)
- Under inspections, search for `38893`. Only one result should appear, for proposal in38893.
- Search for `2151_thaum`. 14 results should appear, for proposal mx34066.
