### PR TITLE
LIMS-1515: Add energy value to data collections

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -62,7 +62,7 @@ class DC extends Page
         array('/dat/:id', 'get', '_plot'),
     );
 
-    public $eVToA = 12398.4198;
+    const EVTOA = 12398.4198;
 
     # ------------------------------------------------------------------------
     # Data Collection AJAX Requests
@@ -424,7 +424,7 @@ class DC extends Page
                     dc.transmission,
                     dc.axisrange,
                     dc.wavelength,
-                    ".$this->eVToA."/dc.wavelength as energy,
+                    ".self::EVTOA."/dc.wavelength as energy,
                     dc.comments,
                     1 as epk,
                     1 as ein,
@@ -561,7 +561,7 @@ class DC extends Page
                     min(dc.transmission) as transmission,
                     min(dc.axisrange) as axisrange,
                     min(dc.wavelength) as wavelength,
-                    ".$this->eVToA."/min(dc.wavelength) as energy,
+                    ".self::EVTOA."/min(dc.wavelength) as energy,
                     min(dc.comments) as comments,
                     1 as epk,
                     1 as ein,
@@ -725,8 +725,8 @@ class DC extends Page
                     es.comments,
                     es.peakenergy,
                     es.inflectionenergy,
-                    ".$this->eVToA."/es.peakenergy as wpk,
-                    ".$this->eVToA."/es.inflectionenergy as win,
+                    ".self::EVTOA."/es.peakenergy as wpk,
+                    ".self::EVTOA."/es.inflectionenergy as win,
                     'A',
                     'A',
                     'A',
@@ -816,7 +816,7 @@ class DC extends Page
                 TO_CHAR(xrf.starttime, 'DD-MM-YYYY HH24:MI:SS') as st,
                 xrf.beamtransmission,
                 1,
-                ".$this->eVToA."/xrf.energy as wavelength,
+                ".self::EVTOA."/xrf.energy as wavelength,
                 xrf.energy as energy,
                 xrf.comments,
                 1,

--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -62,6 +62,8 @@ class DC extends Page
         array('/dat/:id', 'get', '_plot'),
     );
 
+    public $eVToA = 12398.4198;
+
     # ------------------------------------------------------------------------
     # Data Collection AJAX Requests
     #   This is pretty crazy, it will return unioned data collections, energy
@@ -422,9 +424,12 @@ class DC extends Page
                     dc.transmission,
                     dc.axisrange,
                     dc.wavelength,
+                    ".$this->eVToA."/dc.wavelength as energy,
                     dc.comments,
                     1 as epk,
                     1 as ein,
+                    1 as wpk,
+                    1 as win,
                     dc.xtalsnapshotfullpath1 as x1,
                     dc.xtalsnapshotfullpath2 as x2,
                     dc.xtalsnapshotfullpath3 as x3,
@@ -556,9 +561,12 @@ class DC extends Page
                     min(dc.transmission) as transmission,
                     min(dc.axisrange) as axisrange,
                     min(dc.wavelength) as wavelength,
+                    ".$this->eVToA."/min(dc.wavelength) as energy,
                     min(dc.comments) as comments,
                     1 as epk,
                     1 as ein,
+                    1 as wpk,
+                    1 as win,
                     min(dc.xtalsnapshotfullpath1) as x1,
                     min(dc.xtalsnapshotfullpath2) as x2,
                     min(dc.xtalsnapshotfullpath3) as x3,
@@ -705,17 +713,20 @@ class DC extends Page
                     es.energyscanid,
                     1,
                     es.element,
-                    es.peakfprime,
+                    es.peakfprime as resolution,
                     es.exposuretime,
                     es.axisposition,
-                    es.peakfdoubleprime,
+                    es.peakfdoubleprime as numimg,
                     es.starttime as st,
                     es.transmissionfactor,
-                    es.inflectionfprime,
-                    es.inflectionfdoubleprime,
+                    es.inflectionfprime as axisrange,
+                    es.inflectionfdoubleprime as wavelength,
+                    1 as energy,
                     es.comments,
                     es.peakenergy,
                     es.inflectionenergy,
+                    ".$this->eVToA."/es.peakenergy as wpk,
+                    ".$this->eVToA."/es.inflectionenergy as win,
                     'A',
                     'A',
                     'A',
@@ -805,10 +816,13 @@ class DC extends Page
                 TO_CHAR(xrf.starttime, 'DD-MM-YYYY HH24:MI:SS') as st,
                 xrf.beamtransmission,
                 1,
-                xrf.energy,
+                ".$this->eVToA."/xrf.energy as wavelength,
+                xrf.energy as energy,
                 xrf.comments,
                 1,
                 1,
