### PR TITLE
LIMS-1490: Use callback URL for incoming dewars via shipping service

### DIFF
--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -119,8 +119,7 @@ class AuthenticationController
             ($parts[0] == 'shipment' && $parts[1] == 'containers' && $parts[2] == 'history' && in_array($_SERVER["REMOTE_ADDR"], $bcr)) ||
 
                 # Allow shipping service to update dewar status
-            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirmdispatch') ||
-            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirmpickup')
+            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && ($parts[2] == 'confirmdispatch' || $parts[2] == 'confirmpickup'))
             )
             {
                 $need_auth = false;

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -119,7 +119,8 @@ class AuthenticationController
             ($parts[0] == 'shipment' && $parts[1] == 'containers' && $parts[2] == 'history' && in_array($_SERVER["REMOTE_ADDR"], $bcr)) ||
 
                 # Allow shipping service to update dewar status
-            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirmdispatch')
+            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirmdispatch') ||
+            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirmpickup')
             )
             {
                 $need_auth = false;

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -146,6 +146,7 @@ class Shipment extends Page
         'TOKEN' => '\w+',
         'tracking_number' => '\w+',
         'AWBURL' => '[\w\:\/\.\-]+',
+        'pickup_confirmation_code' => '\w+',
 
         'manifest' => '\d',
         'currentuser' => '\d',
@@ -200,6 +201,7 @@ class Shipment extends Page
         array('/dewars/transfer', 'post', '_transfer_dewar'),
         array('/dewars/dispatch', 'post', '_dispatch_dewar'),
         array('/dewars/confirmdispatch/did/:did/token/:TOKEN', 'post', '_dispatch_dewar_confirmation'),
+        array('/dewars/confirmpickup/sid/:sid/token/:TOKEN', 'post', '_pickup_dewar_confirmation'),
 
         array('/dewars/tracking(/:DEWARID)', 'get', '_get_dewar_tracking'),
 
@@ -1428,7 +1430,70 @@ class Shipment extends Page
         $this->_output(1);
     }
 
