### PR TITLE
LIMS-1487: Fix alphafold triggering

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -128,12 +128,12 @@
     $enabled_container_types = array();
 
     # Zocalo message broker credentials - Set to empty string to disable
-    $zocalo_server = 'tcp://activemq.server.ac.uk';
-    $zocalo_username = 'foo';
-    $zocalo_password = 'bar';
-
-    # Primary Zocalo entry point for recipe submission
-    $zocalo_mx_reprocess_queue = '/queue/zocolo.name';
+    $rabbitmq_zocalo_host = 'rabbitmq.server.ac.uk';
+    $rabbitmq_zocalo_port = 5672;
+    $rabbitmq_zocalo_username = 'foo';
+    $rabbitmq_zocalo_password = 'bar';
+    $rabbitmq_zocalo_vhost = 'zocalo';
+    $rabbitmq_zocalo_routing_key = 'processing_recipe';
 
     # This is used to trigger Zocalo recipes on adding new Protein sequences
     # Set to empty string to disable

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -1093,9 +1093,9 @@ class Page
 
     function _submit_zocalo_recipe($recipe, $parameters, $error_code = 500)
     {
-        global $zocalo_mx_reprocess_queue;
+        global $rabbitmq_zocalo_vhost;
 
-        if (isset($zocalo_mx_reprocess_queue))
+        if (isset($rabbitmq_zocalo_vhost))
         {
             // Send job to processing queue
             $zocalo_message = array(
@@ -1104,7 +1104,7 @@ class Page
                 ),
                 'parameters' => $parameters,
             );
-            $this->_send_zocalo_message($zocalo_mx_reprocess_queue, $zocalo_message, $error_code);
+            $this->_send_zocalo_message($rabbitmq_zocalo_vhost, $zocalo_message, $error_code);
         }
     }
 
@@ -1130,7 +1130,6 @@ class Page
 
         try
         {
-            error_log("Sending message" . var_export($zocalo_message, true));
             $queue = new Queue($rabbitmq_zocalo_host, $rabbitmq_zocalo_port, $rabbitmq_zocalo_username, $rabbitmq_zocalo_password, $rabbitmq_zocalo_vhost);
             $queue->send($zocalo_message, $rabbitmq_zocalo_routing_key);
         }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1487](https://jira.diamond.ac.uk/browse/LIMS-1487)

**Summary**:

Automatic triggering of alphafold when a sequence is added was broken by the switch to rabbitmq (https://github.com/DiamondLightSource/SynchWeb/pull/826)

**Changes**:
- Use rabbitmq parameters instead of activemq ones to submit jobs
- Put the updated global variable names in the sample config

**To test**:
- Put the rabbitmq variables into the config (get from prod or from Mark)
- Find a protein in a cm proposal with no current sequence (eg /proteins/pid/604455)
- Add a suitable sequence (eg copy from /proteins/pid/597094)
- Check in [graylog](https://graylog.diamond.ac.uk/streams/6579e104ca674e7c2a7c6bad/search?q=alphafold&rangetype=relative&streams=6579e104ca674e7c2a7c6bad&from=86400) if alphafold has been triggered
- Wait a couple of hours, some pdb files will appear in the **prod** database