### PR TITLE
LIMS-1665: Don't allow multiple groups with the same name

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -2697,23 +2697,22 @@ class Sample extends Page
         if (!$this->has_arg('prop'))
             $this->_error('No proposal specified');
 
-        $sgid = $this->_create_sample_group();
+        $name = $this->has_arg('NAME') ? $this->arg('NAME') : NULL;
 
-        $this->_output($sgid);
+        $sg = $this->db->pq("SELECT blsg.blsamplegroupid
+            FROM blsamplegroup blsg
+            WHERE blsg.name=:1 and blsg.proposalid=:2", array($name, $this->proposalid));
+        if (sizeof($sg)) $this->_error('The specified sample group name already exists');
+
+        $this->db->pq("INSERT INTO blsamplegroup (blsamplegroupid, name, proposalid, ownerid) VALUES(NULL, :1, :2, :3)",
+            array($name, $this->proposalid, $this->user->personId));
+        $sgid = $this->db->id();
 
         $this->_output(array(
             'BLSAMPLEGROUPID' => $sgid,
-            'NAME' => $this->has_arg('NAME') ? $this->arg('NAME') : NULL,
+            'NAME' => $name,
             'SAMPLEGROUPSAMPLES' => 0
         ));
-    }
-
-    function _create_sample_group()
-    {
-        $name = $this->has_arg('NAME') ? $this->arg('NAME') : NULL;
-        $this->db->pq("INSERT INTO blsamplegroup (blsamplegroupid, name, proposalid, ownerid) VALUES(NULL, :1, :2, :3)",
-            array($name, $this->proposalid, $this->user->personId));
-        return $this->db->id();
     }
 
     function _get_sample_groups_by_sample()
@@ -2721,14 +2720,11 @@ class Sample extends Page
         if (!$this->has_arg('prop'))
             $this->_error('No proposal specified');
 
-        $where = 'bsg.proposalid = :1';
-        $args = array($this->proposalid);
-
         if (!$this->has_arg('BLSAMPLEID'))
             $this->_error('No sample specified');
 
-        $where .= ' AND b.blsampleid = :2';
-        array_push($args, $this->arg('BLSAMPLEID'));
+        $where = 'bsg.proposalid = :1 AND b.blsampleid = :2';
+        $args = array($this->proposalid, $this->arg('BLSAMPLEID'));
 
         $tot = $this->db->pq("SELECT count(*) as total
                 FROM blsamplegroup bsg

--- a/client/src/js/app/store/store.js
+++ b/client/src/js/app/store/store.js
@@ -233,9 +233,9 @@ const store = new Vuex.Store({
             resolve(result)
           },
 
-          error: function(err) {
-            let response = err.responseJSON || {status: 400, message: 'Error saving model'}
-            reject(response)
+          error: function(model, response) {
+            let err = response.responseJSON || {status: 400, message: 'Error saving model'}
+            reject(err)
           },
         })
       })

--- a/client/src/js/modules/samples/components/sample-group-create-and-edit.vue
+++ b/client/src/js/modules/samples/components/sample-group-create-and-edit.vue
@@ -343,9 +343,13 @@ export default {
           attributes
         })
 
-        const { BLSAMPLEGROUPID } = result.toJSON()
+        if (result) {
+          const { BLSAMPLEGROUPID } = result.toJSON()
+          this.sampleGroupId = BLSAMPLEGROUPID
+          let message = 'Created sample group ' + this.groupName
+          this.$store.commit('notifications/addNotification', { title: 'Success', message: message, level: 'success' })
+        }
 
-        this.sampleGroupId = BLSAMPLEGROUPID
       }
     },
     addSelectedCells(cellsLocation) {

--- a/client/src/js/modules/types/mx/samples/sample-table-mixin.js
+++ b/client/src/js/modules/types/mx/samples/sample-table-mixin.js
@@ -292,7 +292,12 @@ export default {
     async createNewSampleGroup(value) {
       this.$emit('update-sample-group-input-disabled', true)
       const sampleGroupModel = new SampleGroup({ NAME: value })
-      await this.$store.dispatch('saveModel', { model: sampleGroupModel })
+      const result = await this.$store.dispatch('saveModel', { model: sampleGroupModel })
+      if (result) {
+        const { NAME } = result.toJSON()
+        let message = 'Created sample group ' + NAME
+        this.$store.commit('notifications/addNotification', { title: 'Success', message: message, level: 'success' })
+      }
       this.$emit('update-sample-group-list')
     },
     canEditRow(location, editingRow) {

--- a/client/src/js/modules/types/mx/samples/sample-table-mixin.js
+++ b/client/src/js/modules/types/mx/samples/sample-table-mixin.js
@@ -300,7 +300,7 @@ export default {
       }
       if (result) {
         const { NAME } = result.toJSON()
-        let message = 'Created sample group ' + NAME
+        const message = 'Created sample group ' + NAME
         this.$store.commit('notifications/addNotification', { title: 'Success', message: message, level: 'success' })
       }
       this.$emit('update-sample-group-list')

--- a/client/src/js/modules/types/mx/samples/sample-table-mixin.js
+++ b/client/src/js/modules/types/mx/samples/sample-table-mixin.js
@@ -292,7 +292,12 @@ export default {
     async createNewSampleGroup(value) {
       this.$emit('update-sample-group-input-disabled', true)
       const sampleGroupModel = new SampleGroup({ NAME: value })
-      const result = await this.$store.dispatch('saveModel', { model: sampleGroupModel })
+      let result;
+      try {
+        result = await this.$store.dispatch('saveModel', { model: sampleGroupModel })
+      } catch (err) {
+        this.$store.commit('notifications/addNotification', { title: 'Error', message: err.message, level: 'error' })
+      }
       if (result) {
         const { NAME } = result.toJSON()
         let message = 'Created sample group ' + NAME


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1665](https://jira.diamond.ac.uk/browse/LIMS-1665)

**Summary**:

Users need to create sample groups when setting up samples for UDC. The 'create container' screen does not indicate when this has succeeded and allows for multiple groups of the same name to be created. These groups are distinct, but indistinguishable for the user. This is causing confusion.

Sample groups should be uniquely named within a proposal and users should receive confirmation when a group is created successfully from the create container page.

**Changes**:
- Add a check that the sample group name is unique within the proposal
- Tidy the `_get_sample_groups_by_sample` function
- Fix bug where error messages were not passed through correctly
- Add success notifications for sample group creation, both from Create Container and Create New Sample Group pages

**To test**:
- Go to a proposal with existing sample groups, eg mx23694
- Go to Sample Groups, then click "Create Sample Group" (or go to /samples/group/new)
- Type a group name that already exists, eg `abcdef`, click Save Sample Group, check a red error message appears and no new sample group is created
- Type a different group name, click Save Sample Group, check a green success message appears and the sample group is created
- Select a shipment, a container and select at least one sample, type a different group name, click Save Sample Group, check 2 green success messages appear and the group is created with samples
- Go to a shipment and click Create Container (or just go to /containers/add/did/78301)
- Click the dropdown for Sample Group in one of the rows of the table. Type a name that already exists (eg `abcdef`), check there is no 'Create New' option. Type a different name, click 'Create New', check a green success message appears.
- Go to a container that already exists. Click the edit button on one of the samples. Type a new sample group name and click 'Create New'. Check a green message appears.
- Click 'Create New' again. Check a red error message appears. Go to the Sample Groups page, check only one group has been created.