### PR TITLE
LIMS-1287: Improve workflow for responsive scheduling

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -89,7 +89,7 @@ class Shipment extends Page
         //'FIRSTEXPERIMENTID' => '\w+\d+-\d+',
 
         // Fields for responsive remote questions:
-        'DYNAMIC' => '1?|Yes|No',
+        'DYNAMIC' => '\w+',
         'REMOTEORMAILIN' => '.*',
         'SESSIONLENGTH' => '\w+',
         'ENERGY' => '.*',
@@ -101,6 +101,7 @@ class Shipment extends Page
         'MULTIAXISGONIOMETRY' => '1?|Yes|No',
         'ENCLOSEDHARDDRIVE' => '1?|Yes|No',
         'ENCLOSEDTOOLS' => '1?|Yes|No',
+        'LONGWAVELENGTH' => '1?|Yes|No',
 
         'COMMENTS' => '.*',
 
@@ -164,7 +165,8 @@ class Shipment extends Page
         'EXTRASUPPORTREQUIREMENT',
         'MULTIAXISGONIOMETRY',
         'ENCLOSEDHARDDRIVE',
-        'ENCLOSEDTOOLS'
+        'ENCLOSEDTOOLS',
+        'LONGWAVELENGTH',
     );
 
     public static $dispatch = array(
@@ -2856,7 +2858,7 @@ class Shipment extends Page
 
         $dynamic = null;
         if ($this->has_arg('DYNAMIC')) {
-            $dynamic = $this->arg("DYNAMIC") ? "Yes" : "No";
+            $dynamic = $this->arg("DYNAMIC");
         }
 
         $extra_array = array(
@@ -2866,6 +2868,7 @@ class Shipment extends Page
         );
 
         if ($dynamic) {
+            $long_wavelength = $this->has_arg('LONGWAVELENGTH') ? $this->arg('LONGWAVELENGTH') : '';
             $remote_or_mailin = $this->has_arg('REMOTEORMAILIN') ? $this->arg('REMOTEORMAILIN') : '';
             $session_length = $this->has_arg('SESSIONLENGTH') ? $this->arg('SESSIONLENGTH') : '';
             $energy_requirements = $this->has_arg('ENERGY') ? $this->arg('ENERGY') : '';
@@ -2888,6 +2891,7 @@ class Shipment extends Page
                 $multi_axis_goniometry = $this->arg('MULTIAXISGONIOMETRY') ? "Yes" : "No";
             }
             $dynamic_options = array(
+                "LONGWAVELENGTH" => $long_wavelength,
                 "REMOTEORMAILIN" => $remote_or_mailin,
                 "SESSIONLENGTH" => $session_length,
                 "ENERGY" => $energy_requirements,

--- a/client/src/js/models/shipment.js
+++ b/client/src/js/models/shipment.js
@@ -18,12 +18,20 @@ define(['backbone'], function (Backbone) {
         pattern: 'fcode',
       },
 
+      DYNAMIC: {
+        required: true,
+      },
+
       FIRSTEXPERIMENTID: {
         required: false,
         pattern: 'number',
       },
 
       REMOTEORMAILIN: {
+        required: false,
+      },
+
+      COMMENTS: {
         required: false,
       },
 

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -58,6 +58,7 @@ define(['marionette',
 
         ui: {
             add_dewar: '#add_dewar',
+            longwavelength: '.longwavelength',
         },
         
 
@@ -178,13 +179,19 @@ define(['marionette',
             if (!dynamicSelectedValues.includes(dynamic)) {
                 this.$el.find(".remoteormailin").hide()
                 this.$el.find(".remoteform").hide()
+                this.ui.longwavelength.hide()
             } else {
                 industrial_codes = ['in', 'sw']
                 industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
                 if (industrial_visit) {
                     this.$el.find(".remoteormailin").show()
                 }
-                this.$el.find(".remoteform").show()
+                this.ui.longwavelength.show()
+                if (this.model.get('LONGWAVELENGTH') === 'Yes') {
+                    this.$el.find(".remoteform").hide()
+                } else {
+                    this.$el.find(".remoteform").show()
+                }
             }
         },
         
@@ -214,7 +221,13 @@ define(['marionette',
 
             edit.create("ENCLOSEDHARDDRIVE", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("ENCLOSEDTOOLS", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
-            edit.create("DYNAMIC", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
+            edit.create("DYNAMIC", 'select', { data: {
+                'No': 'I have a session already scheduled',
+                'UDC': 'I am sending pucks for Unattended Data Collection',
+                'Imaging': 'I am sending plates for imaging',
+                'Yes': 'I would like a session to be scheduled',
+                'Other': 'Something else',
+            }})
             industrial_codes = ['in', 'sw']
             industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
             if (!industrial_visit) {
@@ -223,6 +236,7 @@ define(['marionette',
                 edit.create("REMOTEORMAILIN", 'select', { data: {'Remote': 'Remote', 'Mail-in': 'Mail-in', 'Other': 'Other'}})
             }
 
+            edit.create("LONGWAVELENGTH", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             edit.create("SESSIONLENGTH", 'text')
             edit.create("ENERGY", 'text')
             edit.create("MICROFOCUSBEAM", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
@@ -233,7 +247,7 @@ define(['marionette',
             edit.create("MULTIAXISGONIOMETRY", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
 
             this.updateDynamic()
-            this.listenTo(this.model, "change:DYNAMIC", this.updateDynamic)
+            this.listenTo(this.model, "change", this.updateDynamic)
             
             var self = this
             this.contacts = new LabContacts(null, { state: { pageSize: 9999 } })

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -110,6 +110,7 @@ define(['marionette', 'views/form',
                 this.ui.udc.prop('disabled', false)
                 this.ui.responsive.prop('disabled', false)
                 this.ui.imaging.prop('disabled', false)
+                this.ui.other.prop('disabled', false)
             } else {
                 this.ui.udc.prop('disabled', true)
                 this.ui.udc.prop('checked', false)
@@ -117,6 +118,8 @@ define(['marionette', 'views/form',
                 this.ui.responsive.prop('checked', false)
                 this.ui.imaging.prop('disabled', true)
                 this.ui.imaging.prop('checked', false)
+                this.ui.other.prop('disabled', true)
+                this.ui.other.prop('checked', false)
                 this.updateDynamicSchedule()
             }
         },

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -56,26 +56,31 @@ define(['marionette', 'views/form',
         },
 
         events: {
-            'change input[name=DEWARS]': 'updateFCodes',
+            'change @ui.dewars': 'updateFCodes',
             'change @ui.lcret': 'getlcdetails',
             'change select[name^=FCODES]': 'checkFCodes',
             'change @ui.name': 'checkFCodes',
             'click a.add_lc': 'addLC',
-            'click @ui.noexp': 'updateFirstExp',
-            'click @ui.dynamic': 'updateDynamicSchedule',
-            'change select[name^=SAFETYLEVEL]': 'changeSafetyLevel',
+            'change @ui.safetylevel': 'changeSafetyLevel',
+            'change @ui.dynamic': 'updateFirstExp',
+            'change @ui.longwavelengthsel': 'updateLongWavelength',
         },
         
         ui: {
+            dewars: 'input[name=DEWARS]',
             lcret: 'select[name=RETURNLABCONTACTID]',
             lcout: 'select[name=SENDINGLABCONTACTID]',
             first: 'select[name=FIRSTEXPERIMENTID]',
             name: 'input[name=SHIPPINGNAME]',
-            noexp: 'input[name=noexp]',
-            dynamic: 'input[name=DYNAMIC]', // A checkbox to indicate dynamic/remote mail-in scheduling
-            comments: 'textarea[name=COMMENTS]', // We need this so we can prefill comments to aid users
-            safetylevel: 'select[name^=SAFETYLEVEL]',
-            udcresponsive: '.udcresponsive',
+            dynamic: 'input[name=DYNAMIC]',
+            udc: '#udc',
+            responsive: '#responsive',
+            imaging: '#imaging',
+            existing: '#existingsession',
+            other: '#other',
+            safetylevel: 'select[name=SAFETYLEVEL]',
+            longwavelengthsel: 'select[name=LONGWAVELENGTH]',
+            longwavelengthli: '.longwavelength',
         },
         
         addLC: function(e) {
@@ -102,45 +107,75 @@ define(['marionette', 'views/form',
         
         changeSafetyLevel: function() {
             if (this.ui.safetylevel.val() === 'Green') {
-                this.ui.udcresponsive.show()
+                this.ui.udc.prop('disabled', false)
+                this.ui.responsive.prop('disabled', false)
+                this.ui.imaging.prop('disabled', false)
             } else {
-                this.ui.noexp.prop('checked', false)
-                this.updateFirstExp()
-                this.ui.dynamic.prop('checked', false)
+                this.ui.udc.prop('disabled', true)
+                this.ui.udc.prop('checked', false)
+                this.ui.responsive.prop('disabled', true)
+                this.ui.responsive.prop('checked', false)
+                this.ui.imaging.prop('disabled', true)
+                this.ui.imaging.prop('checked', false)
                 this.updateDynamicSchedule()
-                this.ui.udcresponsive.hide()
             }
         },
 
         updateFirstExp: function() {
-            if (this.ui.noexp.is(':checked')) {
-                this.ui.first.html('<option value=""> - </option>')
-                this.ui.dynamic.prop('checked', false)
-            } else {
-                this.ui.first.html('<option value="!">Please select one</option>'+this.visits.opts())
+            if (this.visits.length === 0) {
+                this.ui.existing.prop('disabled', true)
             }
+            if (this.ui.existing.is(':checked')) {
+                this.ui.first.show()
+                this.ui.first.html('<option value="!">Please select one</option>'+this.visits.opts())
+            } else {
+                this.ui.first.html('<option value=""> - </option>').change()
+                this.ui.first.hide()
+            }
+            if (this.ui.other.is(':checked')) {
+                this.model.validation.COMMENTS.required = true
+            } else {
+                this.model.validation.COMMENTS.required = false
+            }
+            this.updateDynamicSchedule()
         },
 
         updateDynamicSchedule: function() {
-            // Added as a fix to allow dynamic sessions
-            // An extra option for proposals with no sessions yet that are not automated
-            industrial_codes = ['in', 'sw']
-            industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
-            if (this.ui.dynamic.is(':checked')) {
-                this.ui.first.html('<option value=""> - </option>')
-                this.ui.noexp.prop('checked', false)
-                this.$el.find(".remoteform").show()
-                if (industrial_visit) {
-                    this.model.validation.REMOTEORMAILIN.required = true
-                    this.$el.find(".remoteormailin").show()
-                }
+            if (this.ui.responsive.is(':checked')) {
+                this.ui.longwavelengthli.show()
+                this.updateLongWavelength()
             } else {
-                this.model.validation.REMOTEORMAILIN.required = false
-                this.ui.first.html('<option value="!">Please select one</option>'+this.visits.opts())
-                this.$el.find(".remoteform").hide()
-                if (industrial_visit) {
-                    this.$el.find(".remoteormailin").hide()
-                }
+                this.ui.longwavelengthli.hide()
+                this.hideRemoteForm()
+            }
+        },
+
+        updateLongWavelength: function() {
+            if (this.ui.longwavelengthsel.val() === 'No') {
+                this.showRemoteForm()
+            } else {
+                this.hideRemoteForm()
+            }
+        },
+
+        isIndustrialProposal: function() {
+            industrial_codes = ['in', 'sw']
+            return industrial_codes.includes(app.prop.slice(0,2))
+        },
+
+        showRemoteForm: function() {
+            this.$el.find(".remoteform").show()
+            if (this.isIndustrialProposal()) {
+                this.model.validation.REMOTEORMAILIN.required = true
+                this.$el.find(".remoteormailin").show()
+            }
+        },
+
+        hideRemoteForm: function() {
+            this.model.validation.REMOTEORMAILIN.required = false
+            this.$el.find(".remoteform").hide()
+            if (this.isIndustrialProposal()) {
+                this.$el.find(".remoteormailin").hide()
             }
         },
 
@@ -206,7 +241,7 @@ define(['marionette', 'views/form',
          Update number of facility code inputs based on number of dewars
         */
         updateFCodes: function() {
-            var d = this.$el.find('input[name=DEWARS]').val()
+            var d = this.ui.dewars.val()
             d > 0 ? this.$el.find('li.d').show() : this.$el.find('li.d').hide()
             var fcs = _.map(_.range(1,parseInt(d)+1), function(i) { return { id: i } })
             this.fcodes.set(fcs)

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -127,7 +127,26 @@
                 <span class="DELIVERYAGENT_DELIVERYDATE"><%-DELIVERYAGENT_DELIVERYDATE%></span>
             </li>
             <%
-                DYNAMIC=(typeof DYNAMIC !== 'undefined')? DYNAMIC : 'No';
+                switch(DYNAMIC) {
+                    case 'No':
+                        DYNAMIC = 'I have a session already scheduled';
+                        break;
+                    case 'UDC':
+                        DYNAMIC = 'I am sending pucks for Unattended Data Collection';
+                        break;
+                    case 'Imaging':
+                        DYNAMIC = 'I am sending plates for imaging';
+                        break;
+                    case 'Yes':
+                        DYNAMIC = 'I would like a session to be scheduled';
+                        break;
+                    case 'Other':
+                        DYNAMIC = 'Something else';
+                        break;
+                    default:
+                        DYNAMIC = '';
+                        break;
+                };
                 REMOTEORMAILIN=(typeof REMOTEORMAILIN !== 'undefined')? REMOTEORMAILIN : null;
                 SESSIONLENGTH=(typeof SESSIONLENGTH !== 'undefined')? SESSIONLENGTH : null;
                 ENERGY=(typeof ENERGY !== 'undefined')? ENERGY : null;
@@ -139,6 +158,7 @@
                 ENCLOSEDTOOLS=(typeof ENCLOSEDTOOLS !== 'undefined')? ENCLOSEDTOOLS : null; 
                 EXTRASUPPORTREQUIREMENT=(typeof EXTRASUPPORTREQUIREMENT !== 'undefined')? EXTRASUPPORTREQUIREMENT : null;
                 MULTIAXISGONIOMETRY=(typeof MULTIAXISGONIOMETRY !== 'undefined')? MULTIAXISGONIOMETRY : null;
+                LONGWAVELENGTH=(typeof LONGWAVELENGTH !== 'undefined')? LONGWAVELENGTH : null;
             %>
             <li>
                 <span class="label">Hard drive enclosed</span>
@@ -151,11 +171,14 @@
             </li>
 
             <li>
-                <span class="label">Responsive</span>
+                <span class="label">Scheduling</span>
                 <span class="DYNAMIC"><%-DYNAMIC %></span>
             </li>
 
-                
+                <li class="longwavelength">
+                    <span class="label">Long wavelength</span>
+                    <span class="LONGWAVELENGTH"><%-LONGWAVELENGTH %></span>
+                </li>
 
                 <li class="remoteormailin">
                     <span class="label">Remote or mail in</span>

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -36,7 +36,7 @@
 
             <li>
                 <label>Safety Level
-                    <span class="small">The safety level of the shipment</span>
+                    <span class="small">Please add all containers and samples to the shipment before sending</span>
                 </label>
                 <select class="tw-h-6" name="SAFETYLEVEL" data-testid="add-shipment-safety-level" required>
                     <option value="Green">Green</option>
@@ -46,21 +46,36 @@
             </li>
 
             <li>
-                <!-- Small tweaks to the styling here using tailwind flexbox -->
-                <label>First Experiment / Scheduling
-                    <span class="small">Select first experiment or if it's for an automated or responsive session</span>
+                <label>Scheduling
+                    <span class="small">Select which best describes your shipment</span>
                 </label>
-                <div class="tw-flex">
-                    <select class="tw-h-6 tw-mr-2" name="FIRSTEXPERIMENTID" data-testid="add-shipment-experiment"></select>
-                    <span class="udcresponsive">
-                      <label class="secondary tw-mr-2">
-                          <input type="checkbox" name="noexp" data-testid="add-shipment-automated"> UDC / Automated / Imager
-                      </label>
-                      <label class="secondary tw-mr-2">
-                          <input type="checkbox" name="DYNAMIC" data-testid="add-shipment-dynamic"> Responsive / Mail-in
-                      </label>
-                    </span>
+                <div>
+                    <label class="secondary tw-mr-2">
+                        <input type="radio" name="DYNAMIC" value="No" id="existingsession" data-testid="add-shipment-existing-session">
+                        I have a session already scheduled
+                    </label>
+                    <select class="tw-h-6 tw-mr-2" name="FIRSTEXPERIMENTID" data-testid="add-shipment-experiment"></select><br />
+                    <label class="secondary tw-mr-2">
+                        <input type="radio" name="DYNAMIC" value="UDC" id="udc" data-testid="add-shipment-automated"> I am sending pucks for Unattended Data Collection
+                    </label><br />
+                    <label class="secondary tw-mr-2">
+                        <input type="radio" name="DYNAMIC" value="Imaging" id="imaging" data-testid="add-shipment-imaging"> I am sending plates for in situ imaging
+                    </label><br />
+                    <label class="secondary tw-mr-2">
+                        <input type="radio" name="DYNAMIC" value="Yes" id="responsive" data-testid="add-shipment-responsive"> I would like a session to be scheduled
+                    </label><br />
+                    <label class="secondary tw-mr-2">
+                        <input type="radio" name="DYNAMIC" value="Other" id="other" data-testid="add-shipment-other"> Something else (please describe in comments)
+                    </label>
                 </div>
+            </li>
+
+            <li class="longwavelength">
+                <label>Do you require a long wavelength beamline (>2.5&#8491;)</label>
+                <select name="LONGWAVELENGTH" data-testid="add-shipment-longwavelength">
+                    <option value="No">No</option>
+                    <option value="Yes">Yes</option>
+                </select>
             </li>
 
             <li class="remoteormailin">
@@ -84,7 +99,7 @@
 
             <li class="remoteform">
                 <label>Energy/Wavelength
-                    <span class="small">Specify any energy/Wavelength requirements [eV/&#8491]</span>
+                    <span class="small">Specify any energy/wavelength requirements [eV/&#8491;]</span>
                 </label>
                 <input type="text" name="ENERGY" data-testid="add-shipment-energy"/>
             </li>
@@ -93,7 +108,10 @@
                 <label>Microfocus beam
                     <span class="small">Microfocus beam is required for this shipment (provide further information in additional comments)</span>
                 </label>
-                <input type="checkbox" name="MICROFOCUSBEAM" data-testid="add-shipment-microfocus">
+                <select name="MICROFOCUSBEAM" data-testid="add-shipment-microfocus">
+                    <option value="0">No</option>
+                    <option value="1">Yes</option>
+                </select>
             </li>
 
             <li class="remoteform">
@@ -107,7 +125,10 @@
                 <label>Short-notice beam time
                     <span class="small">Would you like to be considered for short-notice beamtime, generally with only 1-3 days notice?</span>
                 </label>
-                <input type="checkbox" name="LASTMINUTEBEAMTIME" data-testid="add-shipment-last-minute">
+                <select name="LASTMINUTEBEAMTIME" data-testid="add-shipment-last-minute">
+                    <option value="0">No</option>
+                    <option value="1">Yes</option>
+                </select>
             </li>
 
             <li class="remoteform">
@@ -132,21 +153,30 @@
                 <label>Multi-axis goniometry
                     <span class="small">Do you need multi-axis goniometry?:</span>
                 </label>
-                <input type="checkbox" name="MULTIAXISGONIOMETRY" data-testid="add-shipment-multiaxis">
+                <select name="MULTIAXISGONIOMETRY" data-testid="add-shipment-multiaxis">
+                    <option value="0">No</option>
+                    <option value="1">Yes</option>
+                </select>
             </li>
 
             <li>
                 <label>Hard drive enclosed
                     <span class="small">A hard drive is included with this shipment</span>
                 </label>
-                <input type="checkbox" name="ENCLOSEDHARDDRIVE" data-testid="add-shipment-hdd">
+                <select name="ENCLOSEDHARDDRIVE" data-testid="add-shipment-hdd">
+                    <option value="0">No</option>
+                    <option value="1">Yes</option>
+                </select>
             </li>
 
             <li>
                 <label>Tools enclosed
                     <span class="small">Tools are included within this shipment</span>
                 </label>
-                <input type="checkbox" name="ENCLOSEDTOOLS" data-testid="add-shipment-tools">
+                <select name="ENCLOSEDTOOLS" data-testid="add-shipment-tools">
+                    <option value="0">No</option>
+                    <option value="1">Yes</option>
+                </select>
             </li>
 
             <li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1287](https://jira.diamond.ac.uk/browse/LIMS-1287)

**Summary**:

Users often fill out the scheduling question incorrectly when making a shipment, or not at all. This PR is to try and make it clearer for them and us.

**Changes**:
- Change the Scheduling question to a compulsory radio button, storing the value in the db (rather than just Yes/No)
- Only show the session dropdown if they say they have a scheduled session and a session exists
- Split UDC and Imager into separate answers
- If they ask for a session, ask if they require a long wavelength beamline (ie I23), and in that case dont ask further scheduling questions
- Add a 'Something else' answer with the comments field then compulsory
- Display the full scheduling and long wavelength answers on the View Shipment page
- Make the various checkboxes all into Yes/No dropdowns for consistency

**To test**:
- Go to a proposal with future sessions already scheduled, eg cm40607, then go to /shipments/add
- Check if you choose a safety level of yellow or red, the only option is "I have a session already scheduled"
- Choose "I have a session already scheduled", check that a dropdown appears with future sessions in, which is compulsory
- Check Shipment Name and Lab Contact fields are compulsory
- Create the shipment, check the fields have populated correctly, particularly the First Experiment, and also Hard Drive Enclosed and Tools Enclosed
- Make another shipment, this time choose "I am sending pucks for Unattended Data Collection". Create the shipment, check this value is shown on the View Shipment page
- Repeat but with "I am sending plates for in situ imaging"
- Repeat with "Something else", check the Comments field is now compulsory
- Make a shipment with "I would like a session to be scheduled", check some extra questions appear. Check if you say "Yes" to the long wavelength question, the other scheduling questions disappear. Change back to "No", fill in the other questions, check those answers are shown on the View Shipment page.
- Check you can change the Scheduling answer on the View Shipment page, and the other questions appear if you choose "I would like a session to be scheduled" and disappear if you choose anything else
- Go to a proposal with no future sessions scheduled, eg mx23694. Go to /shipments/add, check you cannot select "I have a session already scheduled"
- Go to an in or sw proposal. Go to /shipments/add, choose "I would like a session to be scheduled", check there is now a question about Mail-in/remote.
