### PR TITLE
LIMS-1496: Fix offset grid scan heatmaps in Safari

### DIFF
--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -395,17 +395,22 @@ define(['jquery', 'marionette',
                 let sheight = h+this.offset_h
                 let dx = 0
                 let dy = 0
-                let dw = this.perceivedw
-                let dh = this.perceivedh
-
-                let isSafari = /safari/i.test(navigator.userAgent) && !/chromium|edg|ucbrowser|chrome|crios|opr|opera|fxios|firefox/i.test(navigator.userAgent)
-                // Safari cannot deal with negative numbers passed to drawImage
-                if (sx < 0 && isSafari) {
-                    dx = -sx*this.scale
-                    dw += sx*this.scale
+                let dwidth = this.perceivedw
+                let dheight = this.perceivedh
+                // Safari ignores sx values less than zero
+                if (sx < 0) {
+                    dx = Math.abs(sx * this.scale)
                     sx = 0
+                    swidth = Math.min(this.perceivedw/this.scale, this.snapshot.width)
+                    dwidth = Math.min(this.perceivedw, this.snapshot.width*this.scale)
                 }
-                this.ctx.drawImage(this.snapshot, sx, sy, swidth, sheight, dx, dy, dw, dh)
+                // Safari ignores swidth values greater than snapshot width - sx
+                if (swidth > this.snapshot.width - sx) {
+                    dwidth *= (this.snapshot.width - sx) / swidth
+                    swidth = this.snapshot.width - sx
+                }
+
+                this.ctx.drawImage(this.snapshot, sx, sy, swidth, sheight, dx, dy, dwidth, dheight)
             }
 
             var d = []

--- a/client/src/js/modules/dc/views/gridplot.js
+++ b/client/src/js/modules/dc/views/gridplot.js
@@ -389,7 +389,23 @@ define(['jquery', 'marionette',
                 this.scale = this.perceivedw/(w+this.offset_w)
 
                 this.ctx.globalAlpha = 1
-                this.ctx.drawImage(this.snapshot, stx-this.offset_w/2, sty-this.offset_h/2, w+this.offset_w, h+this.offset_h, 0, 0, this.perceivedw, this.perceivedh)
+                let sx = stx-this.offset_w/2
+                let sy = sty-this.offset_h/2
+                let swidth = w+this.offset_w
+                let sheight = h+this.offset_h
+                let dx = 0
+                let dy = 0
+                let dw = this.perceivedw
+                let dh = this.perceivedh
+
+                let isSafari = /safari/i.test(navigator.userAgent) && !/chromium|edg|ucbrowser|chrome|crios|opr|opera|fxios|firefox/i.test(navigator.userAgent)
+                // Safari cannot deal with negative numbers passed to drawImage
+                if (sx < 0 && isSafari) {
+                    dx = -sx*this.scale
+                    dw += sx*this.scale
+                    sx = 0
+                }
+                this.ctx.drawImage(this.snapshot, sx, sy, swidth, sheight, dx, dy, dw, dh)
             }
 
             var d = []


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1496](https://jira.diamond.ac.uk/browse/LIMS-1496)

**Summary**:

When viewing vertical grid scans in Safari, the image is offset and so the heatmap doesn't align with the drawn grid. This seems to be because Safari doesn't like negative numbers being passed to drawImage. To test this, go to https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_canvas_drawimage and replace the drawImage line with
```
  ctx.drawImage(img, -250, 0, 500, 300, 0, 0, 250, 300);
```
On Firefox or Chrome, you see a squashed image in the right half of the frame. On Safari, you see the normal image.

It turns out Safari doesn't like negative values for the second parameter (sx), so it ignores them and uses 0 instead. It also doesn't like if sx + swidth is larger than the source image width, and scales down swidth to compensate. (Firefox and Chrome just extend the source image).

**Changes**:
- If sx is negative, set it to zero, move the image with dx and scale the swidth and dwidth if needed
- If sx + swidth is greater than the source image width, adjust swidth so it is not, and scale dwidth by the same amount

**To test**:
- In Firefox or Chrome, go to a vertical gridscan eg /dc/visit/mx38113-1/id/15459994, check the heatmap matches up with the drawn grid. This is the sx<0 case.
- Click on a box, check the box number is shown correctly on the left hand side (labelled as "Image")
- Repeat in Safari
- Repeat at a couple of screen widths (eg 1000px, 1440px)
- Repeat with the grid scan /dc/visit/cm40607-1/id/16363900, this is the (sx+swidth>img.width) case

Before:
![image](https://github.com/user-attachments/assets/8e71e2ea-14cc-484b-b663-c52a03ec5ec2)
After:
![image](https://github.com/user-attachments/assets/74529386-dc4e-4093-ba35-f9d0bcf4865d)
Before:
![image](https://github.com/user-attachments/assets/b3c35212-1643-42dd-8038-b102657ab663)
After:
![image](https://github.com/user-attachments/assets/a149cef0-a5d5-47b4-935f-553ecc833fce)
