### PR TITLE
LIMS-1430: Fix bugs on prepare for data collection page

### DIFF
--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -944,7 +944,6 @@ define(['marionette',
                 { name: '_valid', label: 'Valid', cell: table.TemplateCell, editable: false, test: '_valid', template: '<i class="button fa fa-check active"></i>' },
                 { name: '', cell: table.StatusCell, editable: false },
                 { label: '', cell: SnapshotCell, editable: false, inspectionimages: this.inspectionimages },
-
             ]
 
             if (app.mobile()) {
@@ -1001,7 +1000,3 @@ define(['marionette',
     })
         
 })
-
-// TODO
-//
-// * Add auto sample, filter to manual, add manual, remove auto doesnt work

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -851,8 +851,8 @@ define(['marionette',
             this.getInspectionImages()
             this.refreshQSubSamples()
             this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
-            this.listenTo(this.subsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
-            this.listenTo(this.subsamples, 'change', this.updateQueueLength)
+            this.listenTo(this.unfilteredSubsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
+            this.listenTo(this.unfilteredSubsamples, 'change', this.updateQueueLength)
             this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.onContainerQueueIdChange)
         },
 

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -636,7 +636,7 @@ define(['marionette',
                 },
                 success: function(resp) {
                     _.each(resp, function (r) {
-                        let ss = self.qsubsamples.fullCollection.findWhere({ BLSUBSAMPLEID: r.BLSUBSAMPLEID })
+                        let ss = self.typeselector.shadowCollection.findWhere({ BLSUBSAMPLEID: r.BLSUBSAMPLEID })
                         ss.set({ READYFORQUEUE: '0' })
                     })
                 },
@@ -721,7 +721,7 @@ define(['marionette',
                 return
             }
 
-            // need to validate all models here again incase they havnt been rendered
+            // need to validate all models here again in case they haven't been rendered
             this.qsubsamples.fullCollection.each(function(qs) {
                 if (qs.get('_valid') !== undefined) return
 
@@ -730,7 +730,7 @@ define(['marionette',
                 console.log({ experimentCell: val })
             }, this)
 
-            var invalid = this.qsubsamples.fullCollection.where({ '_valid': false })
+            var invalid = this.typeselector.shadowCollection.where({ '_valid': false })
             console.log('queue', invalid, invalid.length > 0)
             if (invalid.length > 0) {
                 app.alert({ message: 'There are '+invalid.length+' sub samples with invalid experimental plans, please either correct or remove these from the queue' })

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -858,7 +858,7 @@ define(['marionette',
 
         updateQueueLength: function() {
             var n = this.typeselector.shadowCollection.length
-            this.ui.queuelength.html('('+n+' sample'+(n==1 ? '' : 's')+')')
+            this.ui.queuelength.html('('+n+' data collection'+(n==1 ? '' : 's')+')')
         },
 
         onContainerQueueIdChange: function() {

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -858,7 +858,7 @@ define(['marionette',
 
         updateQueueLength: function() {
             var n = this.typeselector.shadowCollection.length
-            this.ui.queuelength.html('('+n+' data collection'+(n==1 ? '' : 's')+')')
+            this.ui.queuelength.html(`(${n} data collection${n===1 ? '' : 's'})`)
         },
 
         onContainerQueueIdChange: function() {

--- a/client/src/js/templates/imaging/queuecontainer.html
+++ b/client/src/js/templates/imaging/queuecontainer.html
@@ -2,8 +2,7 @@
 
 <p class="help">This pages allows you to queue samples in a container for data collection</p>
 
-<% if (CONTAINERQUEUEID) { %>
-<p class="message alert">
+<p class="message alert unqueuebutton">
     <% if (['disposed', 'in_storage', null].indexOf(CONTAINERSTATUS) > -1) { %>
         This container is queued for data collection, you can not modify it without unqueuing it
         <a href="#" class="button unqueue"><i class="fa fa-times"></i> Unqueue</a>
@@ -11,7 +10,6 @@
         This container is en route for data collection, it cannot be unqueued.
     <% } %>
 </p>
-<% } %>
 
 <div class="clearfix xtalpreview">
     <div class="image right"></div>
@@ -65,10 +63,11 @@ Presets: <select name="preset"></select>
 </div>
 <div class="qsamples"></div>
 
-<% if (!CONTAINERQUEUEID) { %>
+<span class="queuebutton">
 <h2>Queue Plate</h2>
 <p>Queuing the container will make the queued items immutable, please make sure you have added all sub samples, and that they have valid experimental plans</p>
 <div class="form">
     <button name="submit" value="1" type="submit" class="button submit">Queue Container</button>
 </div>
-<% } %>
+</span>
+

--- a/client/src/js/templates/imaging/queuecontainer.html
+++ b/client/src/js/templates/imaging/queuecontainer.html
@@ -68,6 +68,7 @@ Presets: <select name="preset"></select>
 <p>Queuing the container will make the queued items immutable, please make sure you have added all sub samples, and that they have valid experimental plans</p>
 <div class="form">
     <button name="submit" value="1" type="submit" class="button submit">Queue Container</button>
+    <span class="queuelength"></span>
 </div>
 </span>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1430](https://jira.diamond.ac.uk/browse/LIMS-1430)

**Summary**:

The (VMXi) "Prepare for data collection" page needs a number of bugfixes and improvements.

**Changes**:
- Allow queueing the container even if all data collections are currently hidden due to filters
- Show/hide relevant controls so that no refresh is needed after queueing or unqueueing the container. This exposed a number of bugs:
  - Fix bug where couldn't remove sample that wasn't currently displayed in the Available Samples section
  - Fix bug where unqueueing container removed all data collections until refresh
- Fix bug where filtering on the available samples affected the filtering of data collections
- Fix bug where invalid data collections could be queued if they were filtered
- Show number of added data collections next to the Queue Container button
- Show successful messages in green not red
- Fix typo from loose to lose

**To test**:
- Go to a plate on a test proposal, eg /containers/queue/309228.
- Try to Queue Container when there are no data collections in the Queued Samples area, check it refuses.
- Add an "Auto" subsample from the Available Samples area, check the plus button next to it disappears.
- Leave the parameters unfilled, try to Queue Container, check it refuses.
- Fill in the parameters, click Queue Container, check "Container Queued Successfully" message appears in green not red.
- Now check Unqueue button has appeared at the top, the plus buttons next to the Available Samples have disappeared, the Copy/Save/Unqueue buttons in the Queued Samples area have been replaced by a View Sample button, and the Queue Container button has disappeared.
- Refresh the page, check the container is still queued, and the list of Queued Samples still shows the same one.
- Unqueue the container, check the list of Queued Samples still shows the same one.
- Add a "Manual" subsample from the Available Samples area, but leave the parameters unfilled. Click the "Auto" filter on the Queued Samples area, so that the invalid sample is hidden. Try to queue the container, check it refuses.
- Check next to the Queued Container button it says "(2 data collections)", even if some are filtered.
- Clear the "Auto" filter on the Queued Samples area, but turn on the "Auto" filter on the Available Samples area. Check you can Unqueue the "manual" sample and it disappears from the Queued Samples area.
- Change the filter on the Available Samples area to "Manual", and re-add the "manual" sample. Turn on the "Auto" filter on the Queued Samples area. Press the Unqueue all button, check all the samples disappear from the Queued Samples area.
