### PR TITLE
Improvement/lims 1458/fix GitHub warnings

### DIFF
--- a/client/src/js/models/protein.js
+++ b/client/src/js/models/protein.js
@@ -16,7 +16,7 @@ define(['backbone', 'markdown'], function(Backbone, markdown) {
         },
         
         refreshOptions: function() {
-            if (this.get('SEQUENCE')) this.attributes.SEQUENCEMD = markdown.toHTML(this.get('SEQUENCE'))
+            if (this.get('SEQUENCE')) this.set('SEQUENCEMD', markdown.toHTML(this.get('SEQUENCE')))
         },
 
         validation: {

--- a/client/src/js/models/visit.js
+++ b/client/src/js/models/visit.js
@@ -51,10 +51,10 @@ define(['backbone', 'backbone-validation', 'luxon'], function(Backbone, BackBone
     addDate: function() {
         var { DateTime } = luxon
         
-        this.attributes.ENISO = DateTime.fromISO(this.get('ENISO'), { zone: this.dateTimeZone })
-        this.attributes.STISO = DateTime.fromISO(this.get('STISO'), { zone: this.dateTimeZone })
-        this.attributes.LEN = Number(this.attributes.ENISO.diff(this.attributes.STISO)/(3600*1000)).toFixed(2);
-        this.attributes.VISITDETAIL = this.get('VISIT')+' ('+this.get('BL')+': '+this.get('ST')+')'
+        this.set('ENISO', DateTime.fromISO(this.get('ENISO'), { zone: this.dateTimeZone }))
+        this.set('STISO', DateTime.fromISO(this.get('STISO'), { zone: this.dateTimeZone }))
+        this.set('LEN', Number(this.get('ENISO').diff(this.get('STISO'))/(3600*1000)).toFixed(2))
+        this.set('VISITDETAIL', this.get('VISIT')+' ('+this.get('BL')+': '+this.get('ST')+')')
     },
 
     dateTimeZone: 'Europe/London'

--- a/client/src/js/modules/cell/views/beamlines.js
+++ b/client/src/js/modules/cell/views/beamlines.js
@@ -9,6 +9,11 @@ define(['marionette', 'utils',
         template: false,
         modelEvents: { 'change': 'render' },
 
+        ascsort: function(a,b) {
+            if (a[0] == b[0]) return 0
+            else return (a[0] < b[0]) ? -1 : 1
+        },
+
         onRender: function() {
               if (this.model.get('data')) {
                   var did = this.getOption('second') ? 1 : 0
@@ -35,23 +40,18 @@ define(['marionette', 'utils',
                     ticks.push([bl.length-1, b])
                 })
 
-                  _.each(this.model.get('data')[did], function(v, i) {
-                      var y = yrs.indexOf(v.YEAR)
-                      var b = bl.indexOf(v.BL)
-                      //console.log('d', y, b)
-                      d[y].data.push([b, v.COUNT])
-                  })
+                _.each(this.model.get('data')[did], function(v, i) {
+                    var y = yrs.indexOf(v.YEAR)
+                    var b = bl.indexOf(v.BL)
+                    //console.log('d', y, b)
+                    d[y].data.push([b, v.COUNT])
+                })
 
-                  function ascsort(a,b) {
-                      if (a[0] == b[0]) return 0
-                      else return (a[0] < b[0]) ? -1 : 1
-                  }
+                _.each(d, function(d,i) {
+                    d.data.sort(this.ascsort)
+                })
 
-                  _.each(d, function(d,i) {
-                      d.data.sort(ascsort)
-                  })
-
-                  console.log(d)
+                console.log(d)
 
                 var options = {
                     series: {

--- a/client/src/js/modules/dc/models/autointegration.js
+++ b/client/src/js/modules/dc/models/autointegration.js
@@ -13,13 +13,13 @@ define(['backbone'], function(Backbone){
             var shells = this.get('SHELLS')
             if (!shells) return
 
-            this.attributes.CLASS = { RMERGE: {}, RMEAS: {}, COMPLETENESS: {} }
+            this.set('CLASS', { RMERGE: {}, RMEAS: {}, COMPLETENESS: {} })
             _.each(['overall', 'innerShell', 'outerShell'], function(k) {
                 var c = shells[k] ? shells[k].COMPLETENESS : null
-                this.attributes.CLASS.COMPLETENESS[k] = c > 95 ? 'active' : (c > 80 ? 'minor' : 'inactive')
+                this.set('CLASS[COMPLETENESS[k]]', c > 95 ? 'active' : (c > 80 ? 'minor' : 'inactive'))
 
                 var r = shells[k] ? shells[k].RMEAS : null
-                this.attributes.CLASS.RMEAS[k] = r < 0.5 ? 'active' : (r < 0.6 ? 'minor' : 'inactive')
+                this.set('CLASS[RMEAS[k]]', r < 0.5 ? 'active' : (r < 0.6 ? 'minor' : 'inactive'))
             }, this)
         },
 

--- a/client/src/js/modules/dc/models/dccomment.js
+++ b/client/src/js/modules/dc/models/dccomment.js
@@ -27,9 +27,9 @@ define(['backbone', 'markdown'], function(Backbone, markdown) {
     },
       
     addDate: function() {
-        this.attributes.CREATETIMEISO = new Date(this.get('CREATETIME'))
-        this.attributes.MODTIMEISO = new Date(this.get('MODTIME'))
-        if (this.get('COMMENTS')) this.attributes.COMMENTSMD = markdown.toHTML(this.get('COMMENTS'))
+        this.set('CREATETIMEISO', new Date(this.get('CREATETIME')))
+        this.set('MODTIMEISO', new Date(this.get('MODTIME')))
+        if (this.get('COMMENTS')) this.set('COMMENTSMD', markdown.toHTML(this.get('COMMENTS')))
     }
       
   })

--- a/client/src/js/modules/dc/views/reprocess2.js
+++ b/client/src/js/modules/dc/views/reprocess2.js
@@ -156,8 +156,8 @@ define(['backbone', 'marionette', 'views/dialog',
             if (e) e.preventDefault()
 
             if (this.aps.length) {
-                var e = this.aps.at(0)
-                var c = e.get('CELL')
+                var a = this.aps.at(0)
+                var c = a.get('CELL')
 
                 this.ui.a.val(c['CELL_A']).trigger('change')
                 this.ui.b.val(c['CELL_B']).trigger('change')
@@ -166,7 +166,7 @@ define(['backbone', 'marionette', 'views/dialog',
                 this.ui.be.val(c['CELL_BE']).trigger('change')
                 this.ui.ga.val(c['CELL_GA']).trigger('change')
 
-                this.ui.sg.val(e['SG']).trigger('change')
+                this.ui.sg.val(a['SG']).trigger('change')
             }
         },
 
@@ -294,11 +294,11 @@ define(['backbone', 'marionette', 'views/dialog',
             }
 
             var self = this
+            var reqs = []
             // Integrate individually
             if (this.ui.ind.is(':checked')) {
                 var jobs = 0
 
-                var reqs = []
                 var rps = []
                 _.each(s, function(sw) {
                     var p = this.pipelines.findWhere({ VALUE: sw.get('PIPELINE') })
@@ -399,7 +399,6 @@ define(['backbone', 'marionette', 'views/dialog',
                     return
                 }
 
-                var reqs = []
                 reqs.push(reprocessing.save({}, {
                     success: function() {
                         var reprocessingparams = new ReprocessingParameters()

--- a/client/src/js/modules/dc/views/reprocessoverview.js
+++ b/client/src/js/modules/dc/views/reprocessoverview.js
@@ -53,14 +53,14 @@ define(['marionette',
             },
 
             render: function() {
-                var columns = [
+                var pcolumns = [
                    { name: 'PARAMETERKEY', label: 'Key', cell: 'string', editable: false },
                    { name: 'PARAMETERVALUE', label: 'Value', cell: 'string', editable: false },
                 ]
 
                 var ptable = new TableView({ 
                     collection: this.params, 
-                    columns: columns, 
+                    columns: pcolumns,
                     loading: false,
                     pages: false,
                     backgrid: { emptyText: 'No parameters found' },
@@ -68,14 +68,14 @@ define(['marionette',
 
                 this.$el.html(ptable.render().$el)
 
-                var columns = [
+                var scolumns = [
                    { label: 'Files', cell: table.TemplateCell, editable: false, template: '<a href="/dc/visit/<%-VISIT%>/id/<%-DATACOLLECTIONID%>"><%-IMAGEDIRECTORY%><%-IMAGEPREFIX%>_<%-DATACOLLECTIONNUMBER%></a>' },
                    { label: 'Image #', cell: table.TemplateCell, editable: false, template: '<%-STARTIMAGE%> - <%-ENDIMAGE%>' },
                 ]
 
                 var stable = new TableView({ 
                     collection: this.sweeps, 
-                    columns: columns, 
+                    columns: scolumns,
                     loading: false,
                     pages: false,
                     backgrid: { emptyText: 'No image sweeps found' },

--- a/client/src/js/modules/dc/views/samplechanger.js
+++ b/client/src/js/modules/dc/views/samplechanger.js
@@ -162,11 +162,11 @@ define(['marionette', 'utils/canvas', 'utils',
             // Draw Grid
             this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
             //this.ctx.drawImage(this.numbers, 0, 0, this.canvas.width, this.canvas.height)
-            for (var j = 0; j < this.sc; j++) {
+            for (var n = 0; n < this.sc; n++) {
                 this.ctx.fillStyle = '#000'
                 this.ctx.font = "11px Arial"
                 this.ctx.lineWidth = 1
-                this.ctx.fillText(j+1,10,this.sh*j+this.tpad+4);
+                this.ctx.fillText(n+1,10,this.sh*n+this.tpad+4);
             }
       
             for (var i = 0; i < this.positions; i++) {

--- a/client/src/js/modules/fault/models/component.js
+++ b/client/src/js/modules/fault/models/component.js
@@ -8,13 +8,13 @@ define(['backbone'], function(Backbone) {
         },
         initialize: function(options) {
             this.on('change', this._add_id, this)
-              this._add_id()
+            this._add_id()
         },
         urlRoot: '/fault/com',
         idAttribute: 'COMPONENTID',
 
         _add_id: function() {
-            this.attributes.ID = this.get('COMPONENTID')
+            this.set('ID', this.get('COMPONENTID'))
         },
 
     })

--- a/client/src/js/modules/fault/models/fault.js
+++ b/client/src/js/modules/fault/models/fault.js
@@ -22,11 +22,11 @@ define(['backbone', 'markdown', 'models/wfile'], function(Backbone, markdown, Fi
         },
         
         refreshOptions: function() {
-            this.attributes.RESOLVEDTEXT = this.resolvedOptions[this.get('RESOLVED')]
-            this.attributes.BEAMTIMELOSTTEXT = this.btlOptions[this.get('BEAMTIMELOST')]
+            this.set('RESOLVEDTEXT', this.resolvedOptions[this.get('RESOLVED')])
+            this.set('BEAMTIMELOSTTEXT', this.btlOptions[this.get('BEAMTIMELOST')])
             
-            if (this.get('DESCRIPTION')) this.attributes.DESCRIPTIONMD = markdown.toHTML(this.get('DESCRIPTION'))
-            if (this.get('RESOLUTION')) this.attributes.RESOLUTIONMD = markdown.toHTML(this.get('RESOLUTION'))
+            if (this.get('DESCRIPTION')) this.set('DESCRIPTIONMD', markdown.toHTML(this.get('DESCRIPTION')))
+            if (this.get('RESOLUTION')) this.set('RESOLUTIONMD', markdown.toHTML(this.get('RESOLUTION')))
         },
         
         validation: {

--- a/client/src/js/modules/fault/models/subcomponent.js
+++ b/client/src/js/modules/fault/models/subcomponent.js
@@ -8,12 +8,12 @@ define(['backbone'], function(Backbone) {
         },
         initialize: function(options) {
             this.on('change', this._add_id, this)
-              this._add_id()
+            this._add_id()
         },
         urlRoot: '/fault/scom',
         idAttribute: 'SUBCOMPONENTID',
         _add_id: function() {
-            this.attributes.ID = this.get('SUBCOMPONENTID')
+            this.set('ID', this.get('SUBCOMPONENTID'))
         },
     })
 })

--- a/client/src/js/modules/fault/models/system.js
+++ b/client/src/js/modules/fault/models/system.js
@@ -13,7 +13,7 @@ define(['backbone'], function(Backbone) {
         urlRoot: '/fault/sys',
         idAttribute: 'SYSTEMID',
         _add_id: function() {
-            this.attributes.ID = this.get('SYSTEMID')
+            this.set('ID', this.get('SYSTEMID'))
         },
     })
     

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -686,10 +686,11 @@ define(['marionette',
         },
 
         applyModel: function(modelParameter, isLimitedToSelected) {
+            var models = null
             if (isLimitedToSelected) {
-                var models = this.qsubsamples.where({ isGridSelected: true })
+                models = this.qsubsamples.where({ isGridSelected: true })
             } else {
-                var models = this.qsubsamples.fullCollection.toArray()
+                models = this.qsubsamples.fullCollection.toArray()
             }
             _.each(models, function(model) {
                 if (modelParameter.get('EXPERIMENTKIND') !== model.get('EXPERIMENTKIND')) return

--- a/client/src/js/modules/shipment/models/containerreport.js
+++ b/client/src/js/modules/shipment/models/containerreport.js
@@ -14,7 +14,7 @@ define(['backbone', 'markdown', 'models/wfile'], function(Backbone, markdown, Fi
         },
         
         refreshOptions: function() {
-            if (this.get('REPORT')) this.attributes.REPORTMD = markdown.toHTML(this.get('REPORT'))
+            if (this.get('REPORT')) this.set('REPORTMD', markdown.toHTML(this.get('REPORT')))
         },
 
         validation: {

--- a/client/src/js/modules/shipment/models/dewarreport.js
+++ b/client/src/js/modules/shipment/models/dewarreport.js
@@ -14,7 +14,7 @@ define(['backbone', 'markdown', 'models/wfile'], function(Backbone, markdown, Fi
         },
         
         refreshOptions: function() {
-            if (this.get('REPORT')) this.attributes.REPORTMD = markdown.toHTML(this.get('REPORT'))
+            if (this.get('REPORT')) this.set('REPORTMD', markdown.toHTML(this.get('REPORT')))
         },
 
         validation: {

--- a/client/src/js/modules/shipment/views/containerregistry.js
+++ b/client/src/js/modules/shipment/views/containerregistry.js
@@ -116,7 +116,7 @@ define(['marionette',
                 this.listenTo(this.proposals, 'backgrid:selected', this.selectModel, this)
                 this.proposals.fetch()
 
-                var columns = [
+                var columns2 = [
                     { label: '', cell: 'select-row', headerCell: 'select-all', editable: false },
                     { name: 'PROPOSALCODE', label: 'Code', cell: 'string', editable: false },
                     { name: 'PROPOSALNUMBER', label: 'Number', cell: 'string', editable: false },
@@ -126,7 +126,7 @@ define(['marionette',
 
                 this.table2 = new TableView({
                     collection: this.proposals,
-                    columns: columns, tableClass: 'proposals', filter: 's', search: options.params.s, loading: true, noPageUrl: true, noSearchUrl: true,
+                    columns: columns2, tableClass: 'proposals', filter: 's', search: options.params.s, loading: true, noPageUrl: true, noSearchUrl: true,
                     backgrid: { emptyText: 'No proposals found' } 
                 })
 

--- a/client/src/js/modules/shipment/views/manifest.js
+++ b/client/src/js/modules/shipment/views/manifest.js
@@ -63,8 +63,8 @@ define(['marionette',
             }, this)
 
 
-            var m = d.getMonth() +1
-            var cur = (m < 10 ? ('0'+m) : m)+'-'+d.getFullYear()
+            var mon = d.getMonth() +1
+            var cur = (mon < 10 ? ('0'+mon) : mon)+'-'+d.getFullYear()
             this.ui.month.val(cur)
 
             var columns = [

--- a/client/src/js/modules/shipment/views/migrate.js
+++ b/client/src/js/modules/shipment/views/migrate.js
@@ -232,20 +232,20 @@ define(['marionette',
 
         var validOnly = app.options.get('valid_components')
         
-            if (!validOnly) {
-        this.rprots.show(new TableView({ 
+        if (!validOnly) {
+            this.rprots.show(new TableView({
                     collection: this.proteins, 
-                       columns: columns, 
+                    columns: columns,
                     tableClass: 'proteins', 
                     filter: 's', 
                     loading: true, 
                     noSearchUrl: false,
                     backgrid: { emptyText: 'No proteins found' } 
-                }))
+            }))
         }
 
 
-            var columns = [
+            var columns2 = [
                 { label: '', cell: 'select-row', headerCell: 'select-all', editable: false },
                 { name: 'CARDNAME', label: 'Card Name', cell: 'string', editable: false },
                 { name: 'GIVENNAME', label: 'First Name', cell: 'string', editable: false },
@@ -260,7 +260,7 @@ define(['marionette',
 
             this.rconts.show(new TableView({ 
                 collection: this.contacts, 
-                columns: columns, 
+                columns: columns2,
                 tableClass: 'labcontacts', 
                 filter: 's', 
                 loading: true, 

--- a/client/src/js/modules/shipment/views/plate.js
+++ b/client/src/js/modules/shipment/views/plate.js
@@ -192,9 +192,9 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
         
                         var sampleid = i*this.pt.dropTotal()+did+1
                         var sample = this.collection.findWhere({ LOCATION: sampleid.toString() })
+                        var im = null
 
-                        if (sample && (this.showImageStatus || this.showMaxScore) && this.inspectionimages) var im = this.inspectionimages.findWhere({ BLSAMPLEID: sample.get('BLSAMPLEID') })
-                        else var im = null
+                        if (sample && (this.showImageStatus || this.showMaxScore) && this.inspectionimages) im = this.inspectionimages.findWhere({ BLSAMPLEID: sample.get('BLSAMPLEID') })
                         
                         this.ctx.beginPath()
                         this.ctx.lineWidth = 1;
@@ -273,10 +273,12 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                             }
                         }
 
+                        var isc = null
+
                         // Show image score
                         if (sample && this.showImageStatus) {
                             if (im) {
-                                var isc = im.get('SCORECOLOUR')
+                                isc = im.get('SCORECOLOUR')
                                 if (isc){
                                     this.ctx.fillStyle = isc
                                     this.ctx.fill()  
@@ -287,7 +289,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                         // Show max image score
                         if (sample && this.showMaxScore) {
                             if (im) {
-                                var isc = im.get('MAXSCORECOLOUR')
+                                isc = im.get('MAXSCORECOLOUR')
                                 if (isc){
                                     this.ctx.fillStyle = isc
                                     this.ctx.fill()

--- a/client/src/js/modules/shipment/views/regdewar.js
+++ b/client/src/js/modules/shipment/views/regdewar.js
@@ -99,7 +99,7 @@ define(['marionette',
             this.dewars.queryParams.all = 1
             this.dewars.fetch().done(this.getHistory.bind(this))
 
-            var columns = [
+            var columns2 = [
                 { name: 'CODE', label: 'Name', cell: 'string', editable: false },
                 { label: 'Shipment', cell: table.TemplateCell, editable: false, template: '<a href="/shipments/sid/<%-SHIPPINGID%>"><%-SHIPPINGNAME%></a>' },
                 { name: 'EXP', label: 'First Exp', cell: 'string', editable: false },
@@ -113,12 +113,12 @@ define(['marionette',
         
             if (app.mobile()) {
                 _.each([0,1,3,6,7], function(v) {
-                    columns[v].renderable = false
+                    columns2[v].renderable = false
                 })
             }
         
             this.dewtable = new TableView({ collection: this.dewars, 
-                columns: columns, tableClass: 'dewars', loading: true, 
+                columns: columns2, tableClass: 'dewars', loading: true,
                 backgrid: { emptyText: 'No dewars found' }
             })
 
@@ -126,14 +126,14 @@ define(['marionette',
             this.listenTo(this.reports, 'sync', this.setupPopups, this)
             this.reports.fetch()
 
-            var columns = [
+            var columns3 = [
                 { name: 'BLTIMESTAMP', label: 'Time / Date', cell: 'string', editable: false },
                 { name: 'REPORT', label: 'Report', cell: 'string', editable: false },
                 { label: 'Image', cell: ImageCell, editable: false },
             ]
 
             this.reptable = new TableView({ collection: this.reports, 
-                columns: columns, tableClass: 'samples', loading: true, 
+                columns: columns3, tableClass: 'samples', loading: true,
                 backgrid: { emptyText: 'No reports found' }
             })
 
@@ -141,7 +141,7 @@ define(['marionette',
             this.proposals.queryParams.DEWARREGISTRYID = this.model.get('DEWARREGISTRYID')
             this.proposals.fetch()
 
-            var columns = [
+            var columns4 = [
                 { name: 'PROPOSAL', label: 'Proposal', cell: 'string', editable: false },
                 { name: 'GIVENNAME', label: 'Given Name', cell: 'string', editable: false },
                 { name: 'FAMILYNAME', label: 'Family Name', cell: 'string', editable: false },
@@ -150,12 +150,12 @@ define(['marionette',
             ]
 
             if (app.staff) {
-                columns.push({ name: '', label: '', cell: DeleteCell, editable: false })
+                columns4.push({ name: '', label: '', cell: DeleteCell, editable: false })
             }
 
             this.proptable = new TableView({
                 collection: this.proposals,
-                columns: columns,
+                columns: columns4,
             })
 
         },

--- a/client/src/js/modules/shipment/views/registeredcontainer.js
+++ b/client/src/js/modules/shipment/views/registeredcontainer.js
@@ -175,7 +175,7 @@ define(['marionette',
             this.containers.queryParams.all = 1
             this.containers.fetch().done(this.getHistory.bind(this))
 
-            var columns = [
+            var columns2 = [
                 // { label: 'Name', cell: table.TemplateCell, editable: false, template: '<a href="/containers/cid/<%-CONTAINERID%>"><%-NAME%></a>' },
                 { name: 'NAME', label: 'Name', cell: 'string', editable: false },
                 { name: 'BLTIMESTAMP', label: 'Created', cell: 'string', editable: false },
@@ -189,12 +189,12 @@ define(['marionette',
         
             if (app.mobile()) {
                 _.each([4,6], function(v) {
-                    columns[v].renderable = false
+                    columns2[v].renderable = false
                 })
             }
         
             this.conttable = new TableView({ collection: this.containers, 
-                columns: columns, tableClass: 'containers', loading: true, 
+                columns: columns2, tableClass: 'containers', loading: true,
                 backgrid: { row: ClickableRow, emptyText: 'No containers found' }
             })
 
@@ -202,7 +202,7 @@ define(['marionette',
             this.listenTo(this.reports, 'sync', this.setupPopups, this)
             this.reports.fetch()
 
-            var columns = [
+            var columns3 = [
                 { name: 'RECORDTIMESTAMP', label: 'Time / Date', cell: 'string', editable: false },
                 { name: 'REPORTER', label: 'Reporter', cell: 'string', editable: false },
                 { name: 'REPORT', label: 'Report', cell: 'string', editable: false },
@@ -210,7 +210,7 @@ define(['marionette',
             ]
 
             this.reptable = new TableView({ collection: this.reports, 
-                columns: columns, tableClass: 'reports', loading: true, 
+                columns: columns3, tableClass: 'reports', loading: true,
                 backgrid: { emptyText: 'No reports found' }
             })
 

--- a/client/src/js/modules/types/xpdf/views/plan.js
+++ b/client/src/js/modules/types/xpdf/views/plan.js
@@ -558,7 +558,7 @@ define(['marionette',
             this.asmps.show(this.table)
 
 
-            var columns = [
+            var columns2 = [
                 { label: '', cell: CollapseExpandCell, editable: false, template: '<a class="button collapsar" href="#"><i class="expcol fa fa-chevron-right"></i></a>' },
                 { label: '#', cell: table.TemplateCell, editable: false, template: '<%-parseInt(PLANORDER)+1%>' },
                 { label: 'Instance', cell: table.TemplateCell, editable: false, template: '<%-SAMPLE%>' },
@@ -570,7 +570,7 @@ define(['marionette',
 
             this.table2 = new SortableTableView({ 
                 collection: this.datacollectionplans, 
-                columns: columns, 
+                columns: columns2,
                 tableClass: 'subsamples', 
                 loading: true,
                 // Below overrides the SortableRow in the SortableTableView which breaks drag and drop events

--- a/client/src/js/tpl.js
+++ b/client/src/js/tpl.js
@@ -92,7 +92,7 @@
       source + '}';
 
     return template;
-  };
+  }
 
 
   define(function () {

--- a/client/src/js/utils/editable.js
+++ b/client/src/js/utils/editable.js
@@ -172,7 +172,9 @@ define(['marionette',
                             if (xhr.responseText) {
                                 try {
                                     json = $.parseJSON(xhr.responseText)
-                                } catch(err) {}
+                                } catch(err) {
+                                    console.log('Error parsing JSON')
+                                }
                             }
                             if (json.message) app.alert({ message: json.message })
                             else app.alert({ message: 'Something went wrong' })

--- a/client/src/js/utils/xhrimage.js
+++ b/client/src/js/utils/xhrimage.js
@@ -38,7 +38,7 @@ define(['marionette'], function() {
             }
 
             var h = xhr.getAllResponseHeaders()
-            var m = h.match(/^Content-Type\:\s*(.*?)$/mi)
+            var m = h.match(/^Content-Type:\s*(.*?)$/mi)
             var mimeType = m[1] || 'image/png';
 
             var blob = new Blob([this.response], { type: mimeType })

--- a/client/src/js/views/log.js
+++ b/client/src/js/views/log.js
@@ -48,7 +48,7 @@ define(['marionette', 'views/dialog', 'utils'], function(Marionette, DialogView,
                 }
 
                 var h = xhr.getAllResponseHeaders()
-                var m = h.match(/^Content-Type\:\s*(.*?)$/mi)
+                var m = h.match(/^Content-Type:\s*(.*?)$/mi)
                 var mimeType = m[1] || 'image/png'
 
                 var blob = new Blob([this.response], { type: mimeType })
@@ -83,7 +83,7 @@ define(['marionette', 'views/dialog', 'utils'], function(Marionette, DialogView,
                             if (!is_routable(href)) return true\n\
                             e.preventDefault()\n\
                             var url = root+\'/\'+href\n\
-                            \sign({\n\
+                            sign({\n\
                                 url: url,\n\
                                 callback: function(resp) {\n\
                                     window.location = url+\'?token=\'+resp.token\n\


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1458](https://jira.diamond.ac.uk/browse/LIMS-1458)

**Summary**:

We should try to decrease the number of JavaScript errors in the "JavaScript build, test and lint" job that runs on creation of a PR.

**Changes**:
- Change `this.attributes.FOO` to `this.get('FOO')`
- Change `this.attributes.FOO = 'BAR'` to `this.set('FOO', 'BAR')`
- Move declaration of or rename js variables so that they are not redefined
- Remove unnecessary escape characters eg `\:`
- Add a log message to avoid having an empty catch statement

**Not done**
- `Use this.$ instead of $ in views` - changing seems to break functionality
- `Do not silence events` - not sure what this does
- `Do not access Object.prototype method 'hasOwnProperty' from target object` - not sure how to fix this

**To test**:
- Manually check the code :(
- Check basic Synchweb functions as expected
- Click "Show all checks" in the "All checks have passed" message below, then click Details on the JavaScript job
- Click on the "JavaScript build, test and lint" task, scroll down and see if there are less than about 50 errors.
