### PR TITLE
LIMS-91: Load sample image if specified in URL

### DIFF
--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -529,31 +529,7 @@ define(['marionette',
 
         inspectionLoaded: function() {
             this.selectSample()
-            this.preCache(1)
         },
-
-        preCache: function(n) {
-            clearTimeout(this.cachethread)
-
-            var self = this
-            var i = this.inspectionimages.at(n)
-            if (this.caching && i) {
-                var xhr =  new XHRImage()
-                console.log('caching', i.urlFor('hd'))
-                xhr.load(i.urlFor('full'), function() {
-                    self.plateView.drawPlate()
-
-                    if (n+1 === self.inspectionimages.length) self.ui.status.html('')
-                    else self.ui.status.html('Loaded '+(n+1)+' out of '+self.inspectionimages.length+' images')
-
-                    self.cachethread = setTimeout(function() {
-                        self.preCache(++n)
-                    }, 200)
-                })
-            }
-
-        },
-
 
         playInspection: function(e) {
             e.preventDefault()
@@ -597,9 +573,7 @@ define(['marionette',
 
         initialize: function(options) {
             this.isPlaying = false
-            this.cachethread = null
             this.playthread = null
-            this.caching = !app.mobile()
 
             this.samples = new Samples(null, { state: {pageSize: 9999} })
             this.samples.queryParams.cid = options.model.get('CONTAINERID')
@@ -925,17 +899,13 @@ define(['marionette',
             }
 
             if (this.getOption('params').sid) {
-                const s = this.samples.findWhere({ BLSAMPLEID: this.getOption('params').sid })
+                const s = this.samples.findWhere({ BLSAMPLEID: this.getOption('params').sid.toString() })
                 if (s) s.set({ isSelected: true })
             } else this.samples.at(0).set({isSelected: true})
             this.sample.show(this.singlesample)
 
         },
 
-        onDestroy: function() {
-            clearTimeout(this.cachethread)
-            this.caching = false
-        },
     })
 
 })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-91](https://jira.diamond.ac.uk/browse/LIMS-91)
**JIRA ticket**: [LIMS-523](https://jira.diamond.ac.uk/browse/LIMS-523)

**Summary**:

If you go to a URL like /containers/cid/317254/iid/152920/sid/6049306, although the correct container (317254) and inspection (152920) are loaded, the sample (6049306) is not.
Also, caching the sample images is unnecessary with modern internet speeds.

**Changes**:
- Remove the `preCache` function and related variables
- Convert the sample id to a string before comparing to samples in the model

**To test**:
- Go to a proposal with plates (eg nt37104), then go to a container (eg /containers/cid/317254)
- Check images are not being cached but are still loaded when you click on a well on the plate
- Add an inspection id to the end of the URL, eg /iid/152920. Check the Inspections dropdown is showing the correct inspection (in this case, from 11/11/2024).
- Add a sample id to the end of that URL, eg /sid/6049306. Check the correct well from the plate is shown, in this case well 35.