### PR TITLE
LIMS-128: Add plate view to queue page

### DIFF
--- a/api/src/Page/Imaging.php
+++ b/api/src/Page/Imaging.php
@@ -611,7 +611,7 @@ class Imaging extends Page
             array_push($args, $this->arg('sid'));
         }
 
-        $images = $this->db->pq("SELECT i.containerid, si.containerinspectionid, ROUND(TIMESTAMPDIFF('HOUR', min(i2.bltimestamp), i.bltimestamp)/24,1) as delta, si.blsampleimageid, si.blsampleid, si.micronsperpixelx, si.micronsperpixely, si.blsampleimagescoreid, si.comments, TO_CHAR(si.bltimestamp, 'DD-MM-YYYY HH24:MI') as bltimestamp, sc.name as scorename, sc.score, sc.colour as scorecolour, max.maxscore, scorecolours.colour as maxscorecolour
+        $images = $this->db->pq("SELECT i.containerid, si.containerinspectionid, ROUND(TIMESTAMPDIFF('HOUR', min(i2.bltimestamp), i.bltimestamp)/24,1) as delta, si.blsampleimageid, si.blsampleid, si.micronsperpixelx, si.micronsperpixely, si.blsampleimagescoreid, si.comments, TO_CHAR(si.bltimestamp, 'DD-MM-YYYY HH24:MI') as bltimestamp, sc.name as scorename, sc.score, sc.colour as scorecolour, max.maxscore, scorecolours.colour as maxscorecolour, b.location
               FROM blsampleimage si
               LEFT OUTER JOIN blsampleimagescore sc ON sc.blsampleimagescoreid = si.blsampleimagescoreid
               INNER JOIN containerinspection i ON i.containerinspectionid = si.containerinspectionid
@@ -621,6 +621,7 @@ class Imaging extends Page
               INNER JOIN dewar d ON d.dewarid = c.dewarid
               INNER JOIN shipping s ON s.shippingid = d.shippingid
               INNER JOIN proposal p ON p.proposalid = s.proposalid
+              INNER JOIN blsample b ON b.blsampleid = si.blsampleid
 
               LEFT OUTER JOIN (SELECT blsampleid, max(score) as maxscore
                                FROM BLSampleImageScore sc

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -634,6 +634,22 @@ class Sample extends Page
         $third_inner_select_where = '';
         $args = array($this->proposalid);
 
+        if ($this->has_arg('s')) {
+            $st = sizeof($args) + 1;
+            $where .= " AND s.name LIKE CONCAT('%',:" . $st . ",'%')";
+            array_push($args, $this->arg('s'));
+        }
+
+        if ($this->has_arg('filter')) {
+            $filters = array(
+                'manual' => " AND ss.source='manual'",
+                'auto' => " AND ss.source='auto'",
+                'point' => " AND dp.experimentkind='SAD'",
+                'region' => " AND dp.experimentkind='MESH'",
+            );
+            $where .= $filters[$this->arg('filter')];
+        }
+
         if ($this->has_arg('sid')) {
             $where .= ' AND s.blsampleid=:' . (sizeof($args) + 1);
             $first_inner_select_where .= ' AND s.blsampleid=:' . (sizeof($args) + 2);

--- a/client/src/css/partials/_imaging.scss
+++ b/client/src/css/partials/_imaging.scss
@@ -226,3 +226,7 @@ input[name=gap] {
     text-align: center;
     box-sizing: content-box;
 }
+
+.plate-max-width {
+    max-width: 700px;
+}

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -12,6 +12,7 @@ define(['marionette',
 
     'modules/imaging/models/plan',
     'modules/imaging/collections/plans',
+    'modules/shipment/views/plate',
 
     'collections/beamlinesetups',
     
@@ -27,6 +28,7 @@ define(['marionette',
         SubSamples,
         TableView, table, FilterView, utils,
         DiffractionPlan, DiffractionPlans,
+        PlateView,
         BeamlineSetups,
         template, pointemplate, gridtemplate, xfetemplate,
         VMXiPoint, VMXiGrid, VMXiXFE,
@@ -361,53 +363,6 @@ define(['marionette',
             {id: 'manual', name: 'Manual' },
         ],
 
-        initialize: function(options) {
-            ClientFilterView.__super__.initialize.call(this, options)
-
-            this.filterablecollection = options.collection.fullCollection// || options.collection
-            this.shadowCollection = this.filterablecollection.clone()
-
-            this.listenTo(this.filterablecollection, 'add', function (model, collection, options) {
-                this.shadowCollection.add(model, options)
-            })
-            this.listenTo(this.filterablecollection, 'remove', function (model, collection, options) {
-                this.shadowCollection.remove(model, options)
-            })
-            this.listenTo(this.filterablecollection, 'sort', function (col) {
-                if (!this.query()) this.shadowCollection.reset(col.models)
-            })
-            this.listenTo(this.filterablecollection, 'reset', function (col, options) {
-                options = _.extend({reindex: true}, options || {})
-                if (options.reindex && options.from == null && options.to == null) {
-                    this.shadowCollection.reset(col.models)
-                    if (this.selected()) this._filter()
-                }
-            })
-        },
-
-        _filter: function() {
-            var id = this.selected()
-            this.trigger('selected:change', id, this.selectedName())
-            if (id) {
-                this.filterablecollection.reset(this.shadowCollection.filter(function(m) {
-                    if (id === 'region') {
-                        return m.get('X2') && m.get('Y2')
-
-                    } else if (id === 'point') {
-                        return m.get('X') && m.get('Y') && !m.get('X2')
-                    }
-                    else if (id === 'auto') {
-                        return m.get('SOURCE') == 'auto'
-
-                    } else if (id === 'manual') {
-                        return m.get('SOURCE') == 'manual'
-                    }
-                }), {reindex: false})
-            } else {
-                console.log('reset', this.shadowCollection)
-                this.filterablecollection.reset(this.shadowCollection.models, {reindex: false})
-            }
-        }
     })
     
 
@@ -518,6 +473,7 @@ define(['marionette',
             qfilt: '.qfilt',
             afilt: '.afilt',
             rimg: '.image',
+            plate: '.plate',
         },
         
         events: {
@@ -762,27 +718,40 @@ define(['marionette',
             return this.ui.notcompleted.is(':checked') ? 1 : null
         },
 
+        getSearch: function() {
+            return this.table.filter.query() || null
+        },
+
+        getFilter: function() {
+            return this.afilt.$el.find('.current').attr('id') || null
+        },
+
         refreshSubSamples: function() {
             this.subsamples.fetch()
         },
         
-        initialize: function() {
+        initialize: function(options) {
+            this.params = options.params
             this._lastSample = null
+            this._subsamples_ready = []
 
             this.platetypes = new PlateTypes()
             this.type = this.platetypes.findWhere({ name: this.model.get('CONTAINERTYPE') })
 
             this.subsamples = new SubSamples()
             this.subsamples.queryParams.cid = this.model.get('CONTAINERID')
+            if (this.params.s) this.subsamples.queryParams.s = this.params.s
+
             this.subsamples.state.pageSize = 10
-            this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
-            this.listenTo(this.subsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
-            this.subsamples.fetch()
+            this._subsamples_ready.push(this.subsamples.fetch())
 
             this.inspections = new ContainerInspections()
             this.inspections.queryParams.cid = this.model.get('CONTAINERID')
             this.inspections.setSorting('BLTIMESTAMP', 1)
-            this.inspections.fetch().done(this.getInspectionImages.bind(this))
+
+            this._subsamples_ready.push(this.inspections.fetch())
+
+            $.when.apply($, this._subsamples_ready).done(this.onSubsamplesReady.bind(this))
 
             this.inspectionimages = new InspectionImages()
 
@@ -827,6 +796,12 @@ define(['marionette',
             }
         },
 
+        onSubsamplesReady: function() {
+            this.getInspectionImages()
+            this.refreshQSubSamples()
+            this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
+            this.listenTo(this.subsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
+        },
 
         populatePresets: function() {
             this.ui.preset.html(this.plans.opts())
@@ -838,7 +813,7 @@ define(['marionette',
         },
 
         selectSample: function() {
-            this.subsamples.at(0).set({ isSelected: true })
+            if (this.subsamples.at(0)) this.subsamples.at(0).set({ isSelected: true })
         },
 
         refreshQSubSamples: function() {
@@ -861,6 +836,8 @@ define(['marionette',
         onRender: function() {
             this.subsamples.queryParams.nodata = this.getNoData.bind(this)
             this.subsamples.queryParams.notcompleted = this.getNotCompleted.bind(this)
+            this.subsamples.queryParams.s = this.getSearch.bind(this)
+            this.subsamples.queryParams.filter = this.getFilter.bind(this)
             this._ready.done(this.doOnRender.bind(this))
         },
 
@@ -886,6 +863,8 @@ define(['marionette',
                 collection: this.subsamples, 
                 columns: subSamplesColumns,
                 tableClass: 'subsamples', 
+                filter: 's',
+                search: this.params.s,
                 loading: true,
                 backgrid: { row: ClickableRow, emptyText: 'No sub samples found' },
                 noPageUrl: true,
@@ -945,10 +924,28 @@ define(['marionette',
             })
 
             this.qsmps.show(this.table2)
+
+            this.plateView = new PlateView({ collection: this.subsamples.fullCollection, type: this.type, inspectionimages: this.inspectionimages, showMaxScore: true })
+            this.listenTo(this.plateView, 'dropClicked', this.filterByLocation, this)
+            this.plate.show(this.plateView)
         },
 
         onShow: function() {
             this.rimg.show(this.image)
+        },
+
+        filterByLocation: function(pos) {
+            if (!pos) return;
+            var namedrop = this.type.getName(pos)+'d'+this.type.getDrop(pos)
+            if (this.table.filter.query() === namedrop) {
+                this.table.filter.clearSearchBox()
+            } else {
+                this.table.filter.searchBox().val(namedrop)
+            }
+            this.table.filter._updateUrl()
+            this.subsamples.fetch().done(this.selectSample.bind(this))
+            var i = this.inspectionimages.findWhere({ LOCATION: pos.toString() })
+            this.image.setModel(i)
         },
         
     })

--- a/client/src/js/modules/shipment/components/container-queue-wrapper.vue
+++ b/client/src/js/modules/shipment/components/container-queue-wrapper.vue
@@ -43,6 +43,7 @@ export default {
     },
     props: {
         'cid': Number,
+        'search': String,
     },
     data: function() {
         return {
@@ -59,6 +60,7 @@ export default {
         options: function() {
             return {
                 model: this.model,
+                params: { s: this.search }
             }
         },
         proposalType : function() {

--- a/client/src/js/modules/shipment/router.js
+++ b/client/src/js/modules/shipment/router.js
@@ -10,7 +10,7 @@ define(['utils/lazyrouter'], function(LazyRouter) {
       'shipments/pickup/sid/:sid': 'rebook_pickup',
 
       'containers/cid/:cid(/iid/:iid)(/sid/:sid)': 'view_container',
-      'containers/queue/:cid': 'queue_container',
+      'containers/queue/:cid(/s/:s)': 'queue_container',
       'containers/add/did/:did': 'add_container',
       'containers/add/visit/:visit': 'add_container_visit',
       'containers(/s/:s)(/ty/:ty)(/page/:page)': 'container_list',

--- a/client/src/js/modules/shipment/routes.js
+++ b/client/src/js/modules/shipment/routes.js
@@ -353,11 +353,12 @@ const routes = [
     }
   },
   {
-    path: '/containers/queue/:cid([0-9]+)',
+    path: '/containers/queue/:cid([0-9]+)(/s/)?:s([a-zA-Z0-9_-]+)?',
     name: 'container-queue',
     component: ContainerQueueWrapper,
     props: route => ({
       cid: +route.params.cid,
+      search: route.params.s || '',
     }),
   },
   {

--- a/client/src/js/templates/imaging/queuecontainer.html
+++ b/client/src/js/templates/imaging/queuecontainer.html
@@ -20,7 +20,7 @@
             <ul>
                 <li>
                     <span class="label">Container</span>
-                    <span class="NAME"><%-NAME%></span>
+                    <span class="NAME"><a href="/containers/cid/<%-CONTAINERID%>"><%-NAME%></a></span>
                 </li>
 
                 <li>
@@ -29,6 +29,8 @@
                 </li>
             </ul>
         </div>
+
+        <div class="plate plate-max-width"></div>
 
         <h2>Available Samples</h2>
         <div class="filter">
@@ -40,9 +42,7 @@
                 <li><label><input type="checkbox" name="nodata" /> Without Data</label></li>
                 <li><label><input type="checkbox" name="notcompleted" /> Not Completed</label></li>
             </ul>
-        </div>
-        <div class="filter">
-            <div class="filter filter-nohide afilt"></div>
+            <span class="filter filter-nohide afilt"></span>
         </div>
         <div class="asamples"></div>
     </div>

--- a/client/src/js/views/search.js
+++ b/client/src/js/views/search.js
@@ -3,7 +3,7 @@ define(['backbone'], function(Backbone) {
   var Search = Backbone.View.extend({
     /** @property */
     events: {
-        "keyup input[type=search]": "search",
+        "input input[type=search]": "search",
         "click a[data-backgrid-action=clear]": "clear",
         "submit": "search"
     },
@@ -131,12 +131,17 @@ define(['backbone'], function(Backbone) {
         collection.getFirstPage({data: data, reset: true, fetch: true});
       }
       else collection.fetch({data: data, reset: true});
-        if (this.url) {
-            var url = this.urlFragment ?
-                window.location.pathname.replace(new RegExp('\\/'+this.urlFragment+'\\/(\\w|-)+'), '')+(this.value ? '/'+this.urlFragment+'/'+this.value : '') :
-                window.location.pathname.replace(/\/\w+$/, '')+(this.value ? '/'+this.value : '')
-            window.history.pushState({}, '', url)
-        }
+      this._updateUrl()
+    },
+
+    _updateUrl: function() {
+      this.value = this.query()
+      if (this.url) {
+          var url = this.urlFragment ?
+              window.location.pathname.replace(new RegExp('\\/'+this.urlFragment+'\\/(\\w|-)+'), '')+(this.value ? '/'+this.urlFragment+'/'+this.value : '') :
+              window.location.pathname.replace(/\/\w+$/, '')+(this.value ? '/'+this.value : '')
+          window.history.pushState({}, '', url)
+      }
     },
 
     /**


### PR DESCRIPTION
**JIRA ticket**: [LIMS-128](https://jira.diamond.ac.uk/browse/LIMS-128)

**Summary**:

When queuing subsamples in a plate for data collection, it would be useful to show a view of the plate, rather than just a list of (possibly 1000s of) subsamples.

**Changes**:
- Move filtering by point/region/manual/auto to the server
- Display a plate view on the "Prepare For Data Collection" page (/containers/queue/<containerid>)
- Add a search bar to the same page
- Synchronize the search bar with clicking on the plate wells
- Load the inspection image when you click on the wells
- Fix site-wide bug where clearing the search box using the x (Chrome-only?) doesn't clear the search parameters

**To test**:
- Go to a VMXi proposal, eg nt37104, navigate to the /containers page, click a plate that is 'in storage' and has some subsamples, eg /containers/cid/309228
- Click on a few wells with subsamples and assign them a 'score', in the top left of the photo of the well, the colour of the well should change depending on the score you give
- Click "Prepare for Data Collection" to go to eg /containers/queue/309228. Check a view of the plate appears with the same colours as the previous page
- Check the Point/Region/Manual/Auto filters query the server and display only the relevant subsamples
- Click on a well on the plate, check the search bar updates to eg A1d1 and only subsamples matching that appear.
- Click on a well, check the photo of the well changes.
- Edit the search manually, check the results update
- Refresh the page, check the search perseveres (as the page URL has /s/searchquery)
- Delete the search using backspace, check all subsamples are displayed again
- (In Chrome or Edge), do a search, then clear it using the little [x] that appears, check the search updates correctly (this affects all search boxes on the site)