### PR TITLE
LIMS-1354: Migrate from ActiveMQ to RabbitMQ

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -21,7 +21,7 @@
     "mpdf/mpdf": "8.1.2",
     "ralouphie/getallheaders": "2.0.5",
     "slim/slim": "2.6.2",
-    "stomp-php/stomp-php": "3.0.6",
+    "php-amqplib/php-amqplib": "^2.0",
     "symfony/http-foundation": "^5.4",
     "symfony/filesystem": "^5.4",
     "mpdf/qrcode": "^1.2",

--- a/api/composer.json
+++ b/api/composer.json
@@ -26,7 +26,8 @@
     "symfony/filesystem": "^5.4",
     "mpdf/qrcode": "^1.2",
     "mtcmedia/dhl-api": "dev-master#9b4b6315",
-    "maennchen/zipstream-php": "2.1.0"
+    "maennchen/zipstream-php": "2.1.0",
+    "phpseclib/bcmath_compat": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -1109,14 +1109,15 @@ class Page
     }
 
 
-    function _send_zocalo_message($zocalo_queue, $zocalo_message, $error_code = 500)
+    function _send_zocalo_message($rabbitmq_zocalo_vhost, $zocalo_message, $error_code = 500)
     {
         global
-        $zocalo_server,
-        $zocalo_username,
-        $zocalo_password;
+        $rabbitmq_zocalo_host,
+        $rabbitmq_zocalo_port,
+        $rabbitmq_zocalo_username,
+        $rabbitmq_zocalo_password;
 
-        if (empty($zocalo_server) || empty($zocalo_queue))
+        if (empty($rabbitmq_zocalo_host) || empty($rabbitmq_zocalo_vhost))
         {
             $message = 'Zocalo server or queue not specified.';
             error_log($message);
@@ -1129,8 +1130,8 @@ class Page
         try
         {
             error_log("Sending message" . var_export($zocalo_message, true));
-            $queue = new Queue($zocalo_server, $zocalo_username, $zocalo_password);
-            $queue->send($zocalo_queue, $zocalo_message, true, $this->user->loginId);
+            $queue = new Queue($rabbitmq_zocalo_host, $rabbitmq_zocalo_port, $rabbitmq_zocalo_username, $rabbitmq_zocalo_password);
+            $queue->send($rabbitmq_zocalo_vhost, $zocalo_message);
         }
         catch (Exception $e)
         {

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -1115,7 +1115,8 @@ class Page
         $rabbitmq_zocalo_host,
         $rabbitmq_zocalo_port,
         $rabbitmq_zocalo_username,
-        $rabbitmq_zocalo_password;
+        $rabbitmq_zocalo_password,
+        $rabbitmq_zocalo_routing_key;
 
         if (empty($rabbitmq_zocalo_host) || empty($rabbitmq_zocalo_vhost))
         {
@@ -1130,8 +1131,8 @@ class Page
         try
         {
             error_log("Sending message" . var_export($zocalo_message, true));
-            $queue = new Queue($rabbitmq_zocalo_host, $rabbitmq_zocalo_port, $rabbitmq_zocalo_username, $rabbitmq_zocalo_password);
-            $queue->send($rabbitmq_zocalo_vhost, $zocalo_message);
+            $queue = new Queue($rabbitmq_zocalo_host, $rabbitmq_zocalo_port, $rabbitmq_zocalo_username, $rabbitmq_zocalo_password, $rabbitmq_zocalo_vhost);
+            $queue->send($zocalo_message, $rabbitmq_zocalo_routing_key);
         }
         catch (Exception $e)
         {

--- a/api/src/Page/Process.php
+++ b/api/src/Page/Process.php
@@ -355,7 +355,7 @@ class Process extends Page
 
     function _enqueue()
     {
-        global $zocalo_mx_reprocess_queue;
+        global $rabbitmq_zocalo_vhost;
 
         if (!$this->has_arg('PROCESSINGJOBID')) $this->_error('No processing job specified');
 
@@ -379,7 +379,7 @@ class Process extends Page
                 'ispyb_process' => intval($this->arg('PROCESSINGJOBID')),
             )
         );
-        $this->_send_zocalo_message($zocalo_mx_reprocess_queue, $message);
+        $this->_send_zocalo_message($rabbitmq_zocalo_vhost, $message);
 
         $this->_output(new \stdClass);
     }

--- a/api/src/Queue.php
+++ b/api/src/Queue.php
@@ -19,22 +19,16 @@ class Queue
 
     function send($vhost, array $message)
     {
-        try {
-            $connection = new AMQPStreamConnection($this->host, $this->port, $this->username, $this->password);
-            $channel = $connection->channel();
+        $connection = new AMQPStreamConnection($this->host, $this->port, $this->username, $this->password);
+        $channel = $connection->channel();
 
-            $msg = new AMQPMessage(
-                json_encode($message, JSON_UNESCAPED_SLASHES)
-            );
+        $msg = new AMQPMessage(
+            json_encode($message, JSON_UNESCAPED_SLASHES)
+        );
 
-            $channel->basic_publish($msg, '', $vhost);
+        $channel->basic_publish($msg, '', $vhost);
 
-            $channel->close();
-            $connection->close();
-        } catch (AMQPException $e) {
-            /** @noinspection PhpUnhandledExceptionInspection */
-
-            throw $e;
-        }
+        $channel->close();
+        $connection->close();
     }
 }

--- a/api/src/Queue.php
+++ b/api/src/Queue.php
@@ -7,26 +7,27 @@ use PhpAmqpLib\Message\AMQPMessage;
 
 class Queue
 {
-    private $host, $port, $username, $password;
+    private $host, $port, $username, $password, $vhost;
 
-    function __construct($host, $port, $username, $password)
+    function __construct($host, $port, $username, $password, $vhost)
     {
         $this->host = $host;
         $this->port = $port;
         $this->username = $username;
         $this->password = $password;
+        $this->vhost = $vhost;
     }
 
-    function send($vhost, array $message)
+    function send(array $message, $routing_key)
     {
-        $connection = new AMQPStreamConnection($this->host, $this->port, $this->username, $this->password);
+        $connection = new AMQPStreamConnection($this->host, $this->port, $this->username, $this->password, $this->vhost);
         $channel = $connection->channel();
 
         $msg = new AMQPMessage(
             json_encode($message, JSON_UNESCAPED_SLASHES)
         );
 
-        $channel->basic_publish($msg, '', $vhost);
+        $channel->basic_publish($msg, null, $routing_key);
 
         $channel->close();
         $connection->close();


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1354](https://jira.diamond.ac.uk/browse/LIMS-1354)

**Summary**:
SynchWeb sends messages to ActiveMQ to trigger MX reprocessing and AlphaFold model prediction jobs. A single ActiveMQ server proved unreliable so a RabbitMQ cluster was established in early 2021. An ActiveMQ to RabbitMQ bridge service was implemented as a temporary solution while applications migrated to RabbitMQ. The failure of the bridge service in mid-2024 highlighted the need to update SynchWeb to send messages direct to RabbitMQ.
SynchWeb uses the Stomp (Simple Text Oriented Message Protocol) PHP client to send messages to ActiveMQ. This ticket updates SynchWeb to use an AMQP (Advanced Message Queuing Protocol) client to send messages to RabbitMQ. The php-amqplib client is the de facto standard and detailed in the RabbitMQ PHP tutorial.

**Changes**:
- Update composer.json to replace stomp-php dependency with php-amqplib.
- Add global variables for RabbitMQ configuration that reflect RabbitMQ nomenclature.
- Update Queue class and Queue::send method to use AMQPStreamConnection and AMQPMessage. Remove redundant ActiveMQ header information e.g. synchweb.host and synchweb.user.
- Update Process class to use new global variable names.
- Update Page class to use new global variable names, Queue class signature, and Queue::send method signature.

**To test**:
- Reprocess MX data via the gearwheel icon on the Data Collection page. In the database, SynchWeb will create a new record in the ProcessingJob table. SynchWeb will send a message to RabbitMQ with this ProcessingJobId. Zocalo will read the message from RabbitMQ and create a corresponding record in the AutoProcProgram table. A new processing job will soon be shown under Auto Processing on the Data Collection page.
- AlphaFold model prediction jobs are triggered when proteins are added or updated with a sequence. Model prediction does not currently work as AlphaFold itself was compressed in the great GPFS02 purge of 2024.