### PR TITLE
LIMS-261: Allow download of PDB files

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -195,6 +195,7 @@ class Sample extends Page
         array('/pdbs(/pid/:pid)', 'get', '_get_pdbs'),
         array('/pdbs', 'post', '_add_pdb'),
         array('/pdbs(/:pdbid)', 'delete', '_remove_pdb'),
+        array('/pdbs/download/:pdbid', 'get', '_download_pdb'),
 
         array('/concentrationtypes', 'get', '_concentration_types'),
         array('/componenttypes', 'get', '_component_types'),
@@ -2060,6 +2061,21 @@ class Sample extends Page
         $rows = $this->db->pq("SELECT distinct hp.proteinhaspdbid, p.pdbid,pr.proteinid, p.name,p.code FROM pdb p INNER JOIN protein_has_pdb hp ON p.pdbid = hp.pdbid INNER JOIN protein pr ON pr.proteinid = hp.proteinid WHERE $where ORDER BY p.pdbid DESC", $args);
 
         $this->_output($rows);
+    }
+
+    # ------------------------------------------------------------------------
+    # Download a pdb file
+    function _download_pdb()
+    {
+        if (!$this->has_arg('pdbid'))
+            $this->_error('No PDB id specified');
+
+        $pdb = $this->db->pq("SELECT name, contents FROM pdb WHERE pdbid = :1", array($this->arg('pdbid')));
+        $pdb = $pdb[0];
+
+        header('Content-Type:text/plain');
+        header('Content-Disposition:attachment;filename='.$pdb['NAME']);
+        print $pdb['CONTENTS'];
     }
 
     # ------------------------------------------------------------------------

--- a/client/src/js/modules/samples/views/pdbs.js
+++ b/client/src/js/modules/samples/views/pdbs.js
@@ -1,15 +1,28 @@
-define(['marionette'], function(Marionette) {
+define(['marionette', 'utils'], function(Marionette, utils) {
 
 
     var UserItem = Marionette.ItemView.extend({
-        template: _.template('<%-NAME%> <% if (CODE) { %>[CODE]<% } else { %>[File]<% } %> <span class="r"><a class="button button-notext delete" href="#"><i class="fa fa-times"></i> <span>Delete</span></a></span>'),
+        template: _.template(''),
         tagName: 'li',
         attributes: { 'data-testid': 'protein-pdb-list-item' },
         events: {
-            'click a.delete': 'deleteUser',
+            'click a.delete': 'deletePDB',
+            'click a.download': utils.signHandler,
         },
         
-        deleteUser: function(e) {
+        render: function() {
+            UserItem.__super__.render.call(this)
+            const linkButton = '<a class="button button-notext" href="https://www.wwpdb.org/pdb?id=pdb_0000'+this.model.get('CODE')+'"><i class="fa fa-link"></i> <span>PDB</span></a>'
+            const deleteButton = '<a class="button button-notext delete" href="#"><i class="fa fa-times"></i> <span>Delete</span></a>'
+            const downloadButton = '<a class="button button-notext download" href="'+app.apiurl+'/sample/pdbs/download/'+this.model.get('PDBID')+'"><i class="fa fa-download"></i> <span>Download</span></a>'
+            if (this.model.get('CODE')) {
+                this.$el.append(this.model.get('NAME')+' [Code] <span class="r">'+linkButton+' '+deleteButton+'</span>')
+            } else {
+                this.$el.append(this.model.get('NAME')+' [File] <span class="r">'+downloadButton+' '+deleteButton+'</span>')
+            }
+        },
+
+        deletePDB: function(e) {
             this.model.destroy()
         },
     })

--- a/client/src/js/modules/samples/views/pdbs.js
+++ b/client/src/js/modules/samples/views/pdbs.js
@@ -12,7 +12,7 @@ define(['marionette', 'utils'], function(Marionette, utils) {
         
         render: function() {
             UserItem.__super__.render.call(this)
-            const linkButton = '<a class="button button-notext" href="https://www.wwpdb.org/pdb?id=pdb_0000'+this.model.get('CODE')+'"><i class="fa fa-link"></i> <span>PDB</span></a>'
+            const linkButton = '<a class="button button-notext" href="https://www.rcsb.org/structure/'+this.model.get('CODE')+'"><i class="fa fa-link"></i> <span>RCSB</span></a>'
             const deleteButton = '<a class="button button-notext delete" href="#"><i class="fa fa-times"></i> <span>Delete</span></a>'
             const downloadButton = '<a class="button button-notext download" href="'+app.apiurl+'/sample/pdbs/download/'+this.model.get('PDBID')+'"><i class="fa fa-download"></i> <span>Download</span></a>'
             if (this.model.get('CODE')) {

--- a/client/src/js/modules/samples/views/pdbs.js
+++ b/client/src/js/modules/samples/views/pdbs.js
@@ -12,7 +12,7 @@ define(['marionette', 'utils'], function(Marionette, utils) {
         
         render: function() {
             UserItem.__super__.render.call(this)
-            const linkButton = '<a class="button button-notext" href="https://www.rcsb.org/structure/'+this.model.get('CODE')+'"><i class="fa fa-link"></i> <span>RCSB</span></a>'
+            const linkButton = '<a class="button button-notext" href="https://www.ebi.ac.uk/pdbe/entry/pdb/'+this.model.get('CODE')+'"><i class="fa fa-link"></i> <span>EBI</span></a>'
             const deleteButton = '<a class="button button-notext delete" href="#"><i class="fa fa-times"></i> <span>Delete</span></a>'
             const downloadButton = '<a class="button button-notext download" href="'+app.apiurl+'/sample/pdbs/download/'+this.model.get('PDBID')+'"><i class="fa fa-download"></i> <span>Download</span></a>'
             if (this.model.get('CODE')) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-261](https://jira.diamond.ac.uk/browse/LIMS-261)

**Summary**:

We store uploaded PDB files (and alphafold generated PDB files) in ISPyB, we should allow users to download them again. (We also store 4-letter PDB codes)

**Changes**:
- Generate buttons on each PDB after rendering, so that the code etc is known
- Add a button with link to EBI if the type is 'code'
- Otherwise, add download button
- Add new endpoint to download contents field

**To test**:
- Go to a protein with PDB's associated with it, eg /proteins/pid/422017
- Check the link button next to a 'code' type PDB goes to the correct entry on ebi.ac.uk
- Check the download button on a 'file' type PDB downloads a file with the correct name and contents (should be plain text)
- Check the delete button removes the association between the PDB and the protein