+    function _pickup_dewar_confirmation()
+    {
+        if (!$this->has_arg('sid'))
+            $this->_error('No shipment specified');
+        if (!$this->has_arg('TOKEN'))
+            $this->_error('No token specified');
+        if (!$this->has_arg('tracking_number'))
+            $this->_error('No tracking number specified');
 
+        // Check token against each dewar
+        $dewars = $this->db->pq(
+            "SELECT d.dewarid,
+                json_unquote(json_extract(d.extra, '$.token')) as token
+                FROM dewar d
+                WHERE d.shippingid=:1",
+            array($this->arg('sid'))
+        );
+
+        foreach ($dewars as $dew) {
+            if ($this->arg('TOKEN') !== $dew['TOKEN']) {
+                $this->_error('Incorrect token');
+            }
+        }
+
+        $this->db->pq("UPDATE shipping set shippingstatus='awb created' WHERE shippingid=:1", array($this->arg('sid')));
+
+        foreach ($dewars as $dew) {
+            // Update the dewar status and storage location
+            $this->db->pq(
+                "UPDATE dewar
+                set dewarstatus='awb created', storagelocation='off-site', trackingnumbertosynchrotron=:2
+                WHERE dewarid=:1",
+                array($dew['DEWARID'], $this->arg('tracking_number'))
+            );
+
+            // Update dewar transport history
+            $this->db->pq(
+                "INSERT INTO dewartransporthistory (dewartransporthistoryid,dewarid,dewarstatus,storagelocation,arrivaldate)
+                VALUES (s_dewartransporthistory.nextval,:1,'awb created','off-site',CURRENT_TIMESTAMP)
+                RETURNING dewartransporthistoryid INTO :id",
+                array($dew['DEWARID'])
+            );
+        }
+
+        if ($this->has_arg('pickup_confirmation_code')) {
+
+            $this->db->pq("UPDATE shipping set shippingstatus='pickup booked' WHERE shippingid=:1", array($this->arg('sid')));
+
+            foreach ($dewars as $dew) {
+                // Update the dewar status
+                $this->db->pq("UPDATE dewar set dewarstatus='pickup booked' WHERE dewarid=:1", array($dew['DEWARID']));
+
+                // Update dewar transport history (plus 1s so history appears in order)
+                $this->db->pq(
+                    "INSERT INTO dewartransporthistory (dewartransporthistoryid,dewarid,dewarstatus,storagelocation,arrivaldate)
+                    VALUES (s_dewartransporthistory.nextval,:1,'pickup booked','off-site',CURRENT_TIMESTAMP+1)
+                    RETURNING dewartransporthistoryid INTO :id",
+                    array($dew['DEWARID'])
+                );
+            }
+        }
+
+        $this->_output(1);
+    }
 
     function _get_dewar_tracking()
     {
@@ -3058,20 +3123,27 @@ class Shipment extends Page
     function _create_shipment_shipment_request($shipment, array $dewars): int
     {
 
-        // if (!is_null($shipment['EXTERNALSHIPPINGIDTOSYNCHROTRON'])) {
-        //     return $shipment['EXTERNALSHIPPINGIDTOSYNCHROTRON'];
-        // }
+        $shipping_id = (int) $shipment['SHIPPINGID'];
+
+        $token = md5(uniqid());
+        $this->db->pq(
+            "UPDATE dewar SET extra = JSON_SET(IFNULL(extra, '{}'), '$.token', :1 ) WHERE shippingid=:2",
+            array($token, $shipping_id)
+        );
+
+        $callback_url = "/api/shipment/dewars/confirmpickup/sid/{$shipping_id}/token/{$token}";
 
         $external_shipping_id = $this->_create_dewars_shipment_request(
             $dewars,
             $shipment['PROP'],
-            (int) $shipment['SHIPPINGID'],
-            (int) $shipment['SHIPPINGID']
+            $shipping_id,
+            $shipping_id,
+            $callback_url
         );
 
         $this->db->pq(
             "UPDATE shipping SET externalShippingIdToSynchrotron=:1 WHERE shippingId=:2",
-            array($external_shipping_id, $shipment['SHIPPINGID'])
+            array($external_shipping_id, $shipping_id)
         );
         return $external_shipping_id;
     }

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -3125,7 +3125,7 @@ class Shipment extends Page
 
         $shipping_id = (int) $shipment['SHIPPINGID'];
 
-        $token = md5(uniqid());
+        $token = md5(openssl_random_pseudo_bytes(7));
         $this->db->pq(
             "UPDATE dewar SET extra = JSON_SET(IFNULL(extra, '{}'), '$.token', :1 ) WHERE shippingid=:2",
             array($token, $shipping_id)

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -70,6 +70,7 @@
                 <span class="label">Safety Level</span>
                 <span class="SAFETYLEVEL"><%-SAFETYLEVEL%></span>
             </li>
+            <% if (!EXTERNALSHIPPINGIDTOSYNCHROTRON || !app.options.get("shipping_service_app_url_incoming")) { %>
             <li>
                 <span class="label">Courier</span>
                 <span class="DELIVERYAGENT_AGENTNAME"><%-DELIVERYAGENT_AGENTNAME%></span>
@@ -126,6 +127,7 @@
                 <span class="label">Estimated Delivery Date</span>
                 <span class="DELIVERYAGENT_DELIVERYDATE"><%-DELIVERYAGENT_DELIVERYDATE%></span>
             </li>
+            <% } %>
             <%
                 DYNAMIC=(typeof DYNAMIC !== 'undefined')? DYNAMIC : 'No';
                 REMOTEORMAILIN=(typeof REMOTEORMAILIN !== 'undefined')? REMOTEORMAILIN : null;


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1490](https://jira.diamond.ac.uk/browse/LIMS-1490)

**Summary**:

If we are to fully use the shipping service for incoming dewars, we need to use the callback URL function to allow setting of the dewar status and tracking number, once the shipping service booking is complete.

**Changes**:
- Add a new (non-authenticated) endpoint (`/api/shipment/dewars/confirmpickup/sid/<shippingid>/token/<token>`) for the shipping service to hit when an incoming dewar has been booked
  - Update the shipping status & dewar status to `awb created` or `pickup booked` as necessary
  - Update the dewar tracking number
  - Add lines to the DewarTransportHistory table
- Use an md5 token to authenticate the new endpoint
- Hide irrelevant fields on the Shipment page if the shipping service has been used

**To test**:
- The dev instance needs to be on a *.diamond.ac.uk address, so use a beamline workstation or deploy to ispyb-dev-*
- Set these variables in config.php
```
$use_shipping_service = True;
$use_shipping_service_incoming_shipments = True;
$shipping_service_api_url = "https://sample-shipping-test.diamond.ac.uk/api";
$shipping_service_api_user = "synchweb";
$shipping_service_api_password = <redacted>;
$shipping_service_app_url = "https://sample-shipping-test.diamond.ac.uk";
$use_shipping_service_redirect_incoming_shipments = True;
$use_shipping_service_redirect = True;
```
- Create a shipment with more than one dewar in a UK proposal, eg mx23694
- On the shipment page, click Create DHL Air Waybill
- Tick the boxes for both dewars, click Use Facility Account and accept the terms
- Click Proceed and you should be redirected to the Shipping Service
- Fill in the address and request a pickup for the following day
- Exit back to Synchweb, and:
  - check the Shipment status and both dewars' status is 'pickup booked'
  - check the "Tracking # to" has been filled for both dewars
  - check the history section has both "awb created" and "pickup booked"
  - check lots of the fields on the Shipment page have been hidden, eg Courier, Courier Account No etc
- Rerun the previous test but don't request a pickup in the shipping service (untick the box). The shipping/dewar status should stay at "awb created" and the history should only have "awb created"
- Set `$use_shipping_service_redirect_incoming_shipments = False;`, create and book a shipment without being redirected to the shipping service, check that still works. Check the Courier, Courier Account No etc fields are displayed.
