### PR TITLE
 LIMS-1390: Fix searching of data collection groups

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -368,13 +368,14 @@ class DC extends Page
             $s = str_replace('_', '$_', $this->arg('s'));
 
             $st = sizeof($args) + 1;
-            $where .= " AND (lower(dc.filetemplate) LIKE lower(CONCAT(CONCAT('%',:$st),'%')) ESCAPE '$' OR lower(dc.imagedirectory) LIKE lower(CONCAT(CONCAT('%',:" . ($st + 1) . "), '%')) ESCAPE '$' OR lower(smp.name) LIKE lower(CONCAT(CONCAT('%', :" . ($st + 2) . "), '%')) ESCAPE '$')";
-            $where2 .= " AND (lower(es.comments) LIKE lower(CONCAT(CONCAT('%',:" . ($st + 3) . "), '%')) ESCAPE '$' OR lower(es.element) LIKE lower(CONCAT(CONCAT('%',:" . ($st + 4) . "), '%')) ESCAPE '$' OR lower(smp.name) LIKE lower(CONCAT(CONCAT('%',:" . ($st + 5) . "), '%')) ESCAPE '$')";
+            $where .= " AND (dc.filetemplate LIKE CONCAT('%',:$st,'%') ESCAPE '$' OR dc.imagedirectory LIKE CONCAT('%',:" . ($st + 1) . ",'%') ESCAPE '$' OR smp.name LIKE CONCAT('%', :" . ($st + 2) . ",'%') ESCAPE '$')";
+            $where2 .= " AND (es.comments LIKE CONCAT('%',:" . ($st + 3) . ",'%') ESCAPE '$' OR es.element LIKE CONCAT('%',:" . ($st + 4) . ",'%') ESCAPE '$' OR smp.name LIKE CONCAT('%',:" . ($st + 5) . ",'%') ESCAPE '$')";
             $where3 .= ' AND r.robotactionid < 0';
-            $where4 .= " AND (lower(xrf.filename) LIKE lower(CONCAT(CONCAT('%',:" . ($st + 6) . "), '%')) ESCAPE '$' OR lower(smp.name) LIKE lower(CONCAT(CONCAT('%',:" . ($st + 7) . "), '%')) ESCAPE '$')";
+            $where4 .= " AND (xrf.filename LIKE CONCAT('%',:" . ($st + 6) . ",'%') ESCAPE '$' OR smp.name LIKE CONCAT('%',:" . ($st + 7) . ",'%') ESCAPE '$')";
 
             for ($i = 0; $i < 8; $i++)
                 array_push($args, $s);
+
         }
 
         # Set Count field
@@ -511,9 +512,9 @@ class DC extends Page
             // $this->db->set_debug(True);
 
             // will want to support these too at some point
-            $where2 = ' AND es.energyscanid < 0';
-            $where3 = ' AND r.robotactionid < 0';
-            $where4 = ' AND xrf.xfefluorescencespectrumid < 0';
+            $where2 .= ' AND es.energyscanid < 0';
+            $where3 .= ' AND r.robotactionid < 0';
+            $where4 .= ' AND xrf.xfefluorescencespectrumid < 0';
 
             if ($this->has_arg('dcg')) {
                 $where .= ' AND dc.datacollectiongroupid=:' . (sizeof($args) + 1);


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1390](https://jira.diamond.ac.uk/browse/LIMS-1390)

**Summary**:

Viewing a data collection group (or a group linked by a processing job) and then using the search box gives a server error.

**Changes**:
- Remove unnecessary `lower()` and `concat()` calls as MariaDB is case-insensitive and you can pass many arguments to a single `concat()`
- Add to `$where2`, `$where3` and `$where4` rather than replacing them, as the `$args` array has already been populated expecting them to have several extra values

**To test**:
- Go to a data collection group, eg /dc/visit/mx34566-20/dcg/12631761 and search for just one of the data collections, eg `16_1`, and check only one data collection is shown
- Go to a data processing group eg /dc/pjid/24527370, and search for just one of the data collections, eg `12_1`, and check only one data collection is shown
- Go to a full visit eg /dc/visit/mx34566-20 and check the search box works as expected
