### PR TITLE
LIMS-1537: Add more options to reprocessing

### DIFF
--- a/client/src/js/modules/dc/views/reprocess2.js
+++ b/client/src/js/modules/dc/views/reprocess2.js
@@ -46,7 +46,8 @@ define(['backbone', 'marionette', 'views/dialog',
             ind: 'div.ind',
             pipeline: 'select[name=pipeline]',
             res: 'input[name=res]',
-            sg: 'select[name=SG]'
+            lowres: 'input[name=lowres]',
+            sg: 'input[name=SG]'
         },
 
         events: {
@@ -71,11 +72,16 @@ define(['backbone', 'marionette', 'views/dialog',
 
             'change @ui.pipeline': 'updatePipeline',
             'change @ui.res': 'updateRes',
+            'change @ui.lowres': 'updateLowRes',
         },
 
 
         updateRes: function() {
             this.model.set('RES', this.ui.res.val())
+        },
+
+        updateLowRes: function() {
+            this.model.set('LOWRES', this.ui.lowres.val())
         },
 
         updatePipeline: function() {
@@ -139,6 +145,7 @@ define(['backbone', 'marionette', 'views/dialog',
             this.ui.ind.hide()
             this.$el.find('ul').addClass('half')
             this.$el.find('li input[type="text"]').css('width', '25%')
+            this.$el.find('div input[type="text"]').css('width', '50px')
             this.ui.pipeline.html(this.getOption('pipelines').opts())
             this.model.set('PIPELINE', this.ui.pipeline.val())
         },
@@ -172,7 +179,7 @@ define(['backbone', 'marionette', 'views/dialog',
                 this.ui.be.val(c['CELL_BE']).trigger('change')
                 this.ui.ga.val(c['CELL_GA']).trigger('change')
 
-                this.ui.sg.val(e['SG']).trigger('change')
+                this.ui.sg.val(e.get('SG')).trigger('change')
             }
         },
 
@@ -213,6 +220,12 @@ define(['backbone', 'marionette', 'views/dialog',
     }, KVCollection))
 
 
+    var AbsorptionLevels = Backbone.Collection.extend(_.extend({
+        keyAttribute: 'NAME',
+        valueAttribute: 'VALUE',
+    }, KVCollection))
+
+
     return ReprocessView = DialogView.extend({
         template: template,
         dialog: true,
@@ -233,6 +246,7 @@ define(['backbone', 'marionette', 'views/dialog',
             sg: 'select[name=sg]',
             sm: 'input[name=sm]',
             indexingMethod: 'select[name=method]',
+            absorptionLevel: 'select[name=absorption_level]',
         },
 
         buttons: {
@@ -287,7 +301,7 @@ define(['backbone', 'marionette', 'views/dialog',
         },
 
         xia2params: function() {
-            return ['cc_half', 'isigma', 'misigma', 'sigma_strong', 'method']
+            return ['cc_half', 'isigma', 'misigma', 'sigma_strong', 'method', 'absorption_level']
         },
 
         integrate: function(e) {
@@ -325,6 +339,12 @@ define(['backbone', 'marionette', 'views/dialog',
                                 PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID'),
                                 PARAMETERKEY: 'd_min', 
                                 PARAMETERVALUE: sw.get('RES')
+                            }))
+
+                            if (sw.get('LOWRES')) reprocessingparams.add(new ReprocessingParameter({
+                                PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID'),
+                                PARAMETERKEY: 'd_max',
+                                PARAMETERVALUE: sw.get('LOWRES')
                             }))
 
                             var hascell = true
@@ -417,6 +437,13 @@ define(['backbone', 'marionette', 'views/dialog',
                             PARAMETERVALUE: res
                         }))
 
+                        var lowres = self.$el.find('input[name=lowres]').val()
+                        if (lowres) reprocessingparams.add(new ReprocessingParameter({
+                            PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID'),
+                            PARAMETERKEY: 'd_max',
+                            PARAMETERVALUE: lowres
+                        }))
+
                         var hascell = true
                         var cell = []
                         _.each(['a', 'b', 'c', 'alpha', 'beta', 'gamma'], function(f, i) {
@@ -506,6 +533,7 @@ define(['backbone', 'marionette', 'views/dialog',
         onRender: function() {
             this.ui.opts.hide()
             this.ui.cell.hide()
+            this.$el.find('span input[type="text"]').css('width', '50px')
 
             this.pipelines = new Pipelines([
                 { NAME: 'Xia2 DIALS', VALUE: 'xia2-dials' },
@@ -524,6 +552,15 @@ define(['backbone', 'marionette', 'views/dialog',
             ])
 
             this.ui.indexingMethod.html(this.indexingMethods.opts())
+
+            this.absorptionLevels = new AbsorptionLevels([
+                { NAME: '-', VALUE: '' },
+                { NAME: 'Low', VALUE: 'low' },
+                { NAME: 'Medium', VALUE: 'medium' },
+                { NAME: 'High', VALUE: 'high' },
+            ])
+
+            this.ui.absorptionLevel.html(this.absorptionLevels.opts())
 
             // asynchronously load space groups into the select menu
             this.showSpaceGroups()

--- a/client/src/js/modules/mc/views/datacollections.js
+++ b/client/src/js/modules/mc/views/datacollections.js
@@ -42,6 +42,12 @@ define(['backbone', 'marionette',
     }, KVCollection))
 
 
+    var AbsorptionLevels = Backbone.Collection.extend(_.extend({
+        keyAttribute: 'NAME',
+        valueAttribute: 'VALUE',
+    }, KVCollection))
+
+
     return Marionette.LayoutView.extend({
         className: 'content',
         template: template,
@@ -63,6 +69,7 @@ define(['backbone', 'marionette',
             wait: '.wait',
             pipeline: 'select[name=pipeline]',
             indexingMethod: 'select[name=method]',
+            absorptionLevel: 'select[name=absorption_level]',
             opts: 'div.options',
             sm: 'input[name=sm]',
             sg: 'select[name=sg]',
@@ -94,7 +101,7 @@ define(['backbone', 'marionette',
         },
 
         xia2params: function() {
-            return ['cc_half', 'isigma', 'misigma', 'sigma_strong', 'method']
+            return ['cc_half', 'isigma', 'misigma', 'sigma_strong', 'method', 'absorption_level']
         },
 
         integrate: function(e) {
@@ -125,6 +132,13 @@ define(['backbone', 'marionette',
                         PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID'),
                         PARAMETERKEY: 'd_min', 
                         PARAMETERVALUE: res
+                    }))
+
+                    var lowres = self.$el.find('input[name=lowres]').val()
+                    if (lowres) reprocessingparams.add(new ReprocessingParameter({
+                        PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID'),
+                        PARAMETERKEY: 'd_max',
+                        PARAMETERVALUE: lowres
                     }))
 
                     var hascell = true
@@ -252,6 +266,15 @@ define(['backbone', 'marionette',
             ])
 
             this.ui.indexingMethod.html(this.indexingMethods.opts())
+
+            this.absorptionLevels = new AbsorptionLevels([
+                { NAME: '-', VALUE: '' },
+                { NAME: 'Low', VALUE: 'low' },
+                { NAME: 'Medium', VALUE: 'medium' },
+                { NAME: 'High', VALUE: 'high' },
+            ])
+
+            this.ui.absorptionLevel.html(this.absorptionLevels.opts())
         },
           
         setCell: function(view, ap) {

--- a/client/src/js/modules/mc/views/datacollections.js
+++ b/client/src/js/modules/mc/views/datacollections.js
@@ -193,7 +193,7 @@ define(['backbone', 'marionette',
                     var reprocessingsweeps = new ReprocessingImageSweeps(sweeps)
                     reprocessingsweeps.save()
 
-                    app.alert({ message: '1 reprocessing job successfully submitted'})
+                    app.message({ message: '1 reprocessing job successfully submitted'})
                     self._enqueue({ PROCESSINGJOBID: reprocessing.get('PROCESSINGJOBID') })
                 },
 

--- a/client/src/js/templates/dc/reprocess.html
+++ b/client/src/js/templates/dc/reprocess.html
@@ -11,7 +11,8 @@
         <span class="multi form">
             | 
             Pipeline :<select name="pipeline"></select>
-            High Res :<input type="text" name="res" /> &#197; |
+            High Res :<input type="text" name="res" /> &#197;
+            Low Res :<input type="text" name="lowres" /> &#197; |
             <a href="#" class="button sgm">Space Group / Cell</a> 
             <!-- Comments: <input type="text" name="comments" class="full" /> -->
         </span>
@@ -36,7 +37,9 @@
         <label>Unmerged &lt;I/sigI&gt; :<input type="text" name="isigma" /></label>
         <label>Merged &lt;I/sigI&gt; :<input type="text" name="misigma" /></label>
         <label>Spot Finding Threshold :<input type="text" name="sigma_strong" /></label>
+        <br /><br />
         <label>Indexing Method: <select name="method"></select></label>
+        <label>Absorption Level: <select name="absorption_level"></select></label>
     </div>
 
 

--- a/client/src/js/templates/dc/reprocess_dc.html
+++ b/client/src/js/templates/dc/reprocess_dc.html
@@ -7,7 +7,8 @@
 
 <div class="ind data_collection">
     Pipeline <select name="pipeline"></select>
-    High Res <input type="text" name="res" /> &#197; | 
+    High Res <input type="text" name="res" /> &#197;
+    Low Res <input type="text" name="lowres" /> &#197; |
     <a href="#" class="button sg">Space Group / Cell</a> <br />
 </div>
 

--- a/client/src/js/templates/mc/datacollections.html
+++ b/client/src/js/templates/mc/datacollections.html
@@ -28,7 +28,8 @@
         <label>&beta; <input type="text" name="beta" /></label>
         <label>&gamma; <input type="text" name="gamma" /></label>
 
-        <label>High Resolution <input type="text" name="res" /></label>
+        <label>High Res <input type="text" name="res" /> &#197;</label>
+        <label>Low Res <input type="text" name="lowres" /> &#197;</label>
 
         <a href="#" class="button integrate" title="Integrate the selected data collections"><i class="fa fa-cog"></i> Integrate</a>
         <a href="#" class="button opt">Xia2 Options</a>
@@ -41,6 +42,7 @@
         <label>Merged &lt;I/sigI&gt; :<input type="text" name="misigma" /></label>
         <label>Spot Finding Threshold :<input type="text" name="sigma_strong" /></label>
         <label>Indexing Method: <select name="method"></select></label>
+        <label>Absorption Level: <select name="absorption_level"></select></label>
     </div>
 
     <div class="dcs"></div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1537](https://jira.diamond.ac.uk/browse/LIMS-1537)

**Summary**:

Add the d_max option and the absorption level option (for xia2 only) for reprocessing jobs. Also fix a bug in space groups when 'process individually' is ticked.

**Changes**:
- Add a low res input next to the current high res input
- Add a dropdown for absorption level with high/medium/low options, default is left blank
- Add the above changes to standard single crystal reprocessing and mutli crystal reprocessing
- Fix the identifier for the space group box to an input (rather than select) for when 'process individually' is ticked, so that the space group can be populated from the 'Use AP Cell' button, and the requested space group is passed on to the reprocessing job

**To test**:
- Change your config to use the production database otherwise the reprocessing won't work
- Go to a recent data collection (so that images are still on disk) in the commissioning directory (as we are using the prod db) where auto processing has been successful (eg /dc/visit/cm37235-5/id/16115203)
- Click the cog icon for reprocessing, choose a Xia2 pipeline (eg Xia2 Dials). Check there are High Res and Low Res fields, put in something like 2A for High Res and 3A for Low Res
- Click the Xia2 Options button, check there is now a dropdown for Absorption Level, set it to something eg Low
- Set the Start to 1 and the End to 100 to ensure processing is quicker, then press Integrate
- Wait around 10 minutes (maybe start the next test while you wait) for it to complete, then click on the new XIa2 Dials tab, and click on Processing Log. Click the button marked 'xia2 output' and you should get a text file, about the 14th line is the 'Command line' Check it has d_min as your High Res, d_max as your Low Res, and absorption_level=low
- Go back to the reprocessing screen, and this time tick 'Process Individually'. Choose a different pipeline (eg fastdp) and click the 'Space Group / Cell'. Click 'Use AP Cell' and check the space group is populated. Change the space group to something else (eg P1), and press Integrate
- Wait for the job to complete (it may fail as the space group is wrong, don't worry), then click on the Processing Log, then click on 'fast_dp log text'. Check you see a line saying 'Set spacegroup: P 1'
- Go back to the reprocessing screen, and this time click 'Multi Crystal' in the top right. Scroll down to the graphs, drag over a range of images from one of the data collections, then fill in the High and Low Res values as before, use Xia2 3dii as the pipeline, and set the Absorption Level to Medium. Press Integrate.
- As the job starts, you should see the parameters you set at the top of the page. When it completes, you should be able to click on the 'DC' column to go to the relevant data collection and see the processing logs, check your parameters were used by the program as before.