### PR TITLE
LIMS-995: Fix Shipment Stats page

### DIFF
--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -34,9 +34,7 @@ class Vstat extends Page
         array('/overview', 'get', '_overview'),
         array('/runs', 'get', '_runs'),
         array('/histogram', 'get', '_parameter_histogram'),
-
         array('/dewars', 'get', '_dewars_breakdown'),
-
     );
 
     var $dhl;
@@ -1074,10 +1072,6 @@ class Vstat extends Page
             array_push($args, $this->proposalid);
         }
 
-        if ($this->has_arg('data')) {
-            $having = 'HAVING count(dc.datacollectionid) > 0';
-        }
-
         if ($this->has_arg('history')) {
             $having = 'HAVING count(th.dewartransporthistoryid) > 1';
         }
@@ -1135,7 +1129,6 @@ class Vstat extends Page
                     sum(shipments) as shipments, 
                     sum(dewars) as dewars, 
                     sum(history) as history,
-                    sum(dcs) as dcs, 
                     sum(containers) as containers, 
                     sum(cta) as cta, 
                     country
@@ -1145,7 +1138,6 @@ class Vstat extends Page
                         count(distinct d.dewarid) as dewars, 
                         count(distinct th.dewartransporthistoryid) as history,
                         count(distinct c.containerid) as containers, 
-                        count(distinct dc.datacollectionid) as dcs, 
                         count(distinct cta.couriertermsacceptedid) as cta, 
                         YEAR(s.bltimestamp) as year, 
                         l.country, 
@@ -1163,9 +1155,6 @@ class Vstat extends Page
                     INNER JOIN laboratory l ON l.laboratoryid = pe.laboratoryid 
 
                     LEFT OUTER JOIN container c ON c.dewarid = d.dewarid
-                    LEFT OUTER JOIN blsample smp ON smp.containerid = c.containerid
-                    LEFT OUTER JOIN datacollection dc ON dc.blsampleid = smp.blsampleid
-
                     LEFT OUTER JOIN blsession ses ON ses.sessionid = d.firstexperimentid
                     WHERE 1=1 $where 
                     -- GROUP BY ses.startdate
@@ -1181,7 +1170,7 @@ class Vstat extends Page
             if ($d['COUNTRY'] && !$d['CODE'])
                 print_r(array($d['COUNTRY']));
 
-            foreach (array('SHIPMENTS', 'DEWARS', 'HISTORY', 'DCS', 'CONTAINERS', 'CTA') as $k)
+            foreach (array('SHIPMENTS', 'DEWARS', 'HISTORY', 'CONTAINERS', 'CTA') as $k)
                 $d[$k] = intval($d[$k]);
         }
 

--- a/client/src/js/modules/shipment/views/dewarstats.js
+++ b/client/src/js/modules/shipment/views/dewarstats.js
@@ -109,7 +109,6 @@ define(['marionette',
             this.rruns.show(new TableView({ 
                 collection: this.run, 
                 columns: columns, 
-                filter: 's', 
                 tableClass: 'runs', 
                 loading: true,
                 backgrid: { emptyText: 'No dewar stats found' } 
@@ -119,7 +118,6 @@ define(['marionette',
             this.rcts.show(new TableView({ 
                 collection: this.countries, 
                 columns: columns2, 
-                filter: 's', 
                 tableClass: 'countries',
                 loading: true, 
                 backgrid: { emptyText: 'No dewar stats found' } 

--- a/client/src/js/modules/shipment/views/dewarstats.js
+++ b/client/src/js/modules/shipment/views/dewarstats.js
@@ -32,12 +32,10 @@ define(['marionette',
         ui: {
             map: '.map',
             years: '.years',
-            data: 'input[name=data]',
             hist: 'input[name=hist]',
         },
 
         events: {
-            'change @ui.data': 'refresh',
             'change @ui.hist': 'refresh',
         },
 
@@ -45,11 +43,6 @@ define(['marionette',
         refresh: function() {
             this.run.fetch()
             this.countries.fetch()
-        },
-
-
-        getData: function() {
-            return this.ui.data.is(':checked') ? 1 : ''
         },
 
 
@@ -88,9 +81,6 @@ define(['marionette',
             this.listenTo(this.countries, 'sync', this.removeSpinnerCountry)
             this.listenTo(this.countries, 'error', this.removeSpinnerCountry)
 
-            this.run.queryParams.data = this.getData.bind(this)
-            this.countries.queryParams.data = this.getData.bind(this)
-
             this.run.queryParams.history = this.getHist.bind(this)
             this.countries.queryParams.history = this.getHist.bind(this)
 
@@ -108,7 +98,6 @@ define(['marionette',
                 { name: 'CTA', label: 'Facility Shipping', cell: 'integer', editable: false },
                 { name: 'DEWARS', label: 'Dewars', cell: 'integer', editable: false },
                 { name: 'CONTAINERS', label: 'Containers', cell: 'integer', editable: false },
-                // { name: 'DCS', label: '# DCs', cell: 'string', editable: false },
             ]
         
             if (app.mobile()) {

--- a/client/src/js/templates/shipment/dewarstats.html
+++ b/client/src/js/templates/shipment/dewarstats.html
@@ -8,7 +8,6 @@
 
 <div class="filter">
     <ul>
-        <li><label><input type="checkbox" name="data" value="1" /> With Data</label></li>
         <li><label><input type="checkbox" name="hist" value="1" /> With Dewar History (>1)</label></li>
     </ul>
 </div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-995](https://jira.diamond.ac.uk/browse/LIMS-995)

**Summary**:

The shipment stats at https://ispyb.diamond.ac.uk/shipments/stats timeout after 1 minute. The slow joins are to BLSample and DataCollection, which are only needed if the 'With Data' tickbox is turned on.

**Changes**:
- Remove 'With Data' checkbox and associated code
- Remove joins to BLSample and DataCollection
- Remove non-functional search boxes

**To test**:
- Go to /shipments/stats, check the page loads, with a graph and 2 tables
- Check there is no 'With Data' checkbox, and no search boxes on any tables
- Check the 'With Dewar History' checkbox still works
