### PR TITLE
LIMS-1558: Add functionality for SMILES code for any sample

### DIFF
--- a/client/src/js/modules/samples/views/view.js
+++ b/client/src/js/modules/samples/views/view.js
@@ -108,6 +108,7 @@ define(['marionette',
             edit.create('DIMENSION3', 'text')
             edit.create('SHAPE', 'text')
             edit.create('COLOR', 'text')
+            edit.create('SMILES', 'text')
 
             if (!this.model.get('HASDATA')) {
                 edit.create('CODE', 'text')

--- a/client/src/js/templates/samples/sample.html
+++ b/client/src/js/templates/samples/sample.html
@@ -95,6 +95,11 @@
         </li>
 
         <li>
+            <span class="label">SMILES Code</span>
+            <span class="SMILES" data-testid="sample-smiles"><%-SMILES%></span>
+        </li>
+
+        <li>
             <span class="label">Barcode</span>
             <span class="CODE" data-testid="sample-barcode"><%-CODE%></span>
         </li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1558](https://jira.diamond.ac.uk/browse/LIMS-1558)

**Summary**:

https://github.com/DiamondLightSource/SynchWeb/pull/793 allowed SMILES codes to be added to samples in plates. This PR is to add that functionality to any sample.

**Changes**:
- Add SMILES entry box to sample view page

**To test**:
- Go to a visit, click on the sample associated with a data collection to go to eg /samples/sid/5461086
- Check the SMILES code box appears.
- Edit the SMILES code, using weird symbols eg .:%=#$@+-[]()/\, check it remains after a refresh
- Try symbols that are not allowed, eg £, check it is refused by the GUI

