### PR TITLE
LIMS-1463: Always display Mesh3D data collections as grid scans

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -992,11 +992,10 @@ class DC extends Page
                         $dc['DCT'] = 'Data Collection';
                 }
 
-                if ($dc['DCT'] == 'Mesh' || $dc['DCT'] == 'Mesh3D') {
+                if ($dc['DCT'] == 'Mesh' || $dc['DCT'] == 'Mesh3D' ||
+                    ($dc['DCT'] != 'Serial Fixed' && $dc['DCT'] != 'Serial Jet' && $dc['AXISRANGE'] == 0 && $dc['NI'] > 1)
+                ) {
                     $dc['DCT'] = 'Grid Scan';
-                    $dc['TYPE'] = 'grid';
-                }
-                if ($dc['DCT'] != 'Serial Fixed' && $dc['DCT'] != 'Serial Jet' && $dc['AXISRANGE'] == 0 && $dc['NI'] > 1) {
                     $dc['TYPE'] = 'grid';
                 }
                 //$this->profile('dc');

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -992,8 +992,10 @@ class DC extends Page
                         $dc['DCT'] = 'Data Collection';
                 }
 
-                if ($dc['DCT'] == 'Mesh')
+                if ($dc['DCT'] == 'Mesh' || $dc['DCT'] == 'Mesh3D') {
                     $dc['DCT'] = 'Grid Scan';
+                    $dc['TYPE'] = 'grid';
+                }
                 if ($dc['DCT'] != 'Serial Fixed' && $dc['DCT'] != 'Serial Jet' && $dc['AXISRANGE'] == 0 && $dc['NI'] > 1) {
                     $dc['TYPE'] = 'grid';
                 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1463](https://jira.diamond.ac.uk/browse/LIMS-1463)

**Summary**:

When Hyperion adds a Mesh3D experiment to ISPyB, Synchweb initially displays it as a rotational data collection, only updating to a grid scan style after a refresh. We should detect that it is a grid scan immediately.

**Changes**:
- Treat the experiment type Mesh3d (ie hyperion grid scans) the same as Mesh (ie GDA grid scans)
- Force both to display as grid scans, irrespective of the axis range and number of images

**To test**:
- View a stopped Hyperion grid scan (eg /dc/visit/cm37235-4/dcg/13099843) check it displays in the style of a grid scan, ie space for a diffraction image and space for a crystal snapshot, no space for a graph of spot counts
- View a completed Hyperion grid scan (eg /dc/visit/cm37235-4/dcg/13087189), check it displays in the style of a grid scan (ie unchanged)
- View a GDA grid scan (eg /dc/visit/cm37236-4/id/15488302), check it displays in the style of a grid scan (ie unchanged)
- View a "SAD" data collection (eg /dc/visit/cm37236-4/id/15488314), check it is unchanged from production)
- View a "Serial Fixed" (eg /dc/visit/cy37017-1/id/15324649) and "Serial Jet" (eg /dc/visit/cm37275-4/id/14945838) experiment, check they are unchanged from production