### PR TITLE
LIMS-1642: Fix search when clicking x on search bars

### DIFF
--- a/client/src/js/views/search.js
+++ b/client/src/js/views/search.js
@@ -3,7 +3,7 @@ define(['backbone'], function(Backbone) {
   var Search = Backbone.View.extend({
     /** @property */
     events: {
-        "keyup input[type=search]": "search",
+        "input input[type=search]": "search",
         "click a[data-backgrid-action=clear]": "clear",
         "submit": "search"
     },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1642](https://jira.diamond.ac.uk/browse/LIMS-1642)

**Summary**:

In Chrome or Edge, when you fill in a search bar, a small x appears to clear the search bar. Synchweb should clear the search parameter when you click the x.

**Changes**:
- Change from using the `keyup` event to the `input` event (https://www.w3schools.com/jsref/event_oninput.asp) 

**To test**:
- In Chrome or Edge, go to the proposals page, search for a proposal number. Click the little x in the search bar, check all proposals are shown again