### PR TITLE
LIMS-1637: Show more info for grid scan groups

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -562,7 +562,7 @@ class DC extends Page
                     min(dc.axisrange) as axisrange,
                     min(dc.wavelength) as wavelength,
                     ".self::EVTOA."/min(dc.wavelength) as energy,
-                    min(dc.comments) as comments,
+                    ifnull(dcg.comments, (select mindc.comments from datacollection mindc where mindc.datacollectionid=min(dc.datacollectionid))) as comments,
                     1 as epk,
                     1 as ein,
                     1 as wpk,
@@ -1461,12 +1461,14 @@ class DC extends Page
     # Grid Scan Info
     function _grid_info()
     {
-        $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, IFNULL(g.micronsperpixelx,g.pixelspermicronx) as micronsperpixelx, IFNULL(g.micronsperpixely,g.pixelspermicrony) as micronsperpixely, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d') as startdate, xrc.status as xrcstatus, xrcr.xraycentringresultid
+        $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid, dc.axisstart, p.posx as x, p.posy as y, p.posz as z, g.dx_mm, g.dy_mm, g.steps_x, g.steps_y, g2.steps_y as steps_z, IFNULL(g.micronsperpixelx,g.pixelspermicronx) as micronsperpixelx, IFNULL(g.micronsperpixely,g.pixelspermicrony) as micronsperpixely, g.snapshot_offsetxpixel, g.snapshot_offsetypixel, g.orientation, g.snaked, DATE_FORMAT(dc.starttime, '%Y%m%d') as startdate, xrc.status as xrcstatus, xrcr.xraycentringresultid
                 FROM gridinfo g
                 INNER JOIN datacollection dc on (dc.datacollectionid = g.datacollectionid) or (dc.datacollectiongroupid = g.datacollectiongroupid)
                 LEFT OUTER JOIN position p ON dc.positionid = p.positionid
                 LEFT OUTER JOIN xraycentring xrc ON dc.datacollectiongroupid = xrc.datacollectiongroupid
                 LEFT OUTER JOIN xraycentringresult xrcr ON xrc.xraycentringid = xrcr.xraycentringid
+                LEFT OUTER JOIN datacollection d2 ON (dc.datacollectiongroupid = d2.datacollectiongroupid AND dc.datacollectionid != d2.datacollectionid)
+                LEFT OUTER JOIN gridinfo g2 ON (d2.datacollectionid = g2.datacollectionid)
                 WHERE dc.datacollectionid = :1 ", array($this->arg('id')));
 
         if (!sizeof($info))
@@ -1500,7 +1502,8 @@ class DC extends Page
     {
         $info = $this->db->pq("SELECT dc.datacollectiongroupid, dc.datacollectionid,
                 xrc.xraycentringtype as method, xrcr.xraycentringresultid,
-                xrcr.centreofmassx as x, xrcr.centreofmassy as y, xrcr.centreofmassz as z
+                xrcr.centreofmassx as x, xrcr.centreofmassy as y, xrcr.centreofmassz as z,
+                xrcr.totalcount
                 FROM datacollection dc
                 INNER JOIN xraycentring xrc ON xrc.datacollectiongroupid = dc.datacollectiongroupid
                 INNER JOIN xraycentringresult xrcr ON xrcr.xraycentringid = xrc.xraycentringid

--- a/client/src/js/modules/dc/views/grid.js
+++ b/client/src/js/modules/dc/views/grid.js
@@ -41,6 +41,7 @@ define(['marionette',
       warningli: '.warning-li',
 
       holder: '.holder h1',
+      gridsize: '.gridsize',
     },
 
     toggleZoom: function(e) {
@@ -120,6 +121,9 @@ define(['marionette',
         if (this.ui.bx.text) this.ui.by.text((gi.get('DY_MM')*1000).toFixed(0))
 
         if (gi.get('STEPS_Y') > 10 && this.ui.zoom.show) this.ui.zoom.show()
+        var gridsize = gi.get('STEPS_X') + ' x ' + gi.get('STEPS_Y')
+        if (gi.get('STEPS_Z')) { gridsize += ' x ' + gi.get('STEPS_Z') }
+        this.ui.gridsize.html(gridsize)
     },
 
     checkXRC: function() {
@@ -144,7 +148,7 @@ define(['marionette',
         var xrcs = this.xrc.get('data')
         var t = ''
         for (var i = 0; i < xrcs.length; i++) {
-            t += ' - Crystal '+(i+1)+': X Pos '+xrcs[i]['X']+' Y Pos '+xrcs[i]['Y']+' Z Pos '+xrcs[i]['Z']
+            t += ' - Crystal '+(i+1)+': X Pos '+xrcs[i]['X']+' Y Pos '+xrcs[i]['Y']+' Z Pos '+xrcs[i]['Z']+' Strength '+xrcs[i]['TOTALCOUNT']
         }
         if (xrcs.length > 0) {
             this.ui.holder.prepend('Method: '+xrcs[0]['METHOD']+t)

--- a/client/src/js/templates/dc/grid.html
+++ b/client/src/js/templates/dc/grid.html
@@ -13,6 +13,7 @@
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         <li>Boxsize: <span class="boxx"></span>x<span class="boxy"></span>&mu;m</li>
+        <li>Grid scan size: <span class="gridsize"></span></li>
         <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <span class="b">Stopped</span></li><% } %>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1637](https://jira.diamond.ac.uk/browse/LIMS-1637)

**Summary**:

If displaying a group of grid scans (eg Mesh3d experiment type), we should show some more info.

**Changes**:
- Show the data collection group comment if one exists, otherwise show the comment from the first grid scan, not the first comment alphabetically
- Show the `totalCount` of each xray centring result as 'Strength', as well as x/y/z positions
- Show the grid size for all grid scans, including the 3rd dimension for 3d grid scans

**To test**:
- Go to a visit with grid scans, eg /dc/visit/mx23694-130/ty/gr
- Check the first grid scan (from 2025-02-26 17:13:55) shows the data collection group comment ("This is a data collection group comment")
- Check the 3rd grid scan (from 2025-02-25 15:10:31) has a long comment, which comes from the first grid scan (/dc/visit/mx23694-130/id/17165788), not the short comment from the second grid scan (/dc/visit/mx23694-130/id/17165791)
- Check each result in the results bar shows X Pos, Y Pos, Z Pos, and Strength, eg `Method: 3d - Crystal 1: X Pos 34.97 Y Pos 12.94 Z Pos 14.86 Strength 519201`
- Check each 3d grid scan group shows the grid scan size in 3 dimensions, eg `102 x 22 x 22`
- Check each single grid scan shows the grid scan size in 2 dimensions eg `1 x 80`
