### PR TITLE
LIMS-1489: Update message when trying to queue containers in uploaded shipments

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -95,7 +95,7 @@
                   name="Queue For UDC"
                 />
                 <span v-else-if="shippingSafetyLevel === null">
-                  Cannot queue container as shipment safety level not set
+                  Cannot queue container until shipment safety level is set
                 </span>
                 <span v-else>
                   Cannot queue containers in {{ shippingSafetyLevel }} shipments

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -94,6 +94,9 @@
                   v-model="QUEUEFORUDC"
                   name="Queue For UDC"
                 />
+                <span v-else-if="shippingSafetyLevel === null">
+                  Cannot queue container as shipment safety level not set
+                </span>
                 <span v-else>
                   Cannot queue containers in {{ shippingSafetyLevel }} shipments
                 </span>
@@ -663,7 +666,7 @@ export default {
 
         await this.$store.dispatch('samples/save', containerId)
         this.$store.commit('notifications/addNotification', {
-          message: `New Container created, click <a href=/containers/cid/${containerId}>here</a> to view it`,
+          message: `New Container created, click <a href=/containers/cid/${containerId}>here</a> to view it. Remember to add sequences and PDBs if needed.`,
           level: 'info',
           persist: true
         })

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -107,7 +107,7 @@
                 ><i class="fa fa-times" /> Unqueue</a>
               </span>
               <span v-else-if="shippingSafetyLevel === null">
-                Cannot queue container as shipment safety level not set
+                Cannot queue container until shipment safety level is set
               </span>
               <span v-else-if="shippingSafetyLevel != 'Green'">
                 Cannot queue containers in {{ shippingSafetyLevel }} shipments

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -106,6 +106,9 @@
                   @click="onUnQueueContainer"
                 ><i class="fa fa-times" /> Unqueue</a>
               </span>
+              <span v-else-if="shippingSafetyLevel === null">
+                Cannot queue container as shipment safety level not set
+              </span>
               <span v-else-if="shippingSafetyLevel != 'Green'">
                 Cannot queue containers in {{ shippingSafetyLevel }} shipments
               </span>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1489](https://jira.diamond.ac.uk/browse/LIMS-1489)
**JIRA ticket**: [LIMS-1506](https://jira.diamond.ac.uk/browse/LIMS-1506)

**Summary**:

If a shipment has been uploaded as a CSV (or created by GDA), it doesn't have a safety level. https://github.com/DiamondLightSource/SynchWeb/pull/827 disabled the ability to queue containers in such shipments, but the message is not helpful, as it says "Cannot queue containers in shipments". We should make the message clearer.

Also, as already editing this file, I added some text to remind users to add PDB and/or sequence information to their proteins.

**Changes**:
- If adding/editing a container in a shipment with a null safety level, display a message advising users to set the shipment safety level
- When a new container is created, remind users to add PDB and/or sequence information to their proteins

**To test**:
- Go to a shipment with safety level 'green', eg /shipments/sid/59056
  - Click Add container, check the Queue For UDC checkbox is available
  - View an existing container, check the Queue button is displayed
- Edit the shipment so that the safety level is red or yellow
  - Click Add container, check the Queue For UDC checkbox is **not** available
  - View an existing container, check the Queue button is **not** displayed
- Go to a shipment with no safety level, eg /shipments/sid/58582
  - Click Add container, check the Queue For UDC checkbox is **not** available, with a message advising what needs to be done
  - View an existing container, check the Queue button is **not** displayed, with a message advising what needs to be done
- Create a puck (in any shipment), check the notification reminds users to add sequences and/or PDBs.
