### PR TITLE
[LIMS-1366] Make dewar registration success messages green

### DIFF
--- a/client/src/js/modules/shipment/views/dewarregistry.js
+++ b/client/src/js/modules/shipment/views/dewarregistry.js
@@ -45,7 +45,7 @@ define(['marionette', 'backgrid',
         },
         
         success: function() {
-            app.alert({message: 'New dewar registered ' + this.model.get('FACILITYCODE'), notify: true})
+            app.message({message: 'New dewar registered ' + this.model.get('FACILITYCODE'), notify: true})
             this.ui.fc.val('')
             this.ui.date.val('')
             this.ui.serial.val('')
@@ -207,7 +207,7 @@ define(['marionette', 'backgrid',
                         m.set('PROPOSALS', props.join(','))
                         if (!m.get('PROP')) m.set('PROP', p.get('PROPOSAL'))
                         // This will be called multiple times for many proposals. Might be a cleaner method..?
-                        app.alert({message: 'Added registered dewar ' + m.get('FACILITYCODE') + ' to proposal(s) ' + props, notify: true})
+                        app.message({message: 'Added registered dewar ' + m.get('FACILITYCODE') + ' to proposal(s) ' + props, notify: true})
                     }
                 })
             }, this)


### PR DESCRIPTION
**Summary**:

Small extension of LIMS-1366, where registration messages are green instead of red, to reduce confusion.

**Changes**:
- Make registration success messages green instead of red

**To test**:
- Log in as a staff member, go to proposal mx34263.
- Go to /dewars/registry 
- Add a new dewar (eg.: DLS-MX-0123)
- Check if the success message is green
- Add the newly created dewar to a proposal
- Check if that message is also green