### PR TITLE
LIMS-380: Fix position of autoPROC images

### DIFF
--- a/client/src/js/views/log.js
+++ b/client/src/js/views/log.js
@@ -7,8 +7,15 @@ define(['marionette', 'views/dialog', 'utils'], function(Marionette, DialogView,
         initialize: function(options) {
             this.url = options.url
             this.load()
-            this.iframe = $(
-                `<iframe style="position: absolute;" onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';this.style.width=(this.contentWindow.document.body.scrollWidth)+'px';"></iframe>`)
+            this.iframe = $(`<iframe style="position: absolute;"></iframe>`)
+            $(window).on("resize", this, this.onResize);
+        },
+
+        onResize: function(event) {
+            parent_el = document.getElementById('dialog')
+            iframe_el = event.data.iframe[0]
+            iframe_el.style.height = parseInt(parent_el.style.height)-10+'px'
+            iframe_el.style.width = parseInt(parent_el.style.width)-10+'px'
         },
 
         // Override existing dialogOptions of Dialog View


### PR DESCRIPTION
**JIRA ticket**: [LIMS-380](https://jira.diamond.ac.uk/browse/LIMS-380)

**Summary**:

https://github.com/DiamondLightSource/SynchWeb/pull/390 introduced a bug where image modals opened in autoPROC's summary file opened at the top of the page, requiring much scrolling just to see them.

**Changes**:
- Don't set the iframe width/height on load, this confuses the modals
- Use the jquery on resize event to set the iframe width/height to just smaller than the parent div

**To test**:
- Go to a data collection with successful autoPROC runs, eg /dc/visit/cm37235-3/id/14930010
- Go to the autoPROC tab, click "Logs & Files", then click "View" next to "summary_inlined.html"
- When the popup loads (can be a few seconds as v large files), scroll down to one of the graphs, and click on it. It should open a larger version, without needing to scroll. Check it closes with the x button.
- Resize the iframe, check the contents are resized to match the space available, and that images still work
- Repeat with a "xia2.html" file from a Xia2 run, check the content resizes as the iframe is resized
- (NB if you try on a txt file, it won't resize as the content is within \<pre\>\</pre\> tags)
