### PR TITLE
LIMS-1424: Show visit for each container if set

### DIFF
--- a/client/src/js/templates/shipment/containerli.html
+++ b/client/src/js/templates/shipment/containerli.html
@@ -1,10 +1,13 @@
 
         <%- NAME %> (<%-SAMPLES%> samples)
         <% if (REQUESTEDIMAGERID) { %>
-        	[Req: <%-REQUESTEDIMAGER%>]
+            [Req: <%-REQUESTEDIMAGER%>]
         <% } %>
         <% if (IMAGERID) { %>
-        	[Img: <%-IMAGER%>]
+            [Img: <%-IMAGER%>]
+        <% } %>
+        <% if (VISIT) { %>
+            (<%-VISIT%>)
         <% } %>
         <span class="r">
             <a class="button button-notext print" title="Click to print container contents" href="<%-APIURL%>/pdf/container/cid/<%-CONTAINERID%>/prop/<%-PROP%>"><i class="fa fa-print"></i> <span>Print Container Report</span></a>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1424](https://jira.diamond.ac.uk/browse/LIMS-1424)

**Summary**:

We should display the visit associated with each container (if one exists).

**Changes**:
- Add visit to each container in the list
- Replace tabs with spaces

**To test**:
- Go to a UDC shipment, eg /shipments/sid/65097, check each container shows the visit after the number of samples eg `CPS5392 (16 samples) (mx34566-21)`
- Go to a non-UDC shipment, eg /shipments/sid/61956, check each container shows only the number of samples eg `CPS5433 (16 samples)`
- Go to a VMXi shipment, eg /shipments/sid/64374, check each container shows the number of samples, the requested and actual imager used, and the visit, eg `7013_magic (192 samples) [Req: VMXi 20c] [Img: VMXi 20c] (nt37104-99)`
