### PR TITLE
LIMS-1529: Fix fast ep model viewer

### DIFF
--- a/api/scripts/mtz2map.sh
+++ b/api/scripts/mtz2map.sh
@@ -14,6 +14,14 @@ else
 	fi
 fi
 
+#export CCP4_MASTER=/dls_sw/apps/ccp4/<ccp4 version>
+export CCP4_MASTER=$5
+export CINCL=$CCP4_MASTER/include
+export CLIBD=$CCP4_MASTER/lib/data
+
+export CCP4_SCR=/tmp
+export root=$CCP4_MASTER/bin
+
 if [ $3 == 'dimple' -o $3 == 'mrbump' ]; then
 
 if [ -f $4 ]; then
@@ -27,14 +35,6 @@ else
 		exit
 	fi
 fi
-
-#export CCP4_MASTER=/dls_sw/apps/ccp4/<ccp4 version>
-export CCP4_MASTER=$5
-export CINCL=$CCP4_MASTER/include
-export CLIBD=$CCP4_MASTER/lib/data
-
-export CCP4_SCR=/tmp
-export root=$CCP4_MASTER/bin
 
 if [ $3 == 'dimple' ]; then
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1529](https://jira.diamond.ac.uk/browse/LIMS-1529)

**Summary**:

https://github.com/DiamondLightSource/SynchWeb/pull/821 introduced a bug where the CCP4 path was set correctly for Dimple and MrBump, but not for Fast EP jobs, so the mtz2map conversion would fail and the map would not load.

**Changes**:
- Move the setting of `$CCP4_MASTER` etc out of the if clause

**To test**:
- EDIT: Make sure to set `$ccp4_location = '/dls_sw/apps/ccp4/latest/ccp4-9';` in your config.php file
- Go to a data collection with Dimple, MrBump and Fast EP results eg /dc/visit/cm37235-4/id/15531187
- Go to each downstream pipeline in turn and click "Map/Model Viewer", check that some electron density appears and no errors occur.