### PR TITLE
LIMS-753: Allow LN2 topups as part of dewar history

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -484,10 +484,10 @@ class Shipment extends Page
 
         if (!$this->has_arg('BARCODE'))
             $this->_error('No barcode specified');
-        if (!$this->has_arg('LOCATION'))
-            $this->_error('No location specified');
+        if (!$this->has_arg('LOCATION') && !$this->has_arg('STATUS'))
+            $this->_error('No location or status specified');
 
-        $dew = $this->db->pq("SELECT CONCAT(pe.givenname, ' ', pe.familyname) as lcout, pe.emailaddress as lcoutemail, CONCAT(CONCAT(pe2.givenname, ' '), pe2.familyname) as lcret, pe2.emailaddress as lcretemail, CONCAT(p.proposalcode, p.proposalnumber, '-', e.visit_number) as firstexp, TO_CHAR(e.startdate, 'DD-MM-YYYY HH24:MI') as firstexpst, e.beamlinename, e.beamlineoperator, d.dewarid, d.trackingnumberfromsynchrotron, s.shippingid, s.shippingname, p.proposalcode, CONCAT(p.proposalcode, p.proposalnumber) as prop, d.barcode, d.facilitycode, d.firstexperimentid, d.dewarstatus
+        $dew = $this->db->pq("SELECT CONCAT(pe.givenname, ' ', pe.familyname) as lcout, pe.emailaddress as lcoutemail, CONCAT(CONCAT(pe2.givenname, ' '), pe2.familyname) as lcret, pe2.emailaddress as lcretemail, CONCAT(p.proposalcode, p.proposalnumber, '-', e.visit_number) as firstexp, TO_CHAR(e.startdate, 'DD-MM-YYYY HH24:MI') as firstexpst, e.beamlinename, e.beamlineoperator, d.dewarid, d.trackingnumberfromsynchrotron, s.shippingid, s.shippingname, p.proposalcode, CONCAT(p.proposalcode, p.proposalnumber) as prop, d.barcode, d.facilitycode, d.firstexperimentid, d.dewarstatus, d.storagelocation
               FROM dewar d 
               INNER JOIN shipping s ON s.shippingid = d.shippingid
               LEFT OUTER JOIN labcontact c ON s.sendinglabcontactid = c.labcontactid 
@@ -505,15 +505,9 @@ class Shipment extends Page
 
         $track = $this->has_arg('TRACKINGNUMBERFROMSYNCHROTRON') ? $this->arg('TRACKINGNUMBERFROMSYNCHROTRON') : $dew['TRACKINGNUMBERFROMSYNCHROTRON'];
 
-        // What was the last history entry for this dewar?
-        // If it's come from a beamline, register flag so we can e-mail further down...
-        $last_history_results = $this->db->pq("SELECT storageLocation FROM dewartransporthistory WHERE dewarId = :1 ORDER BY DewarTransportHistoryId DESC LIMIT 1", array($dew['DEWARID']));
-
-        if (sizeof($last_history_results)) {
-            $last_history = $last_history_results[0];
-            // We only add data to dewar history in lower case from this method.
-            // If that ever changes, update this to become case insensitive search
-            $last_location = $last_history['STORAGELOCATION'];
+        if ($this->has_arg('LOCATION')) {
+            // If it's come from a beamline, register flag so we can e-mail further down...
+            $last_location = $dew['STORAGELOCATION'];
             if (!isset($dewar_complete_email_locations) || !is_array($dewar_complete_email_locations)) {
                 $bls = $this->_get_beamlines_from_type('all');
                 $send_return_email = in_array($last_location, $bls);
@@ -521,99 +515,103 @@ class Shipment extends Page
                 $email_location = $dewar_complete_email_locations[$last_location];
                 $send_return_email = preg_match($email_location, strtolower($this->arg('LOCATION')));
             }
-        } else {
-            // No history - could be a new dewar, so not necessarily an error...
-            if ($this->debug)
-                error_log("No previous dewar transport history for DewarId " . $dew['DEWARID']);
-        }
-        // If dewar status is dispatch-requested - don't change it.
-        // This way the dewar can be moved between storage locations and keep the record that a user requested the dispatch
-        // Default status is 'at-facility'
-        $dewarstatus = strtolower($dew['DEWARSTATUS']) == 'dispatch-requested' ? 'dispatch-requested' : 'at facility';
+            // If dewar status is dispatch-requested - don't change it.
+            // This way the dewar can be moved between storage locations and keep the record that a user requested the dispatch
+            // Default status is 'at-facility'
+            $dewarstatus = strtolower($dew['DEWARSTATUS']) == 'dispatch-requested' ? 'dispatch-requested' : 'at facility';
+            $dewarlocation = $this->arg('LOCATION');
 
-        $this->db->pq("INSERT INTO dewartransporthistory (dewartransporthistoryid,dewarid,dewarstatus,storagelocation,arrivaldate) VALUES (s_dewartransporthistory.nextval,:1,lower(:2),lower(:3),CURRENT_TIMESTAMP) RETURNING dewartransporthistoryid INTO :id", array($dew['DEWARID'], $dewarstatus, $this->arg('LOCATION')));
+        } else {
+            // just a status given
+            $dewarstatus = $this->arg('STATUS');
+            $dewarlocation = $dew['STORAGELOCATION'];
+        }
+
+        $this->db->pq("INSERT INTO dewartransporthistory (dewartransporthistoryid,dewarid,dewarstatus,storagelocation,arrivaldate) VALUES (s_dewartransporthistory.nextval,:1,lower(:2),lower(:3),CURRENT_TIMESTAMP) RETURNING dewartransporthistoryid INTO :id", array($dew['DEWARID'], $dewarstatus, $dewarlocation));
         $dhid = $this->db->id();
 
-        $this->db->pq("UPDATE dewar set dewarstatus=lower(:4), storagelocation=lower(:2), trackingnumberfromsynchrotron=:3 WHERE dewarid=:1", array($dew['DEWARID'], $this->arg('LOCATION'), $track, $dewarstatus));
-        $this->db->pq("UPDATE shipping set shippingstatus=lower(:2) WHERE shippingid=:1", array($dew['SHIPPINGID'], $dewarstatus));
+        if ($this->has_arg('LOCATION')) {
+            $this->db->pq("UPDATE dewar set dewarstatus=lower(:4), storagelocation=lower(:2), trackingnumberfromsynchrotron=:3 WHERE dewarid=:1", array($dew['DEWARID'], $this->arg('LOCATION'), $track, $dewarstatus));
+            $this->db->pq("UPDATE shipping set shippingstatus=lower(:2) WHERE shippingid=:1", array($dew['SHIPPINGID'], $dewarstatus));
 
-        $containers = $this->db->pq("SELECT containerid 
-                FROM container 
-                WHERE dewarid=:1", array($dew['DEWARID']));
-        foreach ($containers as $c) {
-            $this->db->pq("INSERT INTO containerhistory (containerid,status) VALUES (:1,:2)", array($c['CONTAINERID'], 'at facility'));
-        }
-
-        // Email
-        // EHCs, local contact(s), labcontact, dh, pa
-        $dew['NOW'] = strftime('%d-%m-%Y %H:%M');
-        $dew['INCONTACTS'] = $in_contacts;
-        $dew['TRACKINGNUMBERFROMSYNCHROTRON'] = $track;
-
-        if (strtolower($this->arg('LOCATION')) == 'stores-in' && $dew['LCOUTEMAIL']) {
-            $lcs = $this->db->pq("SELECT p.login
-                  FROM person p 
-                  INNER JOIN session_has_person shp ON shp.personid = p.personid
-                  WHERE shp.sessionid=:1 AND (shp.role = 'Local Contact' OR shp.role = 'Local Contact 2')", array($dew['FIRSTEXPERIMENTID']));
-            $emails = array($dew['LCOUTEMAIL'], $arrival_email);
-            foreach ($lcs as $lc) {
-                array_push($emails, $this->_get_email($lc['LOGIN']));
+            $containers = $this->db->pq("SELECT containerid
+                    FROM container
+                    WHERE dewarid=:1", array($dew['DEWARID']));
+            foreach ($containers as $c) {
+                $this->db->pq("INSERT INTO containerhistory (containerid,status) VALUES (:1,:2)", array($c['CONTAINERID'], 'at facility'));
             }
 
-            $email = new Email($dew['PROPOSALCODE'] == 'in' ? 'dewar-stores-in-in' : 'dewar-stores-in', '*** Dewar Received for ' . $dew['PROP'] . ' at ' . $dew['NOW'] . ' ***');
-            $email->data = $dew;
-            $email->send(implode(', ', $emails));
-        }
+            // Email
+            // EHCs, local contact(s), labcontact, dh, pa
+            $dew['NOW'] = strftime('%d-%m-%Y %H:%M');
+            $dew['INCONTACTS'] = $in_contacts;
+            $dew['TRACKINGNUMBERFROMSYNCHROTRON'] = $track;
 
-        if (strtolower($this->arg('LOCATION')) == 'stores-out' && $dew['LCRETEMAIL']) {
-            $email = new Email('dewar-stores-out', '*** Dewar ready to leave Synchrotron ***');
-            $email->data = $dew;
-            $email->send($dew['LCRETEMAIL']);
-        }
+            if (strtolower($this->arg('LOCATION')) == 'stores-in' && $dew['LCOUTEMAIL']) {
+                $lcs = $this->db->pq("SELECT p.login
+                      FROM person p
+                      INNER JOIN session_has_person shp ON shp.personid = p.personid
+                      WHERE shp.sessionid=:1 AND (shp.role = 'Local Contact' OR shp.role = 'Local Contact 2')", array($dew['FIRSTEXPERIMENTID']));
+                $emails = array($dew['LCOUTEMAIL'], $arrival_email);
+                foreach ($lcs as $lc) {
+                    array_push($emails, $this->_get_email($lc['LOGIN']));
+                }
 
-        if (strpos(strtolower($this->arg('LOCATION')), '-rack') !== false && $dew['LCRETEMAIL']) {
-            $dew['LOCATION'] = $this->arg('LOCATION');
-
-            $email = new Email('dewar-rack', '*** Dewar now outside Beamline ***');
-            $email->data = $dew;
-            $email->send($dew['LCRETEMAIL']);
-        }
-
-        if ($dew['LCRETEMAIL'] && $send_return_email) {
-            // Any data collections for this dewar's containers?
-            // Note this counts data collection ids for containers and uses the DataCollection.SESSIONID to determine the session/visit
-            // Should work for UDC (where container.sessionid is set) as well as any normal scheduled session (where container.sessionid is not set)
-            $rows = $this->db->pq("SELECT CONCAT(p.proposalcode, p.proposalnumber, '-', ses.visit_number) as visit, dc.sessionid, count(dc.datacollectionid) as dccount
-                    FROM Dewar d
-                    INNER JOIN Container c on c.dewarid = d.dewarid
-                    INNER JOIN BLSample bls ON bls.containerid = c.containerid
-                    INNER JOIN DataCollection dc ON dc.blsampleid = bls.blsampleid
-                    INNER JOIN BLSession ses ON dc.sessionid = ses.sessionid
-                    INNER JOIN Proposal p ON p.proposalid = ses.proposalid
-                    WHERE d.dewarid = :1
-                    GROUP BY dc.sessionid", array($dew['DEWARID']));
-
-            if (sizeof($rows))
-                $dew['DC'] = $rows;
-
-            $cc = array($dewar_complete_email ? $dewar_complete_email : null);
-
-            $owners = $this->db->pq("SELECT p.emailaddress
-                FROM Container c
-                INNER JOIN Person p ON c.ownerId = p.personId
-                WHERE c.dewarId = :1
-                GROUP BY p.emailaddress", array($dew['DEWARID']));
-
-            foreach ($owners as $owner) {
-                if ($owner['EMAILADDRESS'] != '') array_push($cc, $owner['EMAILADDRESS']);
+                $email = new Email($dew['PROPOSALCODE'] == 'in' ? 'dewar-stores-in-in' : 'dewar-stores-in', '*** Dewar Received for ' . $dew['PROP'] . ' at ' . $dew['NOW'] . ' ***');
+                $email->data = $dew;
+                $email->send(implode(', ', $emails));
             }
 
-            // Log the event if debugging
-            if ($this->debug) error_log("Dewar " . $dew['DEWARID'] . " back from beamline...");
+            if (strtolower($this->arg('LOCATION')) == 'stores-out' && $dew['LCRETEMAIL']) {
+                $email = new Email('dewar-stores-out', '*** Dewar ready to leave Synchrotron ***');
+                $email->data = $dew;
+                $email->send($dew['LCRETEMAIL']);
+            }
 
-            $email = new Email('storage-rack', '*** Visit finished, dewar awaiting instructions ***');
-            $email->data = $dew;
-            $email->send($dew['LCRETEMAIL'], implode(', ', $cc));
+            if (strpos(strtolower($this->arg('LOCATION')), '-rack') !== false && $dew['LCRETEMAIL']) {
+                $dew['LOCATION'] = $this->arg('LOCATION');
+
+                $email = new Email('dewar-rack', '*** Dewar now outside Beamline ***');
+                $email->data = $dew;
+                $email->send($dew['LCRETEMAIL']);
+            }
+
+            if ($dew['LCRETEMAIL'] && $send_return_email) {
+                // Any data collections for this dewar's containers?
+                // Note this counts data collection ids for containers and uses the DataCollection.SESSIONID to determine the session/visit
+                // Should work for UDC (where container.sessionid is set) as well as any normal scheduled session (where container.sessionid is not set)
+                $rows = $this->db->pq("SELECT CONCAT(p.proposalcode, p.proposalnumber, '-', ses.visit_number) as visit, dc.sessionid, count(dc.datacollectionid) as dccount
+                        FROM Dewar d
+                        INNER JOIN Container c on c.dewarid = d.dewarid
+                        INNER JOIN BLSample bls ON bls.containerid = c.containerid
+                        INNER JOIN DataCollection dc ON dc.blsampleid = bls.blsampleid
+                        INNER JOIN BLSession ses ON dc.sessionid = ses.sessionid
+                        INNER JOIN Proposal p ON p.proposalid = ses.proposalid
+                        WHERE d.dewarid = :1
+                        GROUP BY dc.sessionid", array($dew['DEWARID']));
+
+                if (sizeof($rows))
+                    $dew['DC'] = $rows;
+
+                $cc = array($dewar_complete_email ? $dewar_complete_email : null);
+
+                $owners = $this->db->pq("SELECT p.emailaddress
+                    FROM Container c
+                    INNER JOIN Person p ON c.ownerId = p.personId
+                    WHERE c.dewarId = :1
+                    GROUP BY p.emailaddress", array($dew['DEWARID']));
+
+                foreach ($owners as $owner) {
+                    if ($owner['EMAILADDRESS'] != '') array_push($cc, $owner['EMAILADDRESS']);
+                }
+
+                // Log the event if debugging
+                if ($this->debug) error_log("Dewar " . $dew['DEWARID'] . " back from beamline...");
+
+                $email = new Email('storage-rack', '*** Visit finished, dewar awaiting instructions ***');
+                $email->data = $dew;
+                $email->send($dew['LCRETEMAIL'], implode(', ', $cc));
+            }
         }
 
         $this->_output(array('DEWARHISTORYID' => $dhid));


### PR DESCRIPTION
**JIRA ticket**: [LIMS-753](https://jira.diamond.ac.uk/browse/LIMS-753)

**Summary**:

We record every time a dewar is topped up with LN2, but in the `Dewar.comments` field. In order to let the users know what has happened to their dewar, we should record it in the `DewarTransportHistory` table.
Once this code is live, I can edit the [Dewar Logistics](https://github.com/DiamondLightSource/flask-ispyb-logistics/) code to use this endpoint instead.

**Changes**:
- Allow usage of the `shipments/dewars/history` endpoint with a `STATUS` instead of a `LOCATION`.
- Update only `DewarTransportHistory` (and not `Dewar`) if only `STATUS` given
- Only send emails if the location has changed (and other criteria met)

**To test**:
- Edit the `$bcr` variable in config.php to include the IP of a machine you can ping your server from
- Use python requests library (or similar) to hit the endpoint:
```
>>> import requests
>>> url = server_address + "/api/shipment/dewars/history"
>>> data = {"BARCODE": valid_dewar_barcode, "STATUS": "LN2 topped up"}
>>> r = requests.post(url, json=data)
```
If you get a 401 response, double check the $bcr variable. If you get a 200, go the dewar page on your Synchweb instance and check if the status has been added to the history. If no history shows, you might need to remove your IP from $bcr, it can get in the way. It should look like this:
![image](https://github.com/user-attachments/assets/156133c7-ee90-44fb-9c6c-017d057aecdb)
- Repeat the test with a `LOCATION` sent in instead of `STATUS`. Check the dewar location has changed in both the `Dewar` and `DewarTransportHistory` tables.