### PR TITLE
LIMS-1632: Buttons to go to next & previous puck in dewar

### DIFF
--- a/client/src/js/app/components/page-title-header.vue
+++ b/client/src/js/app/components/page-title-header.vue
@@ -3,6 +3,16 @@
     <h1 class="nou">
       <slot>Title</slot>
     </h1>
+
+    <prev-next-btngroup
+      v-show="this.prevNextTargets"
+      next-btn-label="Next Container"
+      prev-btn-label="Prev Container"
+      :path-prefix="this.prevNextPathPrefix"
+      :allTargets="this.prevNextTargets"
+      :currentValue="this.currentValue"
+    >
+    </prev-next-btngroup>
   </div>
 </template>
 
@@ -15,27 +25,44 @@ export default {
     "prev-next-btngroup": PrevNextBtngroup,
   },
   props: {
-    titleText: {
-      type: String,
-      default: "Title",
+    prevNextPathPrefix: {
+        type: String,
+        default: null
     },
+    prevNextTargets: {
+        type: Array,
+        default: []
+    },
+    currentValue: {
+        type: String,
+        default: null
+    },
+    prevNextBtnProps: {
+        type: Object,
+        default: () => ({
+            nextBtnLabel: "Next",
+            prevBtnLabel: "Prev",
+        })
+    },
+
   },
 };
 </script>
 
 <style scoped>
-    h1 {
-        padding: 0;
-    }
+h1 {
+  padding: 0;
+  @apply tw-flex-grow
+}
 
-    .header-row {
-        @apply tw-px-4;
-        @apply tw-pl-0;
-        @apply tw-py-2;
-        @apply tw-flex;
-        @apply tw-flex-row;
-        @apply tw-gap-2;
-        @apply tw-items-center;
-        border-bottom: 1px solid grey;
-    }
+.header-row {
+  @apply tw-px-4;
+  @apply tw-pl-0;
+  @apply tw-py-2;
+  @apply tw-flex;
+  @apply tw-flex-row;
+  @apply tw-gap-2;
+  @apply tw-items-center;
+  border-bottom: 1px solid grey;
+}
 </style>

--- a/client/src/js/app/components/page-title-header.vue
+++ b/client/src/js/app/components/page-title-header.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="content header-row">
+    <h1 class="nou">
+      <slot>Title</slot>
+    </h1>
+  </div>
+</template>
+
+<script>
+import PrevNextBtngroup from "./prev-next-btngroup.vue";
+
+export default {
+  name: "PageTitleHeader",
+  components: {
+    "prev-next-btngroup": PrevNextBtngroup,
+  },
+  props: {
+    titleText: {
+      type: String,
+      default: "Title",
+    },
+  },
+};
+</script>
+
+<style scoped>
+    h1 {
+        padding: 0;
+    }
+
+    .header-row {
+        @apply tw-px-4;
+        @apply tw-pl-0;
+        @apply tw-py-2;
+        @apply tw-flex;
+        @apply tw-flex-row;
+        @apply tw-gap-2;
+        @apply tw-items-center;
+        border-bottom: 1px solid grey;
+    }
+</style>

