### PR TITLE
LIMS-1406: Don't allow the location to be changed during a dispatch request

### DIFF
--- a/client/src/js/templates/shipment/dispatch.html
+++ b/client/src/js/templates/shipment/dispatch.html
@@ -104,7 +104,7 @@
                 <label>Dewar Location
                     <span class="small">Where the dewar currently is</span>
                 </label>
-                <input type="text" name="LOCATION" data-testid="dispatch-location"/>
+                <input type="text" name="LOCATION" data-testid="dispatch-location" disabled="disabled"/>
             </li>
 
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1406](https://jira.diamond.ac.uk/browse/LIMS-1406)

**Summary**:

When a user requests a dewar dispatch, the current dewar location is shown, but editable. It should not be editable.

**Changes**:
- Disable the location input field

**To test**:
- Go to proposal mx23694, go to a shipment that is on site eg /shipments/sid/58389
- Click "Dispatch" and load the dispatch form
- Check the dewar location is displayed and not editable
- If only the short version of the form is shown, change the country to Aruba to see the full version
