### PR TITLE
LIMS-1066: Autofill UDC visit on dispatch form

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1626,12 +1626,24 @@ class Shipment extends Page
                 $order = $cols[$this->arg('sort_by')] . ' ' . $dir;
         }
 
-        $dewars = $this->db->paginate("SELECT CONCAT(p.proposalcode, p.proposalnumber) as prop, CONCAT(p.proposalcode, p.proposalnumber, '-', se.visit_number) as firstexperiment, r.labcontactid, se.beamlineoperator as localcontact, se.beamlinename, TO_CHAR(se.startdate, 'HH24:MI DD-MM-YYYY') as firstexperimentst, d.firstexperimentid, s.shippingid, s.shippingname, d.facilitycode, count(c.containerid) as ccount, (case when se.visit_number > 0 then (CONCAT(p.proposalcode, p.proposalnumber, '-', se.visit_number)) else '' end) as exp, d.code, d.barcode, d.storagelocation, d.dewarstatus, d.dewarid,  d.trackingnumbertosynchrotron, d.trackingnumberfromsynchrotron, d.externalShippingIdFromSynchrotron, s.deliveryagent_agentname, d.weight, d.deliveryagent_barcode, GROUP_CONCAT(c.code SEPARATOR ', ') as containers, s.sendinglabcontactid, s.returnlabcontactid, pe.givenname, pe.familyname, s.safetylevel as shippingsafetylevel
-              FROM dewar d 
-              LEFT OUTER JOIN container c ON c.dewarid = d.dewarid 
-              INNER JOIN shipping s ON d.shippingid = s.shippingid 
-              INNER JOIN proposal p ON p.proposalid = s.proposalid 
-              LEFT OUTER JOIN blsession se ON d.firstexperimentid = se.sessionid 
+        $dewars = $this->db->paginate("SELECT
+            CONCAT(p.proposalcode, p.proposalnumber) as prop,
+            CONCAT(p.proposalcode, p.proposalnumber, '-', se.visit_number) as firstexperiment,
+            CONCAT(p.proposalcode, p.proposalnumber, '-', se2.visit_number) as udcfirstexperiment,
+            r.labcontactid, se.beamlineoperator as localcontact, se.beamlinename,
+            TO_CHAR(se.startdate, 'HH24:MI DD-MM-YYYY') as firstexperimentst, d.firstexperimentid,
+            s.shippingid, s.shippingname, d.facilitycode, count(c.containerid) as ccount,
+            (case when se.visit_number > 0 then (CONCAT(p.proposalcode, p.proposalnumber, '-', se.visit_number)) else '' end) as exp,
+            d.code, d.barcode, d.storagelocation, d.dewarstatus, d.dewarid,
+            d.trackingnumbertosynchrotron, d.trackingnumberfromsynchrotron, d.externalShippingIdFromSynchrotron,
+            s.deliveryagent_agentname, d.weight, d.deliveryagent_barcode, GROUP_CONCAT(c.code SEPARATOR ', ') as containers,
+            s.sendinglabcontactid, s.returnlabcontactid, pe.givenname, pe.familyname, s.safetylevel as shippingsafetylevel
+              FROM dewar d
+              LEFT OUTER JOIN container c ON c.dewarid = d.dewarid
+              INNER JOIN shipping s ON d.shippingid = s.shippingid
+              INNER JOIN proposal p ON p.proposalid = s.proposalid
+              LEFT OUTER JOIN blsession se ON d.firstexperimentid = se.sessionid
+              LEFT OUTER JOIN blsession se2 ON c.sessionid = se2.sessionid
               LEFT OUTER JOIN dewarregistry r ON r.facilitycode = d.facilitycode
               LEFT OUTER JOIN labcontact lc ON s.sendinglabcontactid = lc.labcontactid
               LEFT OUTER JOIN person pe ON lc.personid = pe.personid

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -112,6 +112,7 @@ define(['marionette', 'views/form',
                 DEWARID: this.getOption('dewar').get('DEWARID'), 
                 LABCONTACTID: this.getOption('dewar').get('LABCONTACTID'),
                 VISIT: this.getOption('dewar').get('FIRSTEXPERIMENT'),
+                UDCVISIT: this.getOption('dewar').get('UDCFIRSTEXPERIMENT'),
                 // If no agent specified on inbound, default to diamond dhl
                 DELIVERYAGENT_AGENTNAME: this.getOption('shipping').get('DELIVERYAGENT_AGENTNAME') || 'DHL'
             })
@@ -174,7 +175,8 @@ define(['marionette', 'views/form',
         },
 
         doOnRender: function() {
-            this.ui.exp.html(this.visits.opts()).val(this.model.get('VISIT'))
+            let visit = this.model.get('VISIT') || this.model.get('UDCVISIT')
+            this.ui.exp.html(this.visits.opts()).val(visit)
             this.updateLC()
             this.populateCountries()
             this.stripPostCode()


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1066](https://jira.diamond.ac.uk/browse/LIMS-1066)

**Summary**:

When you request a dewar dispatch, the visit is automatically selected if it is associated with the dewar. But for UDC visits, the visit is associated with the container, so the visit is not automatically selected. This PR is to fix that.

**Changes**:
- Outer join Container to BLSession, and get a UDC visit if one exists
- Auto-select that visit in the dropdown if a non-UDC visit is not found

**To test**:
- Turn off the shipping service, or just use examples who haven't selected 'Use facility account'
- Go to a UDC shipment, eg /shipments/sid/67174, click "Dispatch", check that the visit is selected in the dispatch form
- Go to a non-UDC shipment, eg /shipments/sid/66694, click "Dispatch", check that the visit is selected in the dispatch form
- Go to a shipment with no visit associated, eg /shipments/sid/65232, click "Dispatch", check no visit is selected
