### PR TITLE
LIMS-1652: Revert underscore to 1.8.3

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -46,7 +46,7 @@
         "tailwindcss": "^1.9.5",
         "three": "^0.143.0",
         "uglymol": "^0.6.4",
-        "underscore": "1.12.1",
+        "underscore": "1.8.3",
         "util": "^0.12.4",
         "vee-validate": "^2.2.15",
         "vue": "^2.6.10",
@@ -4428,12 +4428,6 @@
         "underscore": ">=1.4.0 <=1.8.3"
       }
     },
-    "node_modules/backbone.babysitter/node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
-      "license": "MIT"
-    },
     "node_modules/backbone.marionette": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.1.0.tgz",
@@ -4477,12 +4471,6 @@
         "backbone": ">=0.9.9 <=1.3.x",
         "underscore": ">=1.3.3 <=1.8.3"
       }
-    },
-    "node_modules/backbone.wreqr/node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
-      "license": "MIT"
     },
     "node_modules/backgrid": {
       "version": "0.3.8",
@@ -17658,10 +17646,9 @@
       "integrity": "sha512-ZjGNsJbLUt42ETlC7I7yjGPNR6OzdzYeCrefslVHHdEgFsaPKbKtA6OaSzyGlT6zyNuzYYK6uEDuPtgBYfyAuA=="
     },
     "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
-      "license": "MIT"
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg=="
     },
     "node_modules/underscore-template-loader": {
       "version": "1.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -97,7 +97,7 @@
     "tailwindcss": "^1.9.5",
     "three": "^0.143.0",
     "uglymol": "^0.6.4",
-    "underscore": "1.12.1",
+    "underscore": "1.8.3",
     "util": "^0.12.4",
     "vee-validate": "^2.2.15",
     "vue": "^2.6.10",


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1652](https://jira.diamond.ac.uk/browse/LIMS-1652)

**Summary**:

Non-MX pucks are not displayed correctly after updating underscore. This reverts to the previous underscore version.

**Changes**:

- Revert underscore version

**To test**:
- Go to /containers/cid/322576, ensure puck is displayed
