### PR TITLE
LIMS-1454: Show non-automatic downstream processing

### DIFF
--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -141,7 +141,7 @@ class Processing extends Page {
                 INNER JOIN processingjob pj ON pj.datacollectionid = dc.datacollectionid
                 INNER JOIN autoprocprogram app ON pj.processingjobid = app.processingjobid
                 LEFT OUTER JOIN autoprocintegration api ON api.autoprocprogramid = app.autoprocprogramid
-                WHERE $where AND api.autoprocintegrationid IS NULL AND pj.automatic = 1
+                WHERE $where AND api.autoprocintegrationid IS NULL
                     AND app.processingprograms NOT IN ('$filter')",
             ),
             $ids


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1454](https://jira.diamond.ac.uk/browse/LIMS-1454)

**Summary**:

Manually re-run Dimple jobs do not show up as ticks or crosses, although the results are there if you expand.

**Changes**:
- Remove the requirement to only show 'automatic' downstream jobs

**To test**:
- Set the config variable:
```
$downstream_filter = array('big_ep', 'ep_predict', 'mr_predict');
```
- Go to a data collection where dimple has been re-run manually, eg /dc/visit/nt32304-39/id/15055911
- Check the number of ticks and crosses in the Downstream Processing bar matches the number of results that appear when you expand the bar. For the example above, there should be 
  - Dimple: 6 x tick, 4 x cross
  - MrBUMP: 7 x tick, 1 x cross
![image](https://github.com/user-attachments/assets/3233b343-cece-4624-893d-075908c9247c)

