### PR TITLE
LIMS-1466: Disable dispatch form validation when using the shipping service

### DIFF
--- a/client/src/js/modules/shipment/models/dispatch.js
+++ b/client/src/js/modules/shipment/models/dispatch.js
@@ -12,24 +12,18 @@ define(['backbone'], function(Backbone) {
 
         LOCATION: {
             required: false,
-            pattern: 'wwsdash'
         },
 
         VISIT: {
-            required: function() {
-                return this.visitRequired
-            },
-            pattern: 'visit',
+            required: function() {return this.visitRequired},
         },
 
         GIVENNAME: {
             required: function () {return this.dispatchDetailsRequired},
-            pattern: 'wwsdash',
         },
 
         FAMILYNAME: {
             required: function () {return this.dispatchDetailsRequired},
-            pattern: 'wwsdash',
         },
 
         PHONENUMBER: {
@@ -38,12 +32,10 @@ define(['backbone'], function(Backbone) {
 
         EMAILADDRESS: {
             required: function () {return this.dispatchDetailsRequired},
-            pattern: 'email',
         },
 
         LABNAME: {
             required: function () {return this.dispatchDetailsRequired},
-            pattern: 'wwsdash',
         },
 
         ADDRESS: {
@@ -70,32 +62,23 @@ define(['backbone'], function(Backbone) {
             }
         },
 
-
         DESCRIPTION: {
             required: function () {return this.dispatchDetailsRequired},
         },
 
         DELIVERYAGENT_SHIPPINGDATE: {
-            pattern: 'edate',
             required: function () {return this.dispatchDetailsRequired},
         },
 
-        
         DELIVERYAGENT_AGENTNAME: {
-            required: function() {
-                return this.courierDetailsRequired
-            },
-            pattern: 'wwsdash'
+            required: function() {return this.courierDetailsRequired},
         },
 
         DELIVERYAGENT_AGENTCODE: {
-            required: function() {
-                return this.courierDetailsRequired
-            }   
+            required: function() {return this.courierDetailsRequired},
         },
 
         AWBNUMBER: {
-            pattern: 'word',
             required: false,
         }
 

--- a/client/src/js/modules/shipment/views/dispatch.js
+++ b/client/src/js/modules/shipment/views/dispatch.js
@@ -5,12 +5,12 @@ define(['marionette', 'views/form',
     'modules/shipment/collections/dewarhistory',
 
     'modules/shipment/models/dispatch',
-    
+
     'templates/shipment/dispatch.html',
     'jquery',
     'backbone',
     'backbone-validation',
-    
+
     ], function(Marionette, FormView,
         Visits, LabContacts, Countries, DewarHistory,
         DispatchModel,
@@ -19,11 +19,11 @@ define(['marionette', 'views/form',
     /*
      T&C Dialog
     */
-     var Terms = Backbone.Model.extend({
+    var Terms = Backbone.Model.extend({
         idAttribute: 'SHIPPINGID',
         urlRoot: '/shipment/terms',
     })
-            
+
     var TCDialog = DialogView.extend({
         template: _.template('<%=TERMS%>'),
         title: 'Terms & Conditions',
@@ -31,7 +31,7 @@ define(['marionette', 'views/form',
             'Accept': 'accept',
             'Cancel': 'closeDialog',
         },
-        
+
         accept: function() {
             var self = this
             this.model.set({ ACCEPTED: 1 })
@@ -44,7 +44,7 @@ define(['marionette', 'views/form',
         },
     })
 
-   
+
     var VVisits = Visits.extend({
         valueAttribute: 'VISIT',
     })
@@ -52,9 +52,9 @@ define(['marionette', 'views/form',
 
     return FormView.extend({
         template: template,
-        
+
         events: {
-            'change @ui.lc': 'getlcdetails',    
+            'change @ui.lc': 'getlcdetails',
             'change @ui.exp': 'updateLC',
             'click @ui.useAnotherCourierAccount': 'toggleCourierAccountEditing',
             'click @ui.facc': 'showTerms',
@@ -62,7 +62,7 @@ define(['marionette', 'views/form',
             'blur @ui.addr': 'formatAddress',
             'change @ui.country': 'showDispatchForm',
         },
-        
+
         ui: {
             lc: 'select[name=LABCONTACTID]',
 
@@ -105,18 +105,18 @@ define(['marionette', 'views/form',
                 SHIPPING: this.getOption('shipping').toJSON()
             }
         },
-        
+
         createModel: function() {
-            this.model = new DispatchModel({ 
-                FACILITYCODE: this.getOption('dewar').get('FACILITYCODE'), 
-                DEWARID: this.getOption('dewar').get('DEWARID'), 
+            this.model = new DispatchModel({
+                FACILITYCODE: this.getOption('dewar').get('FACILITYCODE'),
+                DEWARID: this.getOption('dewar').get('DEWARID'),
                 LABCONTACTID: this.getOption('dewar').get('LABCONTACTID'),
                 VISIT: this.getOption('dewar').get('FIRSTEXPERIMENT'),
                 // If no agent specified on inbound, default to diamond dhl
                 DELIVERYAGENT_AGENTNAME: this.getOption('shipping').get('DELIVERYAGENT_AGENTNAME') || 'DHL'
             })
         },
-        
+
         success: function() {
             if (
                 app.options.get("shipping_service_app_url")
@@ -145,7 +145,7 @@ define(['marionette', 'views/form',
                 persist: true
             })
         },
-        
+
         onRender: function() {
             this.date('input[name=DELIVERYAGENT_SHIPPINGDATE]')
             this.$el.hide()
@@ -154,7 +154,7 @@ define(['marionette', 'views/form',
             var today = (d.getDate() < 10 ? '0'+d.getDate() : d.getDate()) + '-' + (d.getMonth() < 9 ? '0'+(d.getMonth()+1) : d.getMonth()+1) + '-' + d.getFullYear()
             this.$el.find('input[name=DELIVERYAGENT_SHIPPINGDATE]').val(today)
             this.$el.find('.facilityCourier').hide()
-            
+
             industrial_codes = ['in', 'sw']
             industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
             if (industrial_visit) {
@@ -237,7 +237,7 @@ define(['marionette', 'views/form',
             var vis = this.visits.findWhere({ VISIT: this.ui.exp.val() })
             if (vis) {
                 var lc = vis.get('LC')
-                if (lc) { 
+                if (lc) {
                     var lcs = lc.split(',')
                     this.ui.lco.val(lcs[0].trim())
                 } else this.ui.lco.val('')
@@ -248,12 +248,12 @@ define(['marionette', 'views/form',
         refreshContacts: function() {
             this.contacts.fetch()
         },
-        
+
         updateContacts: function() {
             this.ui.lc.html(this.contacts.opts()).val(this.getOption('dewar').get('RETURNLABCONTACTID'))
             this.getlcdetails()
         },
-        
+
         getlcdetails: function() {
             var lc = this.contacts.findWhere({ LABCONTACTID: this.ui.lc.val() })
             if (lc) {
@@ -276,8 +276,7 @@ define(['marionette', 'views/form',
             this.dispatchCountry = this.ui.country.val()
             this.ui.courierSection.show();
             this.ui.dispatchDetails.show();
-            this.model.visitRequired = true
-            this.model.dispatchDetailsRequired = true
+            this.enableValidation()
             this.ui.submit.show();
             if (
                 this.terms.get("ACCEPTED") ||
@@ -292,9 +291,8 @@ define(['marionette', 'views/form',
                 && app.options.get("shipping_service_app_url")
                 && app.options.get("facility_courier_countries").includes(this.dispatchCountry)
             ){
-                this.model.visitRequired = false
+                this.disableValidation()
                 this.ui.dispatchDetails.hide()
-                this.model.dispatchDetailsRequired = false
                 this.ui.submit.text("Proceed")
                 this.ui.shippingadvice.html("<mark>On clicking 'Proceed' you will be redirected to the new Diamond shipping service to book the shipment. Please ensure all stages of the form are completed.</mark><br /><br />")
             } else {
@@ -303,13 +301,41 @@ define(['marionette', 'views/form',
             }
         },
 
+        enableValidation: function() {
+            this.model.visitRequired = true
+            this.model.dispatchDetailsRequired = true
+            this.model.validation.LOCATION.pattern = 'wwsdash'
+            this.model.validation.GIVENNAME.pattern = 'wwsdash'
+            this.model.validation.FAMILYNAME.pattern = 'wwsdash'
+            this.model.validation.LABNAME.pattern = 'wwsdash'
+            this.model.validation.DELIVERYAGENT_AGENTNAME.pattern = 'wwsdash'
+            this.model.validation.DELIVERYAGENT_SHIPPINGDATE.pattern = 'edate'
+            this.model.validation.EMAILADDRESS.pattern = 'email'
+            this.model.validation.AWBNUMBER.pattern = 'word'
+            this.model.validation.VISIT.pattern = 'visit'
+        },
+
+        disableValidation: function() {
+            this.model.visitRequired = false
+            this.model.dispatchDetailsRequired = false
+            this.model.validation.LOCATION.pattern = ''
+            this.model.validation.GIVENNAME.pattern = ''
+            this.model.validation.FAMILYNAME.pattern = ''
+            this.model.validation.LABNAME.pattern = ''
+            this.model.validation.DELIVERYAGENT_AGENTNAME.pattern = ''
+            this.model.validation.DELIVERYAGENT_SHIPPINGDATE.pattern = ''
+            this.model.validation.EMAILADDRESS.pattern = ''
+            this.model.validation.AWBNUMBER.pattern = ''
+            this.model.validation.VISIT.pattern = ''
+        },
+
         showTerms: function() {
             var terms = new TCDialog({ model: this.terms })
             this.listenTo(terms, 'terms:accepted', this.termsAccepted, this)
             if (!this.terms.get('ACCEPTED')) app.dialog.show(terms)
             return false
         },
-        
+
         toggleCourierAccountEditing: function(event) {
             if (event.target.checked) {
                 this.ui.courier.attr('disabled', false)
@@ -333,9 +359,8 @@ define(['marionette', 'views/form',
                 app.options.get("shipping_service_app_url")
                 && app.options.get("facility_courier_countries").includes(this.ui.country.val())
             ){
-                this.model.visitRequired = false
+                this.disableValidation()
                 this.ui.dispatchDetails.hide()
-                this.model.dispatchDetailsRequired = false
                 this.ui.submit.text("Proceed")
                 this.ui.shippingadvice.html("<mark>On clicking 'Proceed' you will be redirected to the new Diamond shipping service to book the shipment. Please ensure all stages of the form are completed.</mark><br /><br />")
             }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1466](https://jira.diamond.ac.uk/browse/LIMS-1466)

**Summary**:

The dispatch request form has quite strict validation, but little of it is used (or even displayed) if the shipping service will be used. This has led to problems where a hidden field fails validation and the user doesn't know how to fix the problem. We should disable validation if the shipping service is going to be used.

**Changes**:
- Move validation patterns out of model file and into functions within view file
- Tidy some whitespace

**To test**:
- Enable `$use_shipping_service` and `$use_shipping_service_redirect` in config
- Go to a test shipment (eg /shipments/sid/63609) and click "Dispatch"
- Change the country to eg Aruba to show the full form
- Add illegal characters to each field, check that they go red and display an error
- Change the country to United Kingdom, the fields should now be hidden. Check you can Proceed to the shipping service.