### PR TITLE
LIMS-1639: List most common screens at the top of the list

### DIFF
--- a/api/src/Page/Imaging.php
+++ b/api/src/Page/Imaging.php
@@ -866,11 +866,12 @@ class Imaging extends Page
             array_push($args, $this->arg('scid'));
         }
 
-        $screens = $this->db->pq("SELECT ct.name as containertypeid, IFNULL(ct.capacity, 96) as capacity, CONCAT(p.proposalcode, p.proposalnumber) as prop, s.global, s.name, s.screenid, s.proposalid, count(distinct sg.screencomponentgroupid) as groups, count(distinct sc.screencomponentid) as components
+        $screens = $this->db->pq("SELECT ct.name as containertypeid, IFNULL(ct.capacity, 96) as capacity, CONCAT(p.proposalcode, p.proposalnumber) as prop, s.global, s.name, s.screenid, s.proposalid, count(distinct sg.screencomponentgroupid) as groups, count(distinct sc.screencomponentid) as components, COUNT(DISTINCT c.containerid) AS cnt
               FROM screen s
               LEFT OUTER JOIN screencomponentgroup sg ON sg.screenid = s.screenid
               LEFT OUTER JOIN screencomponent sc ON sc.screencomponentgroupid = sg.screencomponentgroupid
               LEFT OUTER JOIN containertype ct ON ct.containertypeid = s.containertypeid
+              LEFT OUTER JOIN container c ON c.screenId = s.screenid
               INNER JOIN proposal p ON p.proposalid = s.proposalid
               WHERE $where
               GROUP BY CONCAT(p.proposalcode, p.proposalnumber), s.global, s.name, s.screenid, s.proposalid", $args);

--- a/client/src/js/modules/types/mx/shipment/views/container-mixin.js
+++ b/client/src/js/modules/types/mx/shipment/views/container-mixin.js
@@ -194,7 +194,10 @@ export default {
       this.imagingScreensCollection = new ImagingScreens(null, { state: { pageSize: 9999 } })
 
       const result = await this.$store.dispatch('getCollection', this.imagingScreensCollection)
-      this.imagingScreens = [{ NAME: '-', SCREENID: '' }, ... result.toJSON()]
+      const originalData = result.toJSON()
+      const resultCopy = JSON.parse(JSON.stringify(originalData))
+      const top15 = resultCopy.sort((a, b) => Number(b.CNT) - Number(a.CNT)).slice(0, 15)
+      this.imagingScreens = [{ NAME: '---', SCREENID: '' }, ...top15, { NAME: '---', SCREENID: '' }, ...originalData]
     },
     async getImagingScheduleComponentsCollection() {
       this.imagingScheduleComponentsCollection = new ImagingScheduleComponents(null, { state: { pageSize: 9999 } })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1639](https://jira.diamond.ac.uk/browse/LIMS-1639)

**Summary**:

When making a new plate, you select the crystallisation screen from a dropdown list. This is currently sorted alphabetically. It would be good to put the most common 15 screens at the top of the list.

**Changes**:
- Get the container count for each screen
- Duplicate the top 15 in order, add them to the top of the list, with a separator

**To test**:
- Log in to any proposal, go to a shipment, click "Add Container"
- Switch the Container Type to a plate, eg CrystalQuickX
- Check the Crystallisation Screen dropdown has 15 items not in alphabetical order, then the full list in alphabetical order. Check the top 15 are duplicated.
- Go to /imaging/screen, check the screens are still in alphabetical order
