### PR TITLE
LIMS-1469: Fix download button on old summary page

### DIFF
--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -91,9 +91,7 @@ class Download extends Page
             $this->_error('There doesnt seem to be a data archive available for this visit');
     }
 
-    # ------------------------------------------------------------------------
-    # Download mtz/log file for Fast DP / XIA2
-    #   TODO: Delete me
+
     # This method either returns a list of plots from MX auto processing tools (n_obs, n_uniq, completeness etc.)
     # Or returns a specific plot based on auto processing attachment id (aid).
     # Individual plotly format Graphs can be returned via an aid, but will not be included in the list of plots (as their format is different)

--- a/client/src/js/modules/dc/views/summary.js
+++ b/client/src/js/modules/dc/views/summary.js
@@ -125,7 +125,7 @@ define(['marionette',
                 { label: 'Resolution', cell: APCell, template: '<%-SHELLS.overall.RLOW%> - <%-SHELLS.overall.RHIGH%><br /><%-SHELLS.innerShell.RLOW%> - <%-SHELLS.innerShell.RHIGH%><br /><%-SHELLS.outerShell.RLOW%> - <%-SHELLS.outerShell.RHIGH%>', editable: false },
                 { label: 'Rmeas', cell: APCell, template: '<span class="<%-CLASS.RMEAS.overall%>"><%-SHELLS.overall.RMEAS%></span><br /><span class="<%-CLASS.RMEAS.innerShell%>"><%-SHELLS.innerShell.RMEAS%></span><br /><span class="<%-CLASS.RMEAS.outerShell%>"><%-SHELLS.outerShell.RMEAS%></span>', editable: false },
                 { label: 'Completeness', cell: APCell, template: '<span class="<%-CLASS.COMPLETENESS.overall%>"><%-SHELLS.overall.COMPLETENESS%></span><br /><span class="<%-CLASS.COMPLETENESS.innerShell%>"><%-SHELLS.innerShell.COMPLETENESS%></span><br /><span class="<%-CLASS.COMPLETENESS.outerShell%>"><%-SHELLS.outerShell.COMPLETENESS%></span>', editable: false },
-                { label: '', cell: APCell, template: '<a href="'+app.apiurl+'/download/id/<%-DCID%>/aid/<%-AID%>" class="button button-notext dll" title="Download MTZ file"><i class="fa fa-download"></i> <span>Download MTZ file</span></a>', editable: false },
+                { label: '', cell: APCell, template: '<a href="'+app.apiurl+'/download/ap/archive/<%-AID%>" class="button button-notext dll" title="Download autoprocessing archive"><i class="fa fa-download"></i> <span>Download autoprocessing archive</span></a>', editable: false },
                 
             ]
             

--- a/client/src/js/modules/summary/views/summary.vue
+++ b/client/src/js/modules/summary/views/summary.vue
@@ -397,8 +397,8 @@
                                 <i class="fa fa-search"></i></a>
                             </p>
                             <p class="tw-ra tw-ml-1">
-                                <a href="'+app.apiurl+'/download/id/<%-DCID%>/aid/<%-AID%>" class="tw-button tw-button-notext tw-dll" 
-                                    title="Download MTZ file"><i class="fa fa-download"></i></a>
+                                <a href="'+app.apiurl+'/download/ap/archive/<%-AID%>" class="tw-button tw-button-notext tw-dll"
+                                    title="Download autoprocessing archive"><i class="fa fa-download"></i></a>
                             </p> -->
 
                         


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1469](https://jira.diamond.ac.uk/browse/LIMS-1469)

**Summary**:

On the (old) summary page, there is a button marked "Download MTZ file", but it just gives a 404 error. It appears the API endpoint was removed in 2b7850223e26c646dcd999a920ae2cd0a2a662f6 (see changes to Download.php).

**Changes**:
- Change link from /download/id/<%-DCID%>/aid/<%-AID%> to /download/ap/archive/<%-AID%> to match the new endpoint
- Remove old "delete me" comment 

**To test**:
- Go to a summary page for a visit eg /dc/summary/visit/cm37235-4
- Check the tooltip for the download button now says "Download autoprocessing archive"
- Check clicking the button downloads a zip of autoprocessing files