### PR TITLE
LIMS-128: Add plate view to queue container page

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -596,7 +596,7 @@ class Sample extends Page
             $this->_error('No containerid specified');
         }
 
-        $args = array($this->proposalid, $this->arg('cid'), $this->arg('cid'), $this->arg('cid'));
+        $args = array($this->proposalid, $this->arg('cid'));
         $where = ' AND c.containerid=:2 AND cq2.completedtimestamp IS NULL';
 
         if ($this->has_arg('filter')) {
@@ -609,8 +609,14 @@ class Sample extends Page
             $where .= $filters[$this->arg('filter')];
         }
 
-        $first_inner_select_where = ' AND s.containerid=:3';
-        $second_inner_select_where = ' AND s.containerid=:4';
+        if ($this->has_arg('LOCATION')) {
+            $where .= ' AND s.location=:' . (sizeof($args) + 1);
+            array_push($args, $this->arg('LOCATION'));
+        }
+
+        $first_inner_select_where = ' AND s.containerid=:' . (sizeof($args) + 1);
+        $second_inner_select_where = ' AND s.containerid=:' . (sizeof($args) + 2);
+        array_push($args, $this->arg('cid'), $this->arg('cid'));
 
         $this->db->wait_rep_sync(true);
         $ss_query_string = $this->get_sub_samples_query($where, $first_inner_select_where, $second_inner_select_where);

--- a/client/src/css/partials/_imaging.scss
+++ b/client/src/css/partials/_imaging.scss
@@ -226,3 +226,7 @@ input[name=gap] {
     text-align: center;
     box-sizing: content-box;
 }