+                1 as wpk,
+                1 as win,
                 'A',
                 'A',
                 'A',
@@ -899,9 +913,12 @@ class DC extends Page
                 1,
                 1,
                 1,
+                1 as energy,
                 'A',
                 1,
                 1,
+                1 as wpk,
+                1 as win,
                 r.xtalsnapshotbefore,
                 r.xtalsnapshotafter,
                 'A',
@@ -974,7 +991,7 @@ class DC extends Page
 
             // Data collections
             if ($dc['TYPE'] == 'data') {
-                $nf = array(1 => array('AXISSTART', 'CHISTART', 'PHI', 'OVERLAP'), 2 => array('RESOLUTION', 'TRANSMISSION', 'AXISRANGE', 'TOTALDOSE'), 4 => array('WAVELENGTH', 'EXPOSURETIME'));
+                $nf = array(0 => array('ENERGY'), 1 => array('AXISSTART', 'CHISTART', 'PHI', 'OVERLAP'), 2 => array('RESOLUTION', 'TRANSMISSION', 'AXISRANGE', 'TOTALDOSE'), 4 => array('WAVELENGTH', 'EXPOSURETIME'));
 
                 $dc['DIRFULL'] = $dc['DIR'];
                 $dc['DIR'] = preg_replace('/.*\/' . $this->arg('prop') . '-' . $dc['VN'] . '\//', '', $dc['DIR']);
@@ -1010,12 +1027,12 @@ class DC extends Page
 
                 $dc['FILETEMPLATE'] = preg_replace('/.*\/' . $this->arg('prop') . '-' . $dc['VN'] . '\//', '', $dc['FILETEMPLATE']);
 
-                $nf = array(2 => array('EXPOSURETIME', 'AXISSTART', 'RESOLUTION', 'TRANSMISSION'));
+                $nf = array(1 => array('EPK', 'EIN'), 2 => array('AXISRANGE', 'WAVELENGTH', 'EXPOSURETIME', 'AXISSTART', 'RESOLUTION', 'TRANSMISSION', 'NUMIMG'), 5 => array('WPK', 'WIN'));
                 $this->profile('edge');
 
                 // MCA Scans
             } else if ($dc['TYPE'] == 'mca') {
-                $nf = array(2 => array('EXPOSURETIME', 'WAVELENGTH', 'TRANSMISSION'));
+                $nf = array(0 => array('ENERGY'), 2 => array('EXPOSURETIME', 'TRANSMISSION'), 4 => array('WAVELENGTH'));
                 $dc['DIRFULL'] = $dc['DIR'];
                 $dc['DIR'] = preg_replace('/.*\/\d\d\d\d\/\w\w\d+-\d+\//', '', $dc['DIR']);
 

--- a/client/src/js/templates/dc/dc.html
+++ b/client/src/js/templates/dc/dc.html
@@ -24,7 +24,7 @@
         <% if (SI != 1 ) { %> <li data-testid="dc-first-image">First Image: <%-SI%></li><% } %>
         <% if ((KAPPA && KAPPA !=0) || (PHI && PHI != 0) || (CHISTART && CHISTART !=0)) { %><li data-testid="dc-kappa-phi-chi"><% if (KAPPA != null) { %>&kappa;: <%-KAPPA%>&deg;<% } %> <% if (PHI != null) { %>&phi;: <%-PHI%>&deg;<% } %> <% if (CHISTART != null) { %>&chi;: <%-CHISTART%>&deg;<% } %></li><% } %>
         <li data-testid="dc-resolution">Resolution: <%-RESOLUTION%>&#197;</li>
-        <li data-testid="dc-wavelength">Wavelength: <%-WAVELENGTH%>&#197;</li>
+        <li data-testid="dc-wavelength">Wavelength: <%-WAVELENGTH%>&#197; (<%-ENERGY%>eV)</li>
         <li data-testid="dc-exposure-time">Exposure: <%-EXPOSURETIME%>s</li>
         <%if (DCC > 1 && TOTALDOSE) { %>
             <li data-testid="dc-dose">Total Dose:  <%-TOTALDOSE%>MGy</li>

--- a/client/src/js/templates/dc/edge.html
+++ b/client/src/js/templates/dc/edge.html
@@ -9,11 +9,11 @@
     </h1>
     
     <ul class="clearfix half">
-        <li>Scan File: <%-FILETEMPLATE%></li>
-        <li>E(Peak): <%-EPK.toFixed(1) %>eV (<% print ((12398.4193/EPK).toFixed(4)) %>&#197;)</li>
-        <li>f&rsquo;&rsquo;: <%-NUMIMG%> / f&rsquo;: <%-RESOLUTION%>e</li>
-        <li>E(Inf): <%-EIN.toFixed(1) %>eV (<% print((12398.4193/EIN).toFixed(4)) %>&#197;)</li>
-        <li>f&rsquo;&rsquo;: <%-WAVELENGTH%> / f&rsquo;: <%-AXISRANGE%>e</li>
+        <li class="comment">Scan File: <%-FILETEMPLATE%></li>
+        <li>E(Peak): <%-EPK%>eV (<%-WPK%>&#197;)</li>
+        <li>f&rsquo;&rsquo;: <%-NUMIMG%>e<sup>-</sup> / f&rsquo;: <%-RESOLUTION%>e<sup>-</sup></li>
+        <li>E(Inf): <%-EIN%>eV (<%-WIN%>&#197;)</li>
+        <li>f&rsquo;&rsquo;: <%-WAVELENGTH%>e<sup>-</sup> / f&rsquo;: <%-AXISRANGE%>e<sup>-</sup></li>
         <li>Exposure: <%-EXPOSURETIME%>s</li>
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>

--- a/client/src/js/templates/dc/grid.html
+++ b/client/src/js/templates/dc/grid.html
@@ -8,7 +8,7 @@
         <li>&<%-ROTATIONAXIS%>; Start: <%-AXISSTART%>&deg;</li>
         <% if ((KAPPA && KAPPA !=0) || (PHI && PHI != 0) || (CHISTART && CHISTART !=0)) { %><li><% if (KAPPA != null) { %>&kappa;: <%-KAPPA%>&deg;<% } %> <% if (PHI != null) { %>&phi;: <%-PHI%>&deg;<% } %> <% if (CHISTART != null) { %>&chi;: <%-CHISTART%>&deg;<% } %></li><% } %>
         <li>Resolution: <%-RESOLUTION%>&#197;</li>
-        <li>Wavelength: <%-WAVELENGTH%>&#197;</li>
+        <li>Wavelength: <%-WAVELENGTH%>&#197; (<%-ENERGY%>eV)</li>
         <li>Exposure: <%-EXPOSURETIME%>s</li>
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>

--- a/client/src/js/templates/dc/mca.html
+++ b/client/src/js/templates/dc/mca.html
@@ -10,7 +10,7 @@
     </h1>
     
     <ul class="clearfix half">
-        <li>Energy: <%-WAVELENGTH%>eV</li>
+        <li>Energy: <%-ENERGY%>eV (<%-WAVELENGTH%>&#197;)</li>
         <li>Exposure: <%-EXPOSURETIME%>s</li>
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1515](https://jira.diamond.ac.uk/browse/LIMS-1515)

**Summary**:

Currently only wavelength is displayed in Synchweb for most data collection types, we should show energy in eV as well.

**Changes**:
- Define the eV/A conversion factor (value from https://en.wikipedia.org/wiki/Electronvolt#Wavelength)
- Add return values to the `_data_collections` function for the `energy` in eV, and also the `wavelength` in A for MCA spectra and peak (`wpk`) and inflection (`win`) wavelengths for edge scans
- Add labels to a few more columns, these are redundant as the union will use the labels from the first select statement, but help to identify where values are coming from
- Return energies to 0 decimal places and wavelengths to 4 decimal places, except for edge scan results which have 1 and 5 respectively (these are results so more precision is needed)
- Display these values, taking conversion factor out of the JS
- Make the edge scan filename a double width column, so that E(peak) is displayed next to the peak f''/f' results, and the same for E(inflection). Cut all f''/f' values to 2 decimal places.

**To test**:
- View a standard data collection (eg /dc/visit/cm37235-4/id/15542386), check the wavelength and energy are displayed as `Wavelength: 0.9537Å (13,000eV)`
- View a grid scan (eg /dc/visit/cm37235-4/id/15542377), check the wavelength and energy are displayed as `Wavelength: 0.9537Å (13,000eV)`
- View an MCA spectrum (eg /dc/visit/cm37235-4/ty/mca/id/15813), check the energy is displayed as `Energy: 18,000eV (0.6888Å)`
- View an edge scan (eg /dc/visit/cm37235-4/ty/edge/id/61197), check:
  - energies have 1 decimal place, wavelengths have 5 decimal places
  - f''/f' values have 2 decimal places, and e- as units
  - peak f''/f' is displayed next to peak energy, inflection f''/f' is displayed next to inflection energy, ie
![image](https://github.com/user-attachments/assets/05b51cdf-e155-495a-b04b-f48b4d135709)
