### PR TITLE
LIMS-1702: Rename Archive button to Download Zip

### DIFF
--- a/client/src/js/modules/dc/components/auto-processing-job-details.vue
+++ b/client/src/js/modules/dc/components/auto-processing-job-details.vue
@@ -30,8 +30,8 @@
 <!--      <p v-if="selectedProcessingProgram['IMAGESWEEPCOUNT'] > 1" class="tw-text-link-color">{{ selectedProcessingProgram['IMAGESWEEPCOUNT'] }} image sweeps</p>-->
       <router-link v-if="selectedProcessingProgram['DCCOUNT'] > 1" :to="`/dc/pjid/${selectedProcessingProgram['PROCESSINGJOBID']}`" class="button tw-mx-1 tw-text-link-color"><span><i class="fa fa-list"></i></span> {{ selectedProcessingProgram['DCCOUNT'] }} Data Sets</router-link>
 <!--      <button class="button tw-mx-1 tw-text-link-color"><span><i class="fa fa-line-chart"></i></span> Plots</button>-->
-<!--      <router-link :to="`${apiUrl}/download/ap/archive/${selectedProcessingProgram['AID']}`" class="button tw-mx-1"><span><i class="fa fa-archive"></i></span> Archive</router-link>-->
 <!--      <button class="button tw-mx-1 tw-text-link-color"><span><i class="fa fa-files-o"></i></span> Logs &amp; Files</button>-->
+<!--      <router-link :to="`${apiUrl}/download/ap/archive/${selectedProcessingProgram['AID']}`" class="button tw-mx-1"><span><i class="fa fa-cloud-download"></i></span> Download Zip</router-link>-->
 <!--      <button v-if="selectedProcessingProgram['TYPE'] === 'fast_dp'" class="button tw-text-link-color"><span><i class="fa fa-search"></i></span> Radiation Damage</button>-->
 <!--      <router-link class="button tw-mx-1" title="Lookup Unit Cell" :to="lookUpUrl"><span></span><i class="fa fa-search"></i> Lookup Cell</router-link>-->
     </div>

--- a/client/src/js/modules/dc/views/downstreamwrapper.js
+++ b/client/src/js/modules/dc/views/downstreamwrapper.js
@@ -74,8 +74,8 @@ define(['backbone', 'marionette',
             if (this.getOption('links')) {
                 var links = [
                     '<a class="view button" href="/dc/map/id/'+this.getOption('DCID')+'/aid/'+this.model.get('AID')+'"><i class="fa fa-search"></i> Map / Model Viewer</a>',
-                    '<a class="dll button" href="'+app.apiurl+'/download/ap/archive/'+this.model.get('AID')+'"><i class="fa fa-archive"></i> Archive</a>',
-                    '<a class="pattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>'
+                    '<a class="pattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>',
+                    '<a class="dll button" href="'+app.apiurl+'/download/ap/archive/'+this.model.get('AID')+'"><i class="fa fa-cloud-download"></i> Download Zip</a>',
                 ]
 
                 if (!this.getOption('mapLink')) {

--- a/client/src/js/templates/dc/dc_autoproc.html
+++ b/client/src/js/templates/dc/dc_autoproc.html
@@ -4,8 +4,8 @@
     <% if (PROCESSINGSTATUS == 0) { %>
 
     <p class="r downloads">
-        <a class="view button dll" href="<%-APIURL%>/download/id/<%-DCID%>/aid/<%-AID%>/archive/1"><i class="fa fa-archive"></i> Archive</a>
         <a class="apattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
+        <a class="view button dll" href="<%-APIURL%>/download/ap/archive/<%-AID%>"><i class="fa fa-cloud-download"></i> Download Zip</a>
     </p>
 
     <p>This processing job failed: <%-PROCESSINGMESSAGE%></p>
@@ -24,8 +24,8 @@
 
         <a class="mainlog button dll" href="<%-APIURL%>/download/ap/log/<%-AID%>"><i class="fa fa-file"></i> Processing Log</a>
         <a class="plot button" href="#"><i class="fa fa-line-chart"></i> Plots</a>
-        <a class="view button dll" href="<%-APIURL%>/download/ap/archive/<%-AID%>"><i class="fa fa-archive"></i> Archive</a>
         <a class="apattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
+        <a class="view button dll" href="<%-APIURL%>/download/ap/archive/<%-AID%>"><i class="fa fa-cloud-download"></i> Download Zip</a>
     
         <% if (TYPE == 'fast_dp') { %>
         <a href="#" class="button view rd"><i class="fa fa-search"></i> Radiation Damage</a>

--- a/client/src/js/templates/dc/downstreamerror.html
+++ b/client/src/js/templates/dc/downstreamerror.html
@@ -1,6 +1,6 @@
 <p class="r downloads">
-    <a class="view button dll" href="<%-APIURL%>/download/archive/<%-AID%>"><i class="fa fa-archive"></i> Archive</a>
     <a class="pattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
+    <a class="view button dll" href="<%-APIURL%>/download/ap/archive/<%-AID%>"><i class="fa fa-cloud-download"></i> Download Zip</a>
 </p>
 
 <p>This processing job failed: <%-PROCESS.PROCESSINGMESSAGE%></p>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1702](https://jira.diamond.ac.uk/browse/LIMS-1702)

**Summary**:

The "Archive" button on each data processing job should be changed to say "Download Zip", as it might be confused with the iCat archive. We should also change the icon to match, and swap positions with the "Logs and Files" button, so the default behaviour is to download individual files.

The "Archive" button is in the code in 5 places, but one is commented out (which would be on the Sample Groups page). The other 4 are:
* Auto processing success
* Auto processing failure
* Downstream processing success
* Downstream processing failure

**Changes**:
- Change 'Archive' to 'Download Zip' in all places, and icon to cloud-download
- Swap places with 'Logs & Files' button
- Fix download link for auto processing failures and downstream processing failures

**To test**:
- Go to a visit that has data processing successes and failures, eg /dc/visit/mx23694-135/ty/fc
- Find an auto processing success, expand the bar and check there is a "Download Zip" button, with a cloud icon, and that the download works
- Repeat for an auto processing failure
- Repeat for a downstream processing success
- Repeat for a downstream processing failure