### PR TITLE
LIMS-1530: Add To Queue Fails when Not Completed filter applied

### DIFF
--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -773,7 +773,7 @@ define(['marionette',
         },
 
         refreshSubSamples: function() {
-            this.subsamples.fetch()
+            this.subsamples.fetch().done(this.onSubsamplesReady.bind(this))
         },
         
         initialize: function() {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1530](https://jira.diamond.ac.uk/browse/LIMS-1530)

**Summary**:

Filtering subsamples by "Not Completed" or "Without Data" breaks the inidvidual "+" (add to queue) buttons and the "Add Current Page to Queue" button for anything but the first page of samples. They are added to the queue but not displayed in the lower half of the page.

**Changes**:
- Rerun the onSubsamplesReady function after changing the "Not Completed" or "Without Data" filters, which regenerates the internal list to keep track of pages

**To test**:
- Go to proposal nt37104, go to `/containers`, go to a container which is "in_storage"
- Click "Mark Point" and click a couple of locations in a well, to generate some manual subsamples, then click "Finish"
- Click "Prepare For Data Collection" to go to `/containers/queue/<containerid>`
- Add a couple of samples to the queue by clicking the plus button next to them, check they appear in the lower half of the screen immediately, and remain so after a refresh
- Repeat this for some samples on a page other than page 1
- Check the "Add Current Page to Queue" button works for page 1 and also later pages
- Turn on the "Without Data" filter and repeat the tests above
- Turn on the "Not Completed" filter and repeat the tests above
- Turn on both the "Not Completed" and "Manual" filters, and repeat the tests above (there may not be more than one page)