--- a/client/src/js/app/components/page-title-header.vue
+++ b/client/src/js/app/components/page-title-header.vue
@@ -59,6 +59,7 @@ h1 {
   @apply tw-px-4;
   @apply tw-pl-0;
   @apply tw-py-2;
+  @apply tw-mb-4;
   @apply tw-flex;
   @apply tw-flex-row;
   @apply tw-gap-2;

--- a/client/src/js/app/components/prev-next-btngroup.vue
+++ b/client/src/js/app/components/prev-next-btngroup.vue
@@ -2,17 +2,17 @@
   <div class="btn-group">
     <flat-button
       @click="pushToPrev()"
-      v-bind:level="prevTarget?.relativeLink ? 'primary' : 'disabled'"
-      v-bind:hint="prevTarget?.tooltip ?? prevTarget?.relativeLink"
+      v-bind:level="prevTarget?.value ? 'primary' : 'disabled'"
+      v-bind:hint="prevTarget?.text ?? prevTarget?.value"
     >
       {{ prevBtnLabel }}
     </flat-button>
-    <slot></slot>
+    {{ currentIdx +1 }} of {{ siblingTargets.length }}
 
     <flat-button
       @click="pushToNext()"
-      v-bind:level="nextTarget?.relativeLink ? 'primary' : 'disabled'"
-      v-bind:hint="nextTarget?.tooltip ?? nextTarget?.relativeLink"
+      v-bind:level="nextTarget?.value ? 'primary' : 'disabled'"
+      v-bind:hint="nextTarget?.text ?? nextTarget?.value"
     >
       {{ nextBtnLabel }}
     </flat-button>
@@ -25,27 +25,38 @@ import router from "../router/router";
 
 /**
  * A simple component that supplies functionality for prev & next router-links.
- * Button labels default to "Prev" & "Next" but alternatives can be supplied
+ * Button labels default to "Prev" & "Next" but alternatives can be supplied.
+ * Keeping state minimal for future re-use as the page is fully reloaded every time.
  */
 export default {
   name: "PrevNextBtnGroup",
   components: {
     "flat-button": FlatButton,
   },
+  computed: {
+    nextTarget() {
+      return this.allTargets[this.currentIdx+1];
+    },
+    prevTarget(){
+      return this.allTargets[this.currentIdx-1];
+    }
+  },
   methods: {
     pushToNext() {
-      if (this.nextTarget?.relativeLink)
-        router.push({ path: this.pathprefix + this.nextTarget.relativeLink });
+      console.log("Next Target:", this.nextTarget)
+      if (this.nextTarget?.value)
+        router.push({ path: this.pathprefix + this.nextTarget.value });
     },
     pushToPrev() {
-      if (this.prevTarget?.relativeLink)
-        router.push({ path: this.pathprefix + this.prevTarget.relativeLink });
+      console.log("Prev Target:", this.prevTarget)
+      if (this.prevTarget?.value)
+        router.push({ path: this.pathprefix + this.prevTarget.value });
     },
   },
   props: {
     pathprefix: {
       type: String,
-      default: ""
+      default: "",
     },
     nextBtnLabel: {
       type: String,
@@ -56,25 +67,14 @@ export default {
       default: "Prev",
     },
 
-    nextTarget: {
-      relativeLink: {
-        type: String,
-        default: null,
-      },
-      tooltip: {
-        type: String,
-        default: null,
-      },
+    allTargets: {
+      type: Array, // { value: string text: string }
+      default: [],
     },
-    prevTarget: {
-      relativeLink: {
-        type: String,
-        default: null,
-      },
-      tooltip: {
-        type: String,
-        default: null,
-      },
+
+    currentIdx: {
+      type: Number,
+      default: 0,
     },
   },
 };

--- a/client/src/js/app/components/prev-next-btngroup.vue
+++ b/client/src/js/app/components/prev-next-btngroup.vue
@@ -83,7 +83,7 @@ export default {
   @apply tw-flex;
   @apply tw-flex-row;
   @apply tw-gap-2;
-  @apply tw-text-center;
+  @apply tw-items-center;
   @apply tw-border;
   @apply tw-rounded;
 }

--- a/client/src/js/app/components/prev-next-btngroup.vue
+++ b/client/src/js/app/components/prev-next-btngroup.vue
@@ -7,7 +7,7 @@
     >
       {{ prevBtnLabel }}
     </flat-button>
-    {{ currentIdx +1 }} of {{ siblingTargets.length }}
+    {{ currentIdx +1 }} of {{ allTargets.length }}
 
     <flat-button
       @click="pushToNext()"
@@ -24,7 +24,7 @@ import FlatButton from "./flat-button.vue";
 import router from "../router/router";
 
 /**
- * A simple component that supplies functionality for prev & next router-links.
+ * A "simple" component that supplies functionality for prev & next router-links.
  * Button labels default to "Prev" & "Next" but alternatives can be supplied.
  * Keeping state minimal for future re-use as the page is fully reloaded every time.
  */
@@ -34,6 +34,9 @@ export default {
     "flat-button": FlatButton,
   },
   computed: {
+    currentIdx () {
+      return _.findIndex(this.allTargets, target => target.value === this.currentValue);
+    },
     nextTarget() {
       return this.allTargets[this.currentIdx+1];
     },
@@ -43,12 +46,10 @@ export default {
   },
   methods: {
     pushToNext() {
-      console.log("Next Target:", this.nextTarget)
       if (this.nextTarget?.value)
         router.push({ path: this.pathprefix + this.nextTarget.value });
     },
     pushToPrev() {
-      console.log("Prev Target:", this.prevTarget)
       if (this.prevTarget?.value)
         router.push({ path: this.pathprefix + this.prevTarget.value });
     },
@@ -72,9 +73,9 @@ export default {
       default: [],
     },
 
-    currentIdx: {
-      type: Number,
-      default: 0,
+    currentValue: {
+      type: String,
+      default: null,
     },
   },
 };

--- a/client/src/js/app/components/prev-next-btngroup.vue
+++ b/client/src/js/app/components/prev-next-btngroup.vue
@@ -35,14 +35,18 @@ export default {
   methods: {
     pushToNext() {
       if (this.nextTarget?.relativeLink)
-        router.push({ path: this.nextTarget.relativeLink });
+        router.push({ path: this.pathprefix + this.nextTarget.relativeLink });
     },
     pushToPrev() {
       if (this.prevTarget?.relativeLink)
-        router.push({ path: this.prevTarget.relativeLink });
+        router.push({ path: this.pathprefix + this.prevTarget.relativeLink });
     },
   },
   props: {
+    pathprefix: {
+      type: String,
+      default: ""
+    },
     nextBtnLabel: {
       type: String,
       default: "Next",

--- a/client/src/js/app/components/prev-next-btngroup.vue
+++ b/client/src/js/app/components/prev-next-btngroup.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="btn-group">
+    <flat-button
+      @click="pushToPrev()"
+      v-bind:level="prevTarget?.relativeLink ? 'primary' : 'disabled'"
+      v-bind:hint="prevTarget?.tooltip ?? prevTarget?.relativeLink"
+    >
+      {{ prevBtnLabel }}
+    </flat-button>
+    <slot></slot>
+
+    <flat-button
+      @click="pushToNext()"
+      v-bind:level="nextTarget?.relativeLink ? 'primary' : 'disabled'"
+      v-bind:hint="nextTarget?.tooltip ?? nextTarget?.relativeLink"
+    >
+      {{ nextBtnLabel }}
+    </flat-button>
+  </div>
+</template>
+  
+<script>
+import FlatButton from "./flat-button.vue";
+import router from "../router/router";
+
+/**
+ * A simple component that supplies functionality for prev & next router-links.
+ * Button labels default to "Prev" & "Next" but alternatives can be supplied
+ */
+export default {
+  name: "PrevNextBtnGroup",
+  components: {
+    "flat-button": FlatButton,
+  },
+  methods: {
+    pushToNext() {
+      if (this.nextTarget?.relativeLink)
+        router.push({ path: this.nextTarget.relativeLink });
+    },
+    pushToPrev() {
+      if (this.prevTarget?.relativeLink)
+        router.push({ path: this.prevTarget.relativeLink });
+    },
+  },
+  props: {
+    nextBtnLabel: {
+      type: String,
+      default: "Next",
+    },
+    prevBtnLabel: {
+      type: String,
+      default: "Prev",
+    },
+
+    nextTarget: {
+      relativeLink: {
+        type: String,
+        default: null,
+      },
+      tooltip: {
+        type: String,
+        default: null,
+      },
+    },
+    prevTarget: {
+      relativeLink: {
+        type: String,
+        default: null,
+      },
+      tooltip: {
+        type: String,
+        default: null,
+      },
+    },
+  },
+};
+</script>
+  
+  <style scoped>
+.btn-group {
+  @apply tw-px-4;
+  @apply tw-py-2;
+  @apply tw-flex;
+  @apply tw-flex-row;
+  @apply tw-gap-2;
+  @apply tw-text-center;
+  @apply tw-border;
+  @apply tw-rounded;
+}
+</style>

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -1,16 +1,13 @@
 <template>
   <div class="content">
-    <h1 data-testid="container-header">Container {{container.NAME}}</h1>
-
-    <prev-next-btngroup
-        v-show="prevNextTargetLinks?.length > 1"
-        next-btn-label="Next Container"
-        prev-btn-label="Prev Container"
-        path-prefix="/containers/cid/"
-        :allTargets="this.prevNextTargetLinks"
-        :currentIdx="this.currentContainerIdx"
-      >
-    </prev-next-btngroup>
+    <!-- <h1 data-testid="container-header">Container {{container.NAME}}</h1> -->
+    <page-title-header
+      prevNextPathPrefix="/containers/cid/"
+      :prevNextTargets="this.prevNextTargetLinks"
+      :currentValue="this.containerId"
+    >
+      Container {{container.NAME }}
+    </page-title-header>
 
     <p class="help">
       This page shows the contents of the selected container. Samples can be added and edited by clicking the pencil icon, and removed by clicking the x
@@ -276,7 +273,8 @@ export default {
   name: 'MxContainerView',
   components: {
     'prev-next-btngroup': PrevNextBtngroup,
-        'base-input-text': BaseInputText,
+    'page-title-header': PageTitleHeader,
+    'base-input-text': BaseInputText,
     'base-input-textarea': BaseInputTextArea,
     'base-input-select': BaseInputSelect,
     'valid-container-graphic': ValidContainerGraphic,
@@ -286,7 +284,7 @@ export default {
     'single-sample-plate': SingleSample,
     'mx-puck-samples-table': MxPuckSamplesTable,
     'validation-observer': ValidationObserver,
-    'validation-provider': ValidationProvider
+    'validation-provider': ValidationProvider,
   },
   mixins: [ContainerMixin],
   props: {
@@ -355,9 +353,6 @@ export default {
       .map(sib => ({ value: sib.CONTAINERID, text: sib.NAME }))
       .sortBy((c) => c.text)
       .value();
-    },
-    currentContainerIdx() {
-      return _.findIndex(this.prevNextTargetLinks, sib => sib.value === this.containerId);
     },
   },
   created: function() {

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -6,6 +6,7 @@
         v-show="siblingContainers?.length > 1"
         next-btn-label="Next Container"
         prev-btn-label="Prev Container"
+        path-prefix="/containers/cid/"
         :next-target="this.nextContainerTarget"
         :prev-target="this.prevContainerTarget"
       >
@@ -352,11 +353,11 @@ export default {
     },
     prevContainerTarget() {
       const target = this.siblingContainers[this.containerIndex-1];
-      return target ? { relativeLink: "/containers/cid/" + target.cId, tooltip: target.cName } : null;
+      return target ? { relativeLink: target.cId, tooltip: target.cName } : null;
     },
     nextContainerTarget() {
       const target = this.siblingContainers[this.containerIndex+1];
-      return target ? { relativeLink: "/containers/cid/" + target.cId, tooltip: target.cName } : null;
+      return target ? { relativeLink: target.cId, tooltip: target.cName } : null;
     },
   },
   created: function() {

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -3,14 +3,13 @@
     <h1 data-testid="container-header">Container {{container.NAME}}</h1>
 
     <prev-next-btngroup
-        v-show="prevNextTargets?.length > 1"
+        v-show="prevNextTargetLinks?.length > 1"
         next-btn-label="Next Container"
         prev-btn-label="Prev Container"
         path-prefix="/containers/cid/"
-        :next-target="this.nextContainerTarget"
-        :prev-target="this.prevContainerTarget"
+        :allTargets="this.prevNextTargetLinks"
+        :currentIdx="this.currentContainerIdx"
       >
-      {{ currentContainerIdx +1 }} of {{ prevNextTargets.length }}
     </prev-next-btngroup>
 
     <p class="help">
@@ -261,6 +260,7 @@ import Containers from 'collections/containers'
 import Dewars from 'collections/dewars'
 
 import PrevNextBtngroup from 'app/components/prev-next-btngroup.vue'
+import PageTitleHeader from 'app/components/page-title-header.vue'
 import BaseInputSelect from 'app/components/base-input-select.vue'
 import BaseInputText from 'app/components/base-input-text.vue'
 import BaseInputTextArea from 'app/components/base-input-textarea.vue'
@@ -276,7 +276,7 @@ export default {
   name: 'MxContainerView',
   components: {
     'prev-next-btngroup': PrevNextBtngroup,
-    'base-input-text': BaseInputText,
+        'base-input-text': BaseInputText,
     'base-input-textarea': BaseInputTextArea,
     'base-input-select': BaseInputSelect,
     'valid-container-graphic': ValidContainerGraphic,
@@ -350,21 +350,14 @@ export default {
     containersSamplesGroupData() {
       return this.$store.getters['samples/getContainerSamplesGroupData']
     },
-    prevNextTargets() {
+    prevNextTargetLinks() {
       return _.chain(this.siblingContainers)
       .map(sib => ({ value: sib.CONTAINERID, text: sib.NAME }))
       .sortBy((c) => c.text)
       .value();
-      // return _.map(this.siblingContainers, sib => ({ relativeLink: sib.cId, tooltip: sib.cName }));
     },
     currentContainerIdx() {
-      return _.findIndex(this.prevNextTargets, sib => sib.value === this.containerId);
-    },
-    prevContainerTarget() {
-      return this.prevNextTargets[this.currentContainerIdx-1];
-    },
-    nextContainerTarget() {
-      return this.prevNextTargets[this.currentContainerIdx+1];
+      return _.findIndex(this.prevNextTargetLinks, sib => sib.value === this.containerId);
     },
   },
   created: function() {
@@ -575,8 +568,6 @@ export default {
       }
 
       this.siblingContainers = result.toJSON();
-      // console.log("Sibling Containers", this.siblingContainers)
-      // console.log("ContainerIdx", this.containerIndex)
     },
     
     async fetchContainers() {

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -286,6 +286,7 @@ export default {
     return {
       container: {},
       containerId: 0,
+      siblingContainers: {}, // All containers using this Dewar and shippingID
       samplesCollection: null,
 
       containerHistory: [],
@@ -354,6 +355,7 @@ export default {
     this.getImagingCollections()
     this.getImagingScheduleCollections()
     this.getImagingScreensCollections()
+    this.fetchSiblingContainers()
   },
   methods: {
     loadContainerData() {
@@ -516,6 +518,21 @@ export default {
       } finally {
         // TODO: Toggle loading state off
       }
+    },
+    // 
+    async fetchSiblingContainers() {
+      // Fetch any other containers sharing the same Dewar & shipment, sorted by containerID.
+      var result = new Containers();
+      result.dewarID = this.container.DEWARID;
+      result.shipmentID = this.container.SHIPPINGID;
+      await result.fetch();
+
+      this.siblingContainers = _.chain(result.toJSON())
+      .map(sib => ({ dewarID: sib.DEWARID,  cid: sib.CONTAINERID }))
+      .sortBy((c) => c.cid)
+      .value();
+
+      console.log("Sibling Containers", this.siblingContainers)
     },
     async fetchContainers() {
       this.containersCollection = new Containers(null, { state: { pageSize: 9999 } })

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -551,14 +551,12 @@ export default {
         // ! if ContainersCollection exists then filter it instead rather than re-fetching.
         // !! WARNING -  THis assumes that containersCollection has ALL containers of the dewar
         result = _.filter(this.containersCollection,  (c) => 
-          c.DEWARID === this.container.DEWARID &&
-          c.SHIPPINGID === this.container.SHIPPINGID
+          c.DEWARID === this.container.DEWARID
         );
 
       } else {
         result = new Containers();
         result.dewarID = this.container.DEWARID;
-        result.shipmentID = this.container.SHIPPINGID;
         await result.fetch();
       }
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1632](https://jira.diamond.ac.uk/browse/LIMS-1632)

**Summary**:
Provides a new component with prev/next button links to access the next & Previous containers in the Dewar when viewing a container. 

**Changes**:
- Added new page-title-header & prev-next-btgroup vue components which can display the prev/next puck in the header if target data supplied. Dumb components for the most part due to page reloads being default behaviour.
- mx-container-view.vue collates sibling containers using existing containersCollection (if exists) or by fetching the collection as required.

**To test**:
- Visit a shipment page containing a Dewar with multiple containers eg `/shipments/sid/69283`. note the order of the containers within the Dewar.
- Click through to a container of the Dewar - noting it's position in the list.
- In the container page, use the prev / next buttons to move between containers in the Dewar confirming the order matches that previously shown at the shipping level. On the first item the "Prev" button should be disabled. On the last item the "Next" button should be disabled. 
- Visit a shipment with 1 container eg `containers/cid/326821`, bothe Next & Prev buttons should show as disabled.

**Further Steps**
- This prev-next-btgroup component could then be used further to provide similar functionality for shipments etc.
- see [LIMS-1683](https://jira.diamond.ac.uk/browse/LIMS-1683) for further expansion