### PR TITLE
LIMS-1467: Allow lab contacts to have spaces in their names

### DIFF
--- a/api/src/Page/Contact.php
+++ b/api/src/Page/Contact.php
@@ -9,8 +9,8 @@ class Contact extends Page
 {
 
         public static $arg_list = array('CARDNAME' => '([\w\s\-])+',
-                              'FAMILYNAME' => '([\w\-])+',
-                              'GIVENNAME' => '([\w\-])+',
+                              'FAMILYNAME' => '([\w\s\-])+',
+                              'GIVENNAME' => '([\w\s\-])+',
                               'PHONENUMBER' => '.*',
                               'EMAILADDRESS' => '.*',
                               'LABNAME' => '([\w\s\-])+',

--- a/client/src/js/models/labcontact.js
+++ b/client/src/js/models/labcontact.js
@@ -14,11 +14,11 @@ define(['backbone'], function(Backbone) {
             },
             FAMILYNAME: {
                 required: true,
-                pattern: 'wwdash',
+                pattern: 'wwsdash',
             },
             GIVENNAME: {
                 required: true,
-                pattern: 'wwdash',
+                pattern: 'wwsdash',
             },
             PHONENUMBER: {
                 required: true,

--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -24,12 +24,12 @@ define(['backbone'], function(Backbone) {
 
         GIVENNAME: {
             required: function () {return this.dispatchDetailsRequired},
-            pattern: 'wwdash',
+            pattern: 'wwsdash',
         },
 
         FAMILYNAME: {
             required: function () {return this.dispatchDetailsRequired},
-            pattern: 'wwdash',
+            pattern: 'wwsdash',
         },
 
         PHONENUMBER: {

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -276,6 +276,7 @@ define(['marionette', 'views/form',
             this.dispatchCountry = this.ui.country.val()
             this.ui.courierSection.show();
             this.ui.dispatchDetails.show();
+            this.model.visitRequired = true
             this.model.dispatchDetailsRequired = true
             this.ui.submit.show();
             if (
@@ -334,6 +335,7 @@ define(['marionette', 'views/form',
             ){
                 this.model.visitRequired = false
                 this.ui.dispatchDetails.hide()
+                this.model.dispatchDetailsRequired = false
                 this.ui.submit.text("Proceed")
                 this.ui.shippingadvice.html("<mark>On clicking 'Proceed' you will be redirected to the new Diamond shipping service to book the shipment. Please ensure all stages of the form are completed.</mark><br /><br />")
             }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1467](https://jira.diamond.ac.uk/browse/LIMS-1467)

**Summary**:

Some people have spaces in their names, both given and family. This should be allowed in Synchweb.

**Changes**:
- Update regex for familyname and givenname args in PHP
- Update model for creating/editing lab contacts and dewar dispatch form
- Ensure visitRequired matches dispatchDetailsRequired

**To test**:
- Set `$use_shipping_service_redirect = True;` in config.php, use sample-shipping-test as the shipping service.
- Create a lab contact with spaces in given and family name, check the GUI gives no errors, and the form submits ok
- Edit the lab contact given and family name (still with spaces), check the form submits ok and edits persist
- Add a shipment with your new lab contact as the outgoing and return contacts, click the "Dispatch" button, choose "Aruba" as the country (so as to not use the shipping service), check the form submits and the dewar is marked as dispatch requested
- Add another shipment with the same lab contact, click "Dispatch" and then choose "United Kingdom" as the country, and then click Proceed. Check you are redirected to the shipping service.
