### PR TITLE
LIMS-1500: Set the dispatch request email recipients based on the dewar barcode

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1147,6 +1147,7 @@ class Shipment extends Page
         global $facility_country;
         global $facility_courier_countries;
         global $dispatch_email;
+        global $dispatch_email_regex;
         global $dispatch_email_intl;
         global $use_shipping_service;
         global $shipping_service_links_in_emails;
@@ -1315,6 +1316,14 @@ class Shipment extends Page
             $local_contact_email = $this->has_arg('LCEMAIL') ? $this->args['LCEMAIL'] : '';
             if ($local_contact_email) $recpts .= ', ' . $local_contact_email;
 
+            if (!is_null($dispatch_email_regex)) {
+                foreach ($dispatch_email_regex as $address => $pattern) {
+                    if (preg_match($pattern, $data['BARCODE'])) {
+                        $recpts .= ', ' . $address;
+                    }
+                }
+            }
+
             $email->send($recpts);
 
             // Update the dewar status and storage location
@@ -1343,6 +1352,7 @@ class Shipment extends Page
     function _dispatch_dewar_confirmation()
     {
         global $dispatch_email;
+        global $dispatch_email_regex;
         global $shipping_service_app_url;
 
         if (!$this->has_arg('did'))
@@ -1404,6 +1414,14 @@ class Shipment extends Page
         if ($data['EMAILADDRESS']) $recpts .= ', ' . $data['EMAILADDRESS'];
         $local_contact_email = $this->has_arg('LCEMAIL') ? $this->args['LCEMAIL'] : '';
         if ($local_contact_email) $recpts .= ', ' . $local_contact_email;
+
+        if (!is_null($dispatch_email_regex)) {
+            foreach ($dispatch_email_regex as $address => $pattern) {
+                if (preg_match($pattern, $data['BARCODE'])) {
+                    $recpts .= ', ' . $address;
+                }
+            }
+        }
 
         $email->send($recpts);
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1500](https://jira.diamond.ac.uk/browse/LIMS-1500)

**Summary**:

Local contacts no longer get dispatch request emails, but I19 staff would like to receive emails for i19 dewars. So we can implement a set of regex patterns to decide who gets an email based on the dewar barcode.

**Changes**:
- Introduce a new config variable called `$dispatch_email_regex`, of an array of email addresses and regex patterns.
- Add each email address to the list of recipients if the pattern matches the dewar barcode.

**To test**:
- Check your Synchweb server can log emails that should be sent (see https://confluence.diamond.ac.uk/display/~ndg63276/Synchweb+Dev#SynchwebDev-Sendingemails)
- Set these config variables (dummy email addresses):
```
$dispatch_email = 'stores.staff@diamond.ac.uk';
$dispatch_email_regex = array(
    'mx.staff@diamond.ac.uk' => '/.*/',
    'i19.staff@diamond.ac.uk' => '/.*i19.*/',
);
```
- Turn on the shipping service
```
$use_shipping_service = True;
$use_shipping_service_redirect = True;
$shipping_service_api_url = "https://sample-shipping-test.diamond.ac.uk/api";
$shipping_service_app_url = "https://sample-shipping-test.diamond.ac.uk";
```
- Request a dispatch for a dewar in the mx23694 proposal, check emails would be sent to stores.staff and mx.staff
- Create a dewar in the cm37266 proposal, setting a future visit so the barcode contains "i19", request dispatch and check emails would be sent to stores.staff, mx.staff and i19.staff.
- Turn off the shipping service:
```
$use_shipping_service = False;
$use_shipping_service_redirect = False;
```
- Request a dispatch for a dewar in the mx23694 proposal, check emails would be sent to stores.staff and mx.staff
- Create a dewar in the cm37266 proposal, setting a future visit so the barcode contains "i19", request dispatch and check emails would be sent to stores.staff, mx.staff and i19.staff.