### PR TITLE
LIMS-1514: Allow sorting of visit list

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -393,7 +393,8 @@ class Proposal extends Page
         }
 
         if ($this->has_arg('s')) {
-            $where .= " AND s.visit_number LIKE :" . (sizeof($args) + 1);
+            $where .= " AND (s.visit_number LIKE :" . (sizeof($args) + 1) . " OR s.beamlinename LIKE :" . (sizeof($args) + 2) . ")";
+            array_push($args, $this->arg('s'));
             array_push($args, $this->arg('s'));
         }
 

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -314,6 +314,7 @@ class Proposal extends Page
         }
     }
 
+
     # ------------------------------------------------------------------------
     # Get visits for a proposal
     function _get_visits($visit = null, $output = true)

--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -314,7 +314,6 @@ class Proposal extends Page
         }
     }
 
-
     # ------------------------------------------------------------------------
     # Get visits for a proposal
     function _get_visits($visit = null, $output = true)
@@ -435,7 +434,9 @@ class Proposal extends Page
         $order = 's.startdate DESC';
 
         if ($this->has_arg('sort_by')) {
-            $cols = array('ST' => 's.startdate', 'EN' => 's.enddate', 'VIS' => 's.visit_number', 'BL' => 's.beamlinename', 'LC' => 's.beamlineoperator', 'COMMENT' => 's.comments');
+            $cols = array('ST' => 's.startdate', 'EN' => 's.enddate', 'VIS' => 's.visit_number', 'BL' => 's.beamlinename',
+                          'LC' => 's.beamlineoperator', 'COMMENT' => 's.comments', 'ERA' => 's.riskrating',
+                          'SESSIONTYPE' => 'sessiontype', 'DCCOUNT' => 'dccount');
             $dir = $this->has_arg('order') ? ($this->arg('order') == 'asc' ? 'ASC' : 'DESC') : 'ASC';
             if (array_key_exists($this->arg('sort_by'), $cols))
                 $order = $cols[$this->arg('sort_by')] . ' ' . $dir;
@@ -469,6 +470,7 @@ class Proposal extends Page
                     s.beamcalendarid,
                     CONCAT(p.proposalcode, p.proposalnumber)                      AS proposal,
                     COUNT(shp.personid)                                           AS persons,
+                    COUNT(distinct dc.datacollectionid)                           AS dccount,
                     s.proposalid
                 FROM BLSession s
                     INNER JOIN proposal p ON p.proposalid = s.proposalid
@@ -476,35 +478,14 @@ class Proposal extends Page
                     LEFT OUTER JOIN session_has_person shp ON shp.sessionid = s.sessionid
                     LEFT OUTER JOIN beamlinesetup bls on bls.beamlinesetupid = s.beamlinesetupid
                     LEFT OUTER JOIN beamcalendar bc ON bc.beamcalendarid = s.beamcalendarid
+                    LEFT OUTER JOIN datacollectiongroup dcg ON dcg.sessionid = s.sessionid
+                    LEFT OUTER JOIN datacollection dc ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                 $where
                 GROUP BY s.sessionid
                 ORDER BY $order", $args);
 
-        $ids = array();
-        $wcs = array();
-        foreach ($rows as $r) {
-            array_push($ids, $r['SESSIONID']);
-            array_push($wcs, 'dcg.sessionid=:' . sizeof($ids));
-        }
-
-        $dcs = array();
-        if (sizeof($ids)) {
-            $where = implode(' OR ', $wcs);
-            $tdcs = $this->db->pq("SELECT count(dc.datacollectionid) as c, dcg.sessionid 
-                    FROM datacollection dc
-                    INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
-                    WHERE $where GROUP BY dcg.sessionid", $ids);
-            foreach ($tdcs as $t)
-                $dcs[$t['SESSIONID']] = $t['C'];
-        }
-
         foreach ($rows as &$r) {
-            $dc = array_key_exists($r['SESSIONID'], $dcs) ? $dcs[$r['SESSIONID']] : 0;
-            $r['COMMENT'] = $r['COMMENTS'];
-            $r['DCCOUNT'] = $dc;
-
             $bl_type = $this->_get_type_from_beamline($r['BL']);
-
             $r['TYPE'] = $bl_type ? $bl_type : 'gen';
         }
 

--- a/client/src/js/modules/visits/views/visit_list.vue
+++ b/client/src/js/modules/visits/views/visit_list.vue
@@ -157,7 +157,7 @@ export default {
                 },
                 {
                     key: "COMMENTS",
-                    title: 'Comments',
+                    title: 'Comments'
                 },
                 {
                     key: "DCCOUNT",

--- a/client/src/js/modules/visits/views/visit_list.vue
+++ b/client/src/js/modules/visits/views/visit_list.vue
@@ -16,15 +16,16 @@
             <div class="tw-pb-2">
                 <input data-testid="visit-table-search"
                        placeholder='Search'                         
-                       v-on:keyup.enter="fetchData" 
+                       v-on:keyup="fetchData"
                        v-model = "searchVisit"/>
             </div>
 
             <table data-testid="visit-table" class="tw-w-full tw-mb-2">
                 <thead>
                     <td v-for="(value) in headers" :key="value.id" data-testid="visit-table-headers"
-                    class="tw-w-1/8 tw-bg-table-header-background tw-text-table-header-color tw-font-bold tw-py-2 tw-text-center">
-                    {{value.title}}
+                    class="tw-w-1/8 tw-bg-table-header-background tw-text-table-header-color tw-py-2 tw-text-center">
+                        <button v-if="value.key != 'DEWARS'" class="tw-font-bold" :id="value.order || value.key" @click="headerClick($event)">{{value.title}}</button>
+                        <span v-else class="tw-font-bold">{{value.title}}</span>
                     </td>
                 </thead>
 
@@ -120,21 +121,25 @@ export default {
             visits: [],
             dewars: [],
             searchVisit : '',
+            orderBy: '',
+            order: 1,
             headers: [
                 {
                     key: "STARTDATE",
-                    title: 'Start'
+                    title: 'Start',
+                    order: 'ST'
                 },
                 {
                     key: "ENDDATE",
-                    title: 'End'
+                    title: 'End',
+                    order: 'EN'
                 },
                 {
                     key: "VIS",
                     title: 'Number'
                 },
                 {
-                    key: "BEAMLINENAME",
+                    key: "BL",
                     title: 'Beamline'
                 },
                 {
@@ -147,11 +152,12 @@ export default {
                 },
                 {
                     key: "UNIQUELCS",
-                    title: 'Local Contact'
+                    title: 'Local Contact',
+                    order: 'LC'
                 },
                 {
                     key: "COMMENTS",
-                    title: 'Comments'
+                    title: 'Comments',
                 },
                 {
                     key: "DCCOUNT",
@@ -178,6 +184,7 @@ export default {
             window.location.href = '/proposals/';
         }
         this.fetchData()
+        this.fetchData = _.debounce(this.fetchData, 500)
     },
     methods: {
         async fetchData() {
@@ -188,8 +195,18 @@ export default {
                 page: this.currentPage,
                 per_page: this.pageSize,
                 prop: this.proposal,
-                s: this.searchVisit,
+                order: 'order',
+                directions: {
+                    '-1': 'asc',
+                    '1': 'desc',
+                },
             };
+            this.visitCollection.state = {
+                sortKey: 'sort_by',
+                order: this.order,
+            };
+            if (this.searchVisit) this.visitCollection.queryParams.s = this.searchVisit;
+            if (this.orderBy) this.visitCollection.queryParams.sort_by = this.orderBy;
 
             const results = await this.$store.dispatch('getCollection', this.visitCollection);
             this.visits = results.toJSON().map((e) => {
@@ -258,6 +275,15 @@ export default {
             else {
                 window.location.href = 'dc/visit/' + this.proposal + '-' + visit.VIS;
             }
+        },
+        headerClick(event) {
+            if (this.orderBy === event.target.id) {
+                this.order = -this.order;
+            } else {
+                this.order = 1;
+            }
+            this.orderBy = event.target.id;
+            this.fetchData();
         },
         handleFocusOut(visit) {
             // if click outside of active input box then input returns to text


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1514](https://jira.diamond.ac.uk/browse/LIMS-1514)

**Summary**:

The list of visits for a proposal is not sortable.

**Changes**:
- Combine the data collection count into the main db query so that it can be sorted on
- Remove the need for an enter press on searching for a visit number, but add a debounce
- Make column headers actually be buttons so that the cursor becomes a pointer
- Re-fetch the data with a sort parameter if a header is clicked (apart from "Dewars")
- Re-fetch the data in the opposite direction if the same header is clicked again
- Don't add a search parameter if the search box is empty
- Allow searching by beamline name

**To test**:
- Open a proposal with a bunch of visits eg mx34263, and go to the /visits page
- Check you can sort by each header, in both directions, apart from "Dewars"
- Check the number of Data Collections is the same as on prod
- Search for a visit number, check only that visit number is displayed, check the debounce is working by looking at the requests sent
- Search for a beamline (eg i03), check only visits for that beamline are displayed
