### PR TITLE
LIMS-1447: Don't allow shipping of red samples

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -58,6 +58,7 @@ class Proposal extends Page
         'BEAMLINESETUPID' => '\d+',
         'BEAMCALENDARID' => '\d+',
         'VISITNUMBER' => '\d+',
+        'RISKRATING' => '\w+',
 
         // visit has person
         'SHPKEY' => '\d+\-\d+',
@@ -404,6 +405,16 @@ class Proposal extends Page
 
         if ($this->has_arg('scheduled')) {
             $where .= " AND s.scheduled=1";
+        }
+
+        if ($this->has_arg('RISKRATING')) {
+            if ($this->arg('RISKRATING') == 'high') {
+                $where .= " AND s.riskrating = 'high'";
+            } else if ($this->arg('RISKRATING') == 'medium') {
+                $where .= " AND s.riskrating in ('high', 'medium')";
+            } else if ($this->arg('RISKRATING') == 'low') {
+                $where .= " AND s.riskrating in ('high', 'medium', 'low')";
+            }
         }
 
         if ($visit) {

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -77,6 +77,7 @@ define(['marionette', 'views/form',
             responsive: '#responsive',
             imaging: '#imaging',
             existing: '#existingsession',
+            nosessions: '#nosessions',
             other: '#other',
             safetylevel: 'select[name=SAFETYLEVEL]',
             longwavelengthsel: 'select[name=LONGWAVELENGTH]',
@@ -122,11 +123,17 @@ define(['marionette', 'views/form',
                 this.ui.other.prop('checked', false)
                 this.updateDynamicSchedule()
             }
+            this.visits.fetch().done(this.updateFirstExp.bind(this))
         },
 
         updateFirstExp: function() {
             if (this.visits.length === 0) {
                 this.ui.existing.prop('disabled', true)
+                this.ui.existing.prop('checked', false)
+                this.ui.nosessions.html('(no suitable sessions found)')
+            } else {
+                this.ui.existing.prop('disabled', false)
+                this.ui.nosessions.html('')
             }
             if (this.ui.existing.is(':checked')) {
                 this.ui.first.show()
@@ -182,6 +189,11 @@ define(['marionette', 'views/form',
             }
         },
 
+        getRiskRating: function() {
+            if (this.ui.safetylevel.val() === 'Yellow') return 'medium'
+            if (this.ui.safetylevel.val() === 'Red') return 'high'
+        },
+
         onRender: function() {
             var self = this
 
@@ -194,6 +206,7 @@ define(['marionette', 'views/form',
             this.refreshContacts()
             
             this.visits = new Visits(null, { queryParams: { next: 1 }, state: { pageSize: 9999 } })
+            this.visits.queryParams.RISKRATING = this.getRiskRating.bind(this)
             this.visits.fetch().done(this.updateFirstExp.bind(this))
             
             this.date('input[name=DELIVERYAGENT_SHIPPINGDATE], input[name=DELIVERYAGENT_DELIVERYDATE]')

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -6,6 +6,8 @@
     <% if (DHL_ENABLE) { %>
         <% if (DELIVERYAGENT_HAS_LABEL == '1') { %>
             <p class="message notify">You can print your Air Waybill by clicking &quot;Print Air Waybill&quot; below</p>
+        <% } else if (SAFETYLEVEL == "Red") { %>
+            <p class="message alert">Shipping of <%- SAFETYLEVEL.toLowerCase() %> samples is not available through this application.
         <% } else if (COUNTRY && FACILITY_COURIER_COUNTRIES_NDE.includes(COUNTRY) ) { %>
             <p class="message alert">International shipping is not available through this application. If you're arranging your own shipping (e.g. industrial users), enter your tracking numbers below after booking and include printed return labels in the dewar case. European academic users, please see <a href="<%-FACILITY_COURIER_COUNTRIES_LINK%>">here</a>.</p>
         <% } else if (COUNTRY && !FACILITY_COURIER_COUNTRIES.includes(COUNTRY) ) { %>
@@ -28,7 +30,7 @@
             <% if (!DELIVERYAGENT_PICKUPCONFIRMATION) { %>
                 <a class="button awb" href="/shipments/pickup/sid/<%-SHIPPINGID%>"><i class="fa fa-truck"></i> Rebook Pickup</a>
             <% } %>
-        <% } else if (COUNTRY && COUNTRY !="United Kingdom" ) { %>
+        <% } else if ((COUNTRY && !FACILITY_COURIER_COUNTRIES.includes(COUNTRY)) || SAFETYLEVEL == "Red") { %>
             <a class="button" href="#"><i class="fa fa-credit-card"></i> Create Air Waybill - Disabled</a>
         <% } else if (EXTERNALSHIPPINGIDTOSYNCHROTRON && app.options.get("shipping_service_app_url_incoming")) { %>
             <% const link = `${app.options.get('shipping_service_app_url_incoming')}/shipment-requests/${EXTERNALSHIPPINGIDTOSYNCHROTRON}/incoming` %>

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -52,7 +52,7 @@
                 <div>
                     <label class="secondary tw-mr-2">
                         <input type="radio" name="DYNAMIC" value="No" id="existingsession" data-testid="add-shipment-existing-session">
-                        I have a session already scheduled
+                        I have a session already scheduled<span id="nosessions"></span>
                     </label>
                     <select class="tw-h-6 tw-mr-2" name="FIRSTEXPERIMENTID" data-testid="add-shipment-experiment"></select><br />
                     <label class="secondary tw-mr-2">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1447](https://jira.diamond.ac.uk/browse/LIMS-1447)

**Summary**:

Users should not be allowed to ship red samples/shipments through Synchweb. Also, red shipments should already have a red session scheduled (and the same for yellow).

**Changes**:
- Disable the "Create Air Waybill" button if the shipment is rated red.
- If a shipment is being created and is rated as not green, only show suitable sessions, also show a message if no sessions are found

**To test**:
- Find a proposal with an upcoming yellow session, the calendar is good for this
- Go to that proposal and start creating a shipment
- Set the shipment as Green, you should be able to select any option for the "Scheduling" question. Choose "I have a session already scheduled", and check a dropdown appears showing all current and future visits
- Change the shipment to Yellow, check the dropdown now only shows the upcoming yellow visit
- Change the shipment to Red, check the dropdown disappears and a message says "(no suitable sessions found)"
- Change the shipment back to green and finish making the shipment, no containers are necessary.
- View the shipment, check the "Create Air Waybill" button is enabled
- Change= the shipment to Red, refresh the page, check the "Create Air Waybill" button is now disabled, with a message at the top.
