### PR TITLE
LIMS-1498: Change name of processed data archive

### DIFF
--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -468,14 +468,14 @@ class Download extends Page
 
         $aps = $this->db->union(
             array(
-                "SELECT app.autoprocprogramid, app.processingprograms, app.processingstatus
+                "SELECT app.autoprocprogramid, app.processingprograms, app.processingstatus, dc.imageprefix, dc.datacollectionnumber
                     FROM autoprocintegration api 
                     INNER JOIN autoprocprogram app ON api.autoprocprogramid = app.autoprocprogramid 
                     INNER JOIN datacollection dc ON dc.datacollectionid = api.datacollectionid
                     INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
                     INNER JOIN blsession s ON s.sessionid = dcg.sessionid
                     WHERE s.proposalid=:1 AND app.autoprocprogramid=:2",
-                "SELECT app.autoprocprogramid, app.processingprograms, app.processingstatus
+                "SELECT app.autoprocprogramid, app.processingprograms, app.processingstatus, dc.imageprefix, dc.datacollectionnumber
                     FROM autoprocprogram app
                     INNER JOIN processingjob pj on pj.processingjobid = app.processingjobid
                     INNER JOIN datacollection dc ON dc.datacollectionid = pj.datacollectionid
@@ -497,7 +497,7 @@ class Download extends Page
         }
 
         $clean_program = preg_replace('/[^A-Za-z0-9\-]/', '', $ap['PROCESSINGPROGRAMS']);
-        $zipName = $this->arg('AUTOPROCPROGRAMID')  . '_' . $clean_program;
+        $zipName = $this->arg('AUTOPROCPROGRAMID') . '_' . $ap['IMAGEPREFIX'] . '_' . $ap['DATACOLLECTIONNUMBER'] . '_' . $clean_program;
         $this->_streamZipFile($files, $zipName);
     }
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1498](https://jira.diamond.ac.uk/browse/LIMS-1498)

**Summary**:

A user emailed pointing out that the Archive download of an autoprocessing run gives a pretty abstract filename of `<datacollectionid>_<pipeline>.zip`, eg `106290598_xia2dials.zip`

**Changes**:
- Added the image prefix and data collection number, so we now have `<datacollectionid>_<imageprefix>_<datacolletionnumber>_<pipeline>.zip`, eg `106290598_sethau_8_42_xia2dials.zip`


**To test**:
- Go to a data collection with successful autoprocessing eg /dc/visit/cm37235-4/id/15531187
- Go to a processing pipeline and click on the "Archive" button, check the download has the image prefix and data collection number in it.
