### PR TITLE
LIMS-1590: Dont allow name editing for lab contacts when login is set

### DIFF
--- a/api/src/Page/Contact.php
+++ b/api/src/Page/Contact.php
@@ -39,10 +39,10 @@ class Contact extends Page
         # Get List of Lab Contacts
         function _get_contacts() {
             if (!$this->has_arg('prop')) $this->_error('No proposal specified');
-            
+
             $args = array($this->proposalid);
             $where = 'WHERE c.proposalid = :1';
-            
+
             if ($this->has_arg('cid')) {
                 $where .= ' AND c.labcontactid=:'.(sizeof($args)+1);
                 array_push($args, $this->arg('cid'));
@@ -63,37 +63,36 @@ class Contact extends Page
             $pp = $this->has_arg('per_page') ? $this->arg('per_page') : 15;
             $start = 0;
             $end = $pp;
-            
+
             if ($this->has_arg('page')) {
                 $pg = $this->arg('page') - 1;
                 $start = $pg*$pp;
                 $end = $pg*$pp+$pp;
             }
-            
+
             $st = sizeof($args)+1;
             $en = $st + 1;
             array_push($args, $start);
             array_push($args, $end);
-            
+
             $order = 'c.labcontactid DESC';
-        
-            $rows = $this->db->paginate("SELECT c.labcontactid, c.cardname, pe.givenname, pe.familyname, pe.phonenumber, l.name as labname, l.address, l.city, l.country, c.courieraccount,  c.billingreference, c.defaultcourriercompany, c.dewaravgcustomsvalue, c.dewaravgtransportvalue, pe.emailaddress, l.postcode, l.country
+
+            $rows = $this->db->paginate("SELECT c.labcontactid, c.cardname, pe.givenname, pe.familyname, pe.phonenumber, IF(pe.login IS NOT NULL, pe.login, IF(pe.externalid IS NOT NULL, 'External', NULL)) AS login, l.name as labname, l.address, l.city, l.country, c.courieraccount, c.billingreference, c.defaultcourriercompany, c.dewaravgcustomsvalue, c.dewaravgtransportvalue, pe.emailaddress, l.postcode, l.country
                                  FROM labcontact c 
                                  INNER JOIN person pe ON c.personid = pe.personid 
                                  INNER JOIN laboratory l ON l.laboratoryid = pe.laboratoryid 
                                  INNER JOIN proposal p ON p.proposalid = c.proposalid 
                                  $where ORDER BY $order", $args);
-            
+
             if ($this->has_arg('cid')) {
                 if (sizeof($rows))$this->_output($rows[0]);
                 else $this->_error('No such contact');
-                
-            } else $this->_output(array('total' => $tot,
-                                 'data' => $rows,
-                           ));
+            } else {
+                $this->_output(array('total' => $tot, 'data' => $rows));
+            }
         }
-        
-        
+
+
         # ------------------------------------------------------------------------
         # Update field for lab contact
         function _update_contact() {

--- a/client/src/js/modules/contact/views/viewcontact.js
+++ b/client/src/js/modules/contact/views/viewcontact.js
@@ -27,8 +27,10 @@ define(['marionette',
         doOnRender: function() {
             var edit = new Editable({ model: this.model, el: this.$el })
             edit.create('CARDNAME', 'text');
-            edit.create('FAMILYNAME', 'text');
-            edit.create('GIVENNAME', 'text');
+            if (!this.model.get('LOGIN')) {
+                edit.create('FAMILYNAME', 'text');
+                edit.create('GIVENNAME', 'text');
+            }
             edit.create('PHONENUMBER', 'text');
             edit.create('EMAILADDRESS', 'text');
             edit.create('LABNAME', 'text');

--- a/client/src/js/templates/contact/contactview.html
+++ b/client/src/js/templates/contact/contactview.html
@@ -4,48 +4,52 @@
 
 <div class="form">
     <ul>
-        
+
         <li>
             <span class="label">Card Name</span>
             <span class="CARDNAME"><%-CARDNAME%></span>
         </li>
-        
+
 
         <li class="head">Contact Details</li>
+
+        <li>
+            <span class="label">Login</span>
+            <span class="LOGIN"><%-LOGIN%></span>
+        </li>
 
         <li>
             <span class="label">Family Name</span>
             <span class="FAMILYNAME"><%-FAMILYNAME%></span>
         </li>
-        
-        
+
         <li>
             <span class="label">First Name</span>
             <span class="GIVENNAME"><%-GIVENNAME%></span>
         </li>
-        
+
         <li>
             <span class="label">Phone Number</span>
             <span class="PHONENUMBER"><%-PHONENUMBER%></span>
         </li>
-        
+
         <li>
             <span class="label">Email Address</span>
             <span class="EMAILADDRESS"><%-EMAILADDRESS%></span>
         </li>
-        
+
         <li class="head">University / Institution / Company Details</li>
-        
+
         <li>
             <span class="label">Name</span>
             <span class="LABNAME"><%-LABNAME%></span>
         </li>
-        
+
         <li class="clearfix">
             <span class="label">Street Address <br />(Max 3 lines, excluding post code, city)</span>
             <div class="ADDRESS text editable tw-block"><%-ADDRESS%></div>
         </li>
-        
+
         <li>
             <span class="label">City</span>
             <span class="CITY"><%-CITY%></span>
@@ -62,31 +66,31 @@
         </li>
 
         <li class="head">Dewar Return Details</li>
-        
+
         <li>
             <span class="label">Courier Company</span>
             <span class="DEFAULTCOURRIERCOMPANY"><%-DEFAULTCOURRIERCOMPANY%></span>
         </li>
-        
+
         <li>
             <span class="label">Courier Account No.</span>
             <span class="COURIERACCOUNT"><%-COURIERACCOUNT%></span>
         </li>
-        
+
         <li>
             <span class="label">Billing Reference</span>
             <span class="BILLINGREFERENCE"><%-BILLINGREFERENCE%></span>
         </li>
-        
+
         <li>
             <span class="label">Dewar Customs Value</span>
             <span class="DEWARAVGCUSTOMSVALUE"><%-DEWARAVGCUSTOMSVALUE%></span>
         </li>
-        
+
         <li>
             <span class="label">Dewar Transport Value</span>
             <span class="DEWARAVGTRANSPORTVALUE"><%-DEWARAVGTRANSPORTVALUE%></span>
         </li>
-        
+
     </ul>
 </div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1590](https://jira.diamond.ac.uk/browse/LIMS-1590)

**Summary**:

The synchronisation scripts from UAS to ISPyB will overwrite any changes to Lab Contact names where the `login` or `externalId` fields are set, so we should disable changing them.

**Changes**:
- Get and display the current value for `login`, or use "External" if the `externalId` is set.
- Don't set the name fields to be editables if the `login` or `externalId` is not null
- Fix some whitespace and indentation

**To test**:
- Go to proposal mx23694, then go to /contacts/cid/11278, check the login is displayed, and the given name and family name fields are not editable
- Go to /contacts/cid/5988, check the login field is blank, and the given name and family name fields are editable
- Run this command `update Person set externalId=1 where personId=267393;`, then go to /contacts/cid/10731, check the login field says "External" and the name fields are not editable