### PR TITLE
LIMS-1663: Per-page dropdown on multicrystal processing page doesnt work

### DIFF
--- a/client/src/js/modules/mc/routes.js
+++ b/client/src/js/modules/mc/routes.js
@@ -18,7 +18,6 @@ const routes = [
                         visit: route.params.visit, 
                         s: route.params.search, 
                         t: 'fc',
-                        per_page: app.mobile() ? 5 : 15, // Was 16 in mc but assume that's error - normally 15
                     },
                     state: { currentPage: route.params.page ? parseInt(route.params.page) : 1}
                 }),

--- a/client/src/js/templates/mc/datacollections.html
+++ b/client/src/js/templates/mc/datacollections.html
@@ -4,7 +4,6 @@
     <p class="help">Select data sets to integrate by dragging across the per-image analysis plot below. This selects which images of the data set to integrate.</p>
 
     <div class="filter filter-nohide">
-    	<div class="srch"></div>
         <ul class="clearfix">
             <li><span class="wait">-</span> job(s) waiting</li>
             <li><span class="jobs">-</span> job(s) running</li>
@@ -12,6 +11,8 @@
     </div>
 
     <div class="rps"></div>
+
+    <div class="srch"></div>
 
     <div class="cell data_collection">
         <div class="autoproc">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1663](https://jira.diamond.ac.uk/browse/LIMS-1663)

**Summary**:

If you go to eg https://ispyb.diamond.ac.uk/mc/visit/mx23694-130, there are many pages of data collections at the bottom. But the Per Page dropdown doesn't work, it always shows 15 per page.

**Changes**:
- Remove the fixed number of data collections shown per page, allowing the dropdown to work as expected
- Move the search bar down to just above the data collections as this is what it searches

**To test**:
- Go to /mc/visit/mx23694-130
- Check you can adjust the number of data collections shown in the lower half of the page by changing the dropdown
- Check the search bar now appears in the bar with "Pipeline", "Spacegroup" etc, and that the search works on data collections in the lower half of the page
