### PR TITLE
LIMS-1462: Show characterizations on Screenings tab

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -121,11 +121,11 @@ class DC extends Page
 
                 $where = '';
                 if ($this->arg('t') == 'sc')
-                    $where = ' AND (dc.overlap != 0 OR ifnull(et.name, dcg.experimenttype) = "Screening")';
+                    $where = ' AND (dc.overlap != 0 OR ifnull(et.name, dcg.experimenttype) in ("Screening", "Characterization"))';
                 else if ($this->arg('t') == 'gr')
                     $where = ' AND dc.axisrange = 0';
                 else if ($this->arg('t') == 'fc')
-                    $where = ' AND dc.overlap = 0 AND dc.axisrange > 0 AND dc.numberOfImages > 1 AND ifnull(et.name, dcg.experimenttype) != "Screening"';
+                    $where = ' AND dc.overlap = 0 AND dc.axisrange > 0 AND dc.numberOfImages > 1 AND ifnull(et.name, dcg.experimenttype) not in ("Screening", "Characterization")';
             } else if ($this->arg('t') == 'edge') {
                 $where2 = '';
             } else if ($this->arg('t') == 'mca') {
@@ -139,11 +139,11 @@ class DC extends Page
                 $where2 = " AND es.comments LIKE '%_FLAG_%'";
                 $where4 = " AND xrf.comments LIKE '%_FLAG_%'";
             } else if ($this->arg('t') == 'ap') {
-                $where = ' AND app.processingstatus = 1';
+                $where = " AND ifnull(et.name, dcg.experimenttype) not in ('Screening', 'Characterization') AND app.processingstatus = 1";
                 $extj[0] .= "INNER JOIN autoprocintegration ap ON dc.datacollectionid = ap.datacollectionid
                         INNER JOIN autoprocprogram app ON app.autoprocprogramid = ap.autoprocprogramid";
             } else if ($this->arg('t') == 'ph') {
-                $where = " AND app.processingstatus = 1 AND app.processingprograms in ('big_ep', 'fast_ep')";
+                $where = " AND ifnull(et.name, dcg.experimenttype) not in ('Screening', 'Characterization') AND app.processingstatus = 1 AND app.processingprograms in ('big_ep', 'fast_ep')";
                 $extj[0] .= "INNER JOIN processingjob pj ON dc.datacollectionid = pj.datacollectionid
                         INNER JOIN autoprocprogram app ON app.processingjobid = pj.processingjobid";
             } else if ($this->arg('t') == 'err') {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1462](https://jira.diamond.ac.uk/browse/LIMS-1462)

**Summary**:

Currently the screening tab only shows data collections with a non-zero overlap or the experiment type of 'Screening'. We should include the experiment type 'Characterisation'.

**Changes**:
- If the "Screenings" tab is selected, show data collections of type "Characterization" as well
- If the "Full Collections" tab is selected,, hide data collections of type "Characterization" as well
- If the "Auto Integrated" tab is selected, data collections of type "Screening" and "Characterization" as well (have checked with I19)
- If the "Phasing" tab is selected, data collections of type "Screening" and "Characterization" as well

**To test**:
- Go to an MX data collection of type "Characterization" (eg /dc/visit/au34221-7/id/15375847), check it still displays if you select "Screenings", but hides if you select "Full Collections", "Auto Integrated" or "Phasing"
- Go to an I19 data collection of type "Screening" (eg /dc/visit/cm37266-4/id/14949228), check it still displays if you select "Screenings", but hides if you select "Full Collections", "Auto Integrated" or "Phasing"
- Go to an MX style screening data collection (eg /dc/visit/cm37236-4/id/15059304), check it still displays if you select "Screenings", but hides if you select "Full Collections", "Auto Integrated" or "Phasing"
- Go to an MX style full data collection with fast_ep results (eg /dc/visit/cm37236-4/id/15412522), check it hides if you select "Screenings", but still displays if you select "Full Collections", "Auto Integrated" or "Phasing"
- Go to an I19 style full data collection with xia2 results (eg /dc/visit/cm37266-4/id/15148840), check it hides if you select "Screenings", but still displays if you select "Full Collections" or "Auto Integrated"