+
+.plate-max-width {
+    max-width: 700px;
+}

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -1013,7 +1013,7 @@ define(['marionette',
             let newPos = this.avtypeselector.selectedPos != pos
             this.avtypeselector.selectedPos = null
             this.avtypeselector._filter()
-            _.map(this.subsamples.fullCollection.where({ isSelected: true }), function(ss) {
+            this.subsamples.fullCollection.where({ isSelected: true }).map((ss) => {
                 ss.set({ isSelected: false })
             })
             if (newPos) {

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -786,7 +786,6 @@ define(['marionette',
         },
         
         initialize: function() {
-            this._lastSample = null
             this._subsamples_ready = []
 
             this.platetypes = new PlateTypes()
@@ -860,7 +859,6 @@ define(['marionette',
             this.getInspectionImages()
             this.refreshQSubSamples()
             this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
-            //this.listenTo(this.subsamples.fullCollection, 'change:isSelected', this.selectSubSample, this)
             this.listenTo(this.unfilteredSubsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
             this.listenTo(this.unfilteredSubsamples, 'change', this.updateQueueLength)
             this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.onContainerQueueIdChange)
@@ -897,14 +895,12 @@ define(['marionette',
         },
 
         selectSubSample: function() {
-            ss = this.subsamples.fullCollection.findWhere({ isSelected: true })
+            var ss = this.subsamples.findWhere({ isSelected: true })
             if (ss) {
                 var s = ss.get('BLSAMPLEID')
-                if (s !== this._lastSample) {
-                    this.imagess.reset(this.subsamples.fullCollection.where({ BLSAMPLEID: s }))
-                    var i = this.inspectionimages.findWhere({ BLSAMPLEID: s })
-                    this.image.setModel(i)
-                }
+                this.imagess.reset(this.subsamples.fullCollection.where({ BLSAMPLEID: s }))
+                var i = this.inspectionimages.findWhere({ BLSAMPLEID: s })
+                this.image.setModel(i)
             }
         },
         

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -12,6 +12,7 @@ define(['marionette',
 
     'modules/imaging/models/plan',
     'modules/imaging/collections/plans',
+    'modules/shipment/views/plate',
 
     'collections/beamlinesetups',
     
@@ -27,6 +28,7 @@ define(['marionette',
         SubSamples,
         TableView, table, FilterView, utils,
         DiffractionPlan, DiffractionPlans,
+        PlateView,
         BeamlineSetups,
         template, pointemplate, gridtemplate, xfetemplate,
         VMXiPoint, VMXiGrid, VMXiXFE,
@@ -365,6 +367,7 @@ define(['marionette',
 
             this.filterablecollection = options.collection.fullCollection// || options.collection
             this.shadowCollection = this.filterablecollection.clone()
+            this.selectedPos = null
 
             this.listenTo(this.filterablecollection, 'add', function (model, collection, options) {
                 this.shadowCollection.add(model, options)
@@ -387,19 +390,19 @@ define(['marionette',
         _filter: function() {
             var id = this.selected()
             this.trigger('selected:change', id, this.selectedName())
-            if (id) {
+            if (id || this.selectedPos) {
+                var self = this
                 this.filterablecollection.reset(this.shadowCollection.filter(function(m) {
                     if (id === 'region') {
-                        return m.get('X2') && m.get('Y2')
-
+                        return m.get('X2') && m.get('Y2') && (self.selectedPos == null || m.get('LOCATION') == self.selectedPos)
                     } else if (id === 'point') {
-                        return m.get('X') && m.get('Y') && !m.get('X2')
-                    }
-                    else if (id === 'auto') {
-                        return m.get('SOURCE') == 'auto'
-
+                        return m.get('X') && m.get('Y') && !m.get('X2') && (self.selectedPos == null || m.get('LOCATION') == self.selectedPos)
+                    } else if (id === 'auto') {
+                        return m.get('SOURCE') == 'auto' && (self.selectedPos == null || m.get('LOCATION') == self.selectedPos)
                     } else if (id === 'manual') {
-                        return m.get('SOURCE') == 'manual'
+                        return m.get('SOURCE') == 'manual' && (self.selectedPos == null || m.get('LOCATION') == self.selectedPos)
+                    } else if (!isNaN(self.selectedPos)) {
+                        return m.get('LOCATION') == self.selectedPos
                     }
                 }), {reindex: false})
             } else {
@@ -517,6 +520,7 @@ define(['marionette',
             qfilt: '.qfilt',
             afilt: '.afilt',
             rimg: '.image',
+            plate: '.plate',
         },
         
         events: {
@@ -575,6 +579,10 @@ define(['marionette',
             current = this.$el.find('.afilt').find('.current')
             if (current.length > 0) {
                 data.filter = current.attr('id')
+            }
+
+            if (this.avtypeselector.selectedPos) {
+                data.LOCATION = this.avtypeselector.selectedPos
             }
 
             var self = this
@@ -852,6 +860,7 @@ define(['marionette',
             this.getInspectionImages()
             this.refreshQSubSamples()
             this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
+            //this.listenTo(this.subsamples.fullCollection, 'change:isSelected', this.selectSubSample, this)
             this.listenTo(this.unfilteredSubsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
             this.listenTo(this.unfilteredSubsamples, 'change', this.updateQueueLength)
             this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.onContainerQueueIdChange)
@@ -878,7 +887,7 @@ define(['marionette',
         },
 
         selectSample: function() {
-            this.subsamples.at(0).set({ isSelected: true })
+            if (this.subsamples.length) this.subsamples.at(0).set({ isSelected: true })
         },
 
         refreshQSubSamples: function() {
@@ -888,12 +897,14 @@ define(['marionette',
         },
 
         selectSubSample: function() {
-            var ss = this.subsamples.findWhere({ isSelected: true })
-            var s = ss.get('BLSAMPLEID')
-            if (s !== this._lastSample) {
-                this.imagess.reset(this.subsamples.fullCollection.where({ BLSAMPLEID: s }))
-                var i = this.inspectionimages.findWhere({ BLSAMPLEID: s })
-                this.image.setModel(i)
+            ss = this.subsamples.fullCollection.findWhere({ isSelected: true })
+            if (ss) {
+                var s = ss.get('BLSAMPLEID')
+                if (s !== this._lastSample) {
+                    this.imagess.reset(this.subsamples.fullCollection.where({ BLSAMPLEID: s }))
+                    var i = this.inspectionimages.findWhere({ BLSAMPLEID: s })
+                    this.image.setModel(i)
+                }
             }
         },
         
@@ -992,12 +1003,31 @@ define(['marionette',
             })
 
             this.qsmps.show(this.table2)
+
+            this.plateView = new PlateView({ collection: this.subsamples.fullCollection, type: this.type, inspectionimages: this.inspectionimages })
+            this.listenTo(this.plateView, 'dropClicked', this.filterByLocation, this)
+            this.plate.show(this.plateView)
         },
 
         onShow: function() {
             this.rimg.show(this.image)
         },
         
+        filterByLocation: function(pos) {
+            let newPos = this.avtypeselector.selectedPos != pos
+            this.avtypeselector.selectedPos = null
+            this.avtypeselector._filter()
+            _.map(this.subsamples.fullCollection.where({ isSelected: true }), function(ss) {
+                ss.set({ isSelected: false })
+            })
+            if (newPos) {
+                this.avtypeselector.selectedPos = pos
+                this.avtypeselector._filter()
+            }
+            this.selectSample()
+
+        },
+
     })
         
 })

--- a/client/src/js/modules/shipment/views/plate.js
+++ b/client/src/js/modules/shipment/views/plate.js
@@ -33,6 +33,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                 
                 this.trigger('plate:select')
                 if (drop) drop.set('isSelected', true)
+                this.trigger('dropClicked', pos)
                 this.drawPlate()
             }
         },
@@ -187,7 +188,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                         var did = (k*this.pt.get('drop_per_well_x'))+j
                         if (this.pt.get('well_drop') > -1) {
                             if (did == this.pt.get('well_drop')) continue
-                                if (did > this.pt.get('well_drop')) did--;
+                            if (did > this.pt.get('well_drop')) did--;
                         }
         
                         var sampleid = i*this.pt.dropTotal()+did+1

--- a/client/src/js/modules/shipment/views/plate.js
+++ b/client/src/js/modules/shipment/views/plate.js
@@ -35,6 +35,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                 if (drop) drop.set('isSelected', true)
                 this.trigger('dropClicked', pos)
                 this.drawPlate()
+                this.lastClickedWell = this.lastClickedWell === pos ? null : pos
             }
         },
         
@@ -47,6 +48,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
             this.showImageStatus = this.getOption('showImageStatus')
             this.showSampleStatus = this.getOption('showSampleStatus')
             this.showMaxScore = false
+            this.lastClickedWell = null
             
             Backbone.Validation.bind(this, {
                 collection: this.collection
@@ -199,7 +201,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                         
                         this.ctx.beginPath()
                         this.ctx.lineWidth = 1;
-                        if (sample && sample.get('isSelected')) {
+                        if ((sample && sample.get('isSelected')) || sampleid === this.lastClickedWell) {
                             this.ctx.strokeStyle = 'cyan'
                             
                         } else if (sample && sample.get('PROTEINID') > -1) {

--- a/client/src/js/templates/imaging/queuecontainer.html
+++ b/client/src/js/templates/imaging/queuecontainer.html
@@ -18,7 +18,7 @@
             <ul>
                 <li>
                     <span class="label">Container</span>
-                    <span class="NAME"><%-NAME%></span>
+                    <span class="NAME"><a href="/containers/cid/<%-CONTAINERID%>"><%-NAME%></a></span>
                 </li>
 
                 <li>
@@ -27,6 +27,8 @@
                 </li>
             </ul>
         </div>
+
+        <div class="plate plate-max-width"></div>
 
         <h2>Available Samples</h2>
         <div class="filter">
@@ -38,9 +40,7 @@
                 <li><label><input type="checkbox" name="nodata" /> Without Data</label></li>
                 <li><label><input type="checkbox" name="notcompleted" /> Not Completed</label></li>
             </ul>
-        </div>
-        <div class="filter">
-            <div class="filter filter-nohide afilt"></div>
+        <span class="filter filter-nohide afilt"></span>
         </div>
         <div class="asamples"></div>
     </div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-128](https://jira.diamond.ac.uk/browse/LIMS-128)

**Summary**:

When queuing samples in a plate for data collection, it would be useful to show a view of the plate, rather than just a list of (possibly 1000s of) samples.
First attempt at this was https://github.com/DiamondLightSource/SynchWeb/pull/839 but had to be reverted.

**Changes**:
- Display a plate view on the "Prepare For Data Collection" page (/containers/queue/)
- Filter the list when you click on a well
- Load the inspection image when you click on a well
- Ensure 'Add all to queue' only adds from the current well (otherwise you get an error as the server queues samples the client isn't showing)

**To test**:
- Go to a proposal with plates (eg nt37104) and then go to a plate (eg /containers/cid/317254)
- Check clicking on a well still loads the inspection image for the well (this page hasn't changed)
- Click "Prepare for Data Collection" near the bottom
- Check a map of the plate appears, and that wells with samples in are outlined (most of them). Check the container name at the top is a link back to the previous page.
- Check that clicking on a well shows a list of samples from that well
- Check the Auto/Manual/Point/Region filters work, alone and in combination with a well
- Check the "Add Current Page to Queue" button adds only those currently displayed
- Check the "Add All to Queue" adds all the pages, but obeys the Auto/Manual/Point/Region filters, and if you have clicked on a well, it obeys that filter also.
- Check the list of "Queued Samples" stays the same even if you change filter on "Available Samples"
