### PR TITLE
LIMS-1286: Show ERA status on calendar and visits list

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -456,6 +456,7 @@ class Proposal extends Page
                     s.beamlineoperator                                            AS lc,
                     s.comments,
                     s.scheduled,
+                    s.riskrating,
                     st.typename                                                   AS sessiontype,
                     DATE_FORMAT(s.startdate, '%d-%m-%Y %H:%i')                    AS startdate,
                     DATE_FORMAT(s.enddate, '%d-%m-%Y %H:%i')                      AS enddate,

--- a/client/src/js/modules/calendar/views/components/calendar-day-events.vue
+++ b/client/src/js/modules/calendar/views/components/calendar-day-events.vue
@@ -21,7 +21,12 @@
             class="tw-no-underline tw-text-content-page-color"
           >
             {{ session['VISIT'] }}
-          </router-link> <span> ({{ session['LEN'] }})</span>
+          </router-link>
+          <span v-if="session['RISKRATING'] == 'Low'" title="Risk Rating: Low">&#128994;</span>
+          <span v-else-if="session['RISKRATING'] == 'Medium'" title="Risk Rating: Medium">&#128993;</span>
+          <span v-else-if="session['RISKRATING'] == 'High'" title="Risk Rating: High">&#128308;</span>
+          <span v-else title="No approved ERA">&#9899;</span>
+          <span> ({{ session['LEN'] }})</span>
         </p>
         <p class="tw-ml-2">
           - {{ session['BEAMLINEOPERATOR'] }}

--- a/client/src/js/modules/visits/views/visit_list.vue
+++ b/client/src/js/modules/visits/views/visit_list.vue
@@ -57,7 +57,10 @@
                                 <a v-if="value.key == 'LINKS' && visit.DCCOUNT>0" class="button button-notext" title="View Statistics" id="STATS"><i class="fa fa-pie-chart"></i></a>
                                 <a v-if="value.key == 'LINKS' && visit.DCCOUNT>0" class="button button-notext" title="Download PDF Report" id="PDF"><i class="fa fa-list"></i></a>
                                 <a v-if="value.key == 'LINKS' && visit.DCCOUNT>0" class="button button-notext" title="Export Data Collections to CSV" id="CSV"><i class="fa fa-file-o"></i></a>
-                                
+                                <span v-if="value.key == 'ERA' && visit.RISKRATING == 'Low'" title="Risk Rating: Low">&#128994;</span>
+                                <span v-else-if="value.key == 'ERA' && visit.RISKRATING == 'Medium'" title="Risk Rating: Medium">&#128993;</span>
+                                <span v-else-if="value.key == 'ERA' && visit.RISKRATING == 'High'" title="Risk Rating: High">&#128308;</span>
+                                <span v-else-if="value.key == 'ERA'" title="No approved ERA">&#9899;</span>
                                 <div data-testid="visit-table-archived" v-if="value.key == 'ARCHIVED' && visit.ARCHIVED == 1">
                                     <i class="fa fa-archive r" :title="'The raw data from this visit have been '+ isArchived + '. You can no longer reprocess data or view full sized diffraction images.'"></i>
                                 </div>
@@ -133,6 +136,10 @@ export default {
                 {
                     key: "BEAMLINENAME",
                     title: 'Beamline'
+                },
+                {
+                    key: "ERA",
+                    title: 'ERA'
                 },
                 {
                     key: "DEWARS",


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1286](https://jira.diamond.ac.uk/browse/LIMS-1286)

**Summary**:

Users (and staff) often don't realise their ERA has not been validated as the visit approaches, so we should display it more prominently.

**Changes**:
- Get risk rating for each session from ISPyB (it should be synced to UAS)
- Display a green/yellow/red circle for low/medium/high risk sessions, and a black circle if the ERA has not been approved yet, on both the calendar page and also the visits list page
- Display a tooltip to explain the circle if a user hovers over it

**To test**:
- Go to an MX proposal (eg /dc/visit/mx37045-1) and then click the calendar link at the top left. As staff you should see lots of visits for the mx village, check a coloured circle appears next to each, and a tooltip appears if you hover over it. Check there are some green, yellow and black.
- Go to the /visits page, check there is an ERA column with the same circles and tooltip.
- Go to proposal mx18802 and check the visits list, this proposal has High risk sessions from May 2018, so should have red circles.

