### PR TITLE
LIMS-1064: Display dropdown or span depending on number of schema options

### DIFF
--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -264,6 +264,7 @@ define(['marionette',
 
             sampleStatusAuto: 'input[id=sample_status_auto]',
             schema: 'select[name=schema]',
+            schemaspan: '.schemaspan',
             class: 'select[name=class]',
         },
 
@@ -656,6 +657,14 @@ define(['marionette',
         },
 
         updateSchemas: function() {
+            if (this.autoscoreschemas.length === 1) {
+                this.ui.schemaspan.html(this.autoscoreschemas.at(0).get('SCHEMANAME'))
+                this.ui.schemaspan.show()
+                this.ui.schema.hide()
+            } else {
+                this.ui.schemaspan.hide()
+                this.ui.schema.show()
+            }
             this.ui.schema.html(this.autoscoreschemas.opts())
             this.selectSchema()
         },

--- a/client/src/js/templates/shipment/containerplateimage.html
+++ b/client/src/js/templates/shipment/containerplateimage.html
@@ -45,10 +45,8 @@
                 <div>
                     <label>
                         <input type="radio" value="sample_status_auto" name="sample_status" id="sample_status_auto"/> 
-                        CHIMP Auto Scores
+                        <select name="schema"></select><span class="schemaspan"></span> Auto Scores
                     </label>
-                    <!--There is only ever one option in schema but it was too hard to remove the code see ticket LIMS-1064 -->
-                    <select name="schema" style="display:none"></select> 
                     Class: <select name="class"></select>
                 </div>
                 <div class="sta small"></div> 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1064](https://jira.diamond.ac.uk/browse/LIMS-1064)

**Summary**:

In https://github.com/DiamondLightSource/SynchWeb/pull/621 we hard-coded the UI to say only CHIMP auto-scores were available. There are 275 plates in the database with MARCO scores, and of course other schemas may be used in future, So we should show a dropdown if mulitple schema results return, but just a span if only one schema results return.

**Changes**:
- Re-enable the schema dropdown, as well as an empty span
- Show or hide them according to the number of schemas returned

**To test**:
- Go to a container inspection with both MARCO and CHIMP scores, eg /containers/cid/177952, inspection on 9th Dec 2020, check a dropdown appears to choose between MARCO and CHIMP scores
- Switch to an older inspection (eg 21st July 2020) which just has MARCO scores, check the dropdown disappears and it just says "MARCO Auto Scores"
- Go to a newer plate (eg /containers/cid/317254) with just CHIMP scores, check it says "CHIMP Auto Scores"
