### PR TITLE
LIMS-1615: Allow direct links to visit summary page

### DIFF
--- a/client/src/js/modules/dc/routes.js
+++ b/client/src/js/modules/dc/routes.js
@@ -58,8 +58,7 @@ application.addInitializer(function() {
 // },
 
 function lookupVisit(visit) {
-  // router guard takes care of setting proposal from route path
-  //application.cookie(visit.split('-')[0])
+  application.cookie(visit.split('-')[0])
 
   return new Promise((resolve, reject) => {
       visitModel = new Visit({ VISIT: visit })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1615](https://jira.diamond.ac.uk/browse/LIMS-1615)

**Summary**:

Links to eg https://ispyb.diamond.ac.uk/dc/summary/visit/cm40608-1 don't work, as the proposal is not set.

**Changes**:
- Set the proposal 'cookie' when navigating to the page. This is reverting commit https://github.com/DiamondLightSource/SynchWeb/commit/80ef089a61b8fc9ac25a7acc09eb6da6bb8dd6c2.

**To test**:
- In a new browser tab for each, go to /dc/summary/visit/cm40608-1, /dc/apstatussummary/visit/cm40608-1, /dc/sc/visit/cm40608-1 and /dc/visit/cm40608-1 and check each one loads correctly, with the proposal set.
- Try again, but log in as someone without permission to view that visit, check each page doesn't load
