### PR TITLE
LIMS-1621: Support webcam auth

### DIFF
--- a/api/src/Page/Image.php
+++ b/api/src/Page/Image.php
@@ -331,6 +331,7 @@ class Image extends Page
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_URL, 'http://'.$img.'/axis-cgi/mjpg/video.cgi?fps=5&resolution=CIF&resolution=480x270');
             curl_setopt($ch, CURLOPT_HEADER, 0);
+            curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
             $im = curl_exec($ch);
             curl_close($ch);
         }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1621](https://jira.diamond.ac.uk/browse/LIMS-1621)

**Summary**:

If the webcams require a username and password to view, this can be added to the address in the config file, but that will be ignored without telling curl to use it.

**Changes**:
- Allow curl to use any suitable auth method

**To test**:
- Get the i19 webcam username and password from Mark or Sarah Barnett
- Update the `$webcams` array in the config, to set (with real credentials)
```
'i03' => array('172.23.103.177', '172.23.103.176'),
'i19-1' => array('user:pass@i19-webcam10.diamond.ac.uk', 'user:pass@i19-webcam11.diamond.ac.uk'),
'i19-2' => array('user:pass@i19-webcam8.diamond.ac.uk', 'user:pass@i19-webcam9.diamond.ac.uk'),
```
- Log in to proposal cm40638, then go to /status/bl/i19-1, check the webcams work
- Do the same for cm40607 and /status/bl/i03, check the webcams still work
