### PR TITLE
LIMS-1549: Disallow dispatch requests on dewars that are 'processing'

### DIFF
--- a/client/src/css/partials/_tables.scss
+++ b/client/src/css/partials/_tables.scss
@@ -165,10 +165,6 @@ They can be overriden by specific classes below
             }
             
             tr {
-                .deactivate {
-                    display: none;
-                }
-                
                 &.inactive td {
                     background: $content-inactive !important;
                 }
@@ -179,10 +175,6 @@ They can be overriden by specific classes below
                 
                 &.active td, &.active:nth-child(odd) td {
                     background: $content-active;
-                    
-                    .deactivate {
-                        display: inline;
-                    }
                 }
             }
             

--- a/client/src/js/modules/shipment/views/dewars.js
+++ b/client/src/js/modules/shipment/views/dewars.js
@@ -12,8 +12,8 @@ define(['marionette', 'backbone',
     
         'backbone-validation',
     ], function(Marionette, Backbone, Visits, DewarRegistry, ValidatedRow, Editable, forms, utils, template, rowtemplate, rowtemplatenew) {
-    
-        
+
+
     var GridRow = ValidatedRow.extend(_.extend({}, forms, {
         getTemplate: function() {
             return this.model.get('new') ? rowtemplatenew : rowtemplate
@@ -33,16 +33,19 @@ define(['marionette', 'backbone',
             'click a.deact': 'deactivateDewar',
             'click a.print': utils.signHandler,
         },
-        
+
         ui: {
             first: 'select[name=FIRSTEXPERIMENTID]',
             fc: 'select[name=FACILITYCODE]',
+            deact: '.deact',
+            dispatch: '.dispatch',
+            transfer: '.transfer',
+            ssd: '.ssdispatch',
         },
 
         className: function() {
             if (this.model.get('DEWARSTATUS') == 'processing') return 'active'
         },
-        
 
         deactivateDewar: function(e) {
             e.preventDefault()
@@ -52,6 +55,8 @@ define(['marionette', 'backbone',
                 data: { did: this.model.get('DEWARID') },
                 success: function() {
                     self.$el.removeClass('active')
+                    self.model.set('DEWARSTATUS', 'at facility')
+                    self.showHideButtons()
                 },
                 
                 error: function() {
@@ -66,7 +71,7 @@ define(['marionette', 'backbone',
             if (this.model.get('new')) return
             app.trigger('shipment:showdewar', this.model.get('DEWARID'))
         },
-        
+
         setData: function() {
             var data = {}
             _.each(['CODE', 'FACILITYCODE','FIRSTEXPERIMENTID','TRACKINGNUMBERTOSYNCHROTRON','TRACKINGNUMBERFROMSYNCHROTRON', 'WEIGHT'], function(f) {
@@ -82,11 +87,11 @@ define(['marionette', 'backbone',
                 self.render()
             })
         },
-        
+
         error: function(m,r,o) {
             app.message('Something went wrong creating this dewar, please try again')
         },
-        
+
         cancelDewar: function(e) {
             e.preventDefault()
             this.model.collection.remove(this.model)
@@ -95,7 +100,7 @@ define(['marionette', 'backbone',
         initialize: function() {
             this.showDewar = _.debounce(this.showDewar, 500)
         },
-    
+
         onRender: function() {
             console.log('rendering row')
             Backbone.Validation.unbind(this)
@@ -120,21 +125,44 @@ define(['marionette', 'backbone',
             })
 
             this.ui.fc.html(this.getOption('regdewars').opts({ empty: true }))
+            this.showHideButtons()
+        },
+
+        showHideButtons: function() {
+            if (this.model.get('DEWARSTATUS') === 'processing') {
+                this.ui.deact.show()
+                this.ui.dispatch.hide()
+                this.ui.transfer.hide()
+            } else {
+                this.ui.deact.hide()
+                this.ui.dispatch.show()
+                this.ui.transfer.show()
+            }
+            if (this.model.get('STORAGELOCATION') === 'stores-out') {
+                this.ui.dispatch.hide()
+                this.ui.transfer.hide()
+            }
+            if (app.options.get('shipping_service_app_url') && this.model.get('EXTERNALSHIPPINGIDFROMSYNCHROTRON')) {
+                let link = app.options.get('shipping_service_app_url')+'/shipment-requests/'+this.model.get('EXTERNALSHIPPINGIDFROMSYNCHROTRON')+'/outgoing'
+                this.ui.ssd.attr('href', link)
+            } else {
+                this.ui.ssd.hide()
+            }
         },
 
         modelEvents: {
             sync: 'render'
         }
     }))
-    
+
 
     var EmptyView = Marionette.ItemView.extend({
         tagName: 'tr',
         template: _.template('<td colspan="10">No dewars for this shipment</td>')
     })
-        
+
     return GridView = Backbone.Marionette.CompositeView.extend({
-        tagName: "table",
+        tagName: 'table',
         emptyView: EmptyView,
         className: 'dewars reflow',
         template: template,
@@ -154,12 +182,6 @@ define(['marionette', 'backbone',
             this.regdewars.state.pageSize = 9999
             this.regdewars.fetch()
         },
-        
-        // This magically works, which is worrying...
-        /*appendHtml: function(collectionView, itemView){
-            collectionView.$("tbody").append(itemView.el);
-        },*/
-        
     })
     
 })

--- a/client/src/js/templates/shipment/dewarlistrow.html
+++ b/client/src/js/templates/shipment/dewarlistrow.html
@@ -10,18 +10,12 @@
     <td><%-STORAGELOCATION%></td>
     <td><%-CCOUNT%></td>
     <td>
-        <span class="deactivate"><a class="button deact" title="Deactivate Dewar"><i class="fa fa-power-off"></i> <span class="tw-hidden xl:tw-inline">Deactivate</span></a></span>
+        <a class="button deact" title="Deactivate Dewar"><i class="fa fa-power-off"></i> <span class="tw-hidden xl:tw-inline">Deactivate</span></a>
         <a class="button print" title="Click to print dewar contents" href="<%-APIURL%>/pdf/container/did/<%-DEWARID%>/prop/<%-PROP%>"><i class="fa fa-print"></i> <span class="tw-hidden xl:tw-inline">Print Report</span></a>
         <% const container = (app.type == "xpdf") ? "Puck" : "Container" %>
         <a class="button add add-container-small" data-testid="shipment-add-container" title="Click to Add a <%-container%>" href="/containers/add/did/<%-DEWARID%>"><i class="fa fa-plus"></i> <span class="add-container-text tw-hidden xl:tw-inline">Add <%-container%></span></a>
-        <% if (STORAGELOCATION != 'stores-out') { %>
-            <% if (app.options.get("shipping_service_app_url") && EXTERNALSHIPPINGIDFROMSYNCHROTRON) { %>
-                <% const link = `${app.options.get("shipping_service_app_url")}/shipment-requests/${EXTERNALSHIPPINGIDFROMSYNCHROTRON}/outgoing` %>
-                <a class="button" title="Click to view dispatch information" href="<%-link%>"><i class="fa fa-home"></i> <span class="tw-hidden xl:tw-inline">Dispatch</span></a>
-            <% } else { %>
-                <a class="button" title="Click to dispatch dewar back to your lab" href="/dewars/dispatch/<%-DEWARID%>"><i class="fa fa-home"></i> <span class="tw-hidden xl:tw-inline">Dispatch</span></a>
-            <% } %>
-            <a class="button" title="Click to transfer dewar to another beamline" href="/dewars/transfer/<%-DEWARID%>"><i class="fa fa-arrows-h"></i> <span class="tw-hidden xl:tw-inline">Transfer</span></a>
-        <% } %>
+        <a class="button ssdispatch" title="Click to view dispatch information" href=""><i class="fa fa-home"></i> <span class="tw-hidden xl:tw-inline">View Dispatch Request</span></a>
+        <a class="button dispatch" title="Click to dispatch dewar back to your lab" href="/dewars/dispatch/<%-DEWARID%>"><i class="fa fa-home"></i> <span class="tw-hidden xl:tw-inline">Dispatch</span></a>
+        <a class="button transfer" title="Click to transfer dewar to another beamline" href="/dewars/transfer/<%-DEWARID%>"><i class="fa fa-arrows-h"></i> <span class="tw-hidden xl:tw-inline">Transfer</span></a>
     </td>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1549](https://jira.diamond.ac.uk/browse/LIMS-1549)

**Summary**:

If a user requests a dewar dispatch while a dewar is 'processing' (in use on a beamline), the status of 'dispatch-requested' is lost when the pucks are unloaded.

(I can't work out why exactly, each unloaded container triggers [this SP](https://github.com/DiamondLightSource/ispyb-database/blob/7543303b814f62975fa3556132935e2de4811de9/schemas/ispyb/stored_programs/sp_update_container_assign.sql), which seems to not change dewarStatus if the container was already 'processing')

**Changes**:
- Hide the 'Dispatch' and 'Transfer' buttons if the dewar status is processing. Users can 'deactivate' the dewar to get these buttons back.
- Move the show/hide of buttons depending on location from HTML to JS
- Move the show/hide of the link to the shipping service from HTML to JS
- Move the show/hide of the 'Deactivate' button from CSS to JS

**To test**:
- Go to the cm37235 proposal, and find a shipment with pucks that are assigned on the beamline (eg /shipments/sid/62271 at time of writing). The dewar should be highlighted green on the shipment page.
- Check the buttons displayed next to the dewar are 'Deactivate', 'Print Report' and 'Add Container' (ie not Dispatch or Transfer)
- Click 'Deactivate', check the 'Deactivate' button disappears and the 'Dispatch' and 'Transfer' buttons appear. Check they remain so after a refresh.
- Go to a shipment that has been returned via the shipping service, and therefore has a location of 'stores-out', eg /shipments/sid/67624. Check the 'Dispatch' and 'Transfer' buttons are hidden, but a 'View Dispatch Request' button is displayed that links to the shipping service dispatch request

