### PR TITLE
LIMS-1719: Fix data collection comments button

### DIFF
--- a/client/src/js/modules/dc/models/dccomment.js
+++ b/client/src/js/modules/dc/models/dccomment.js
@@ -22,7 +22,7 @@ define(['backbone', 'markdown'], function(Backbone, markdown) {
 
 
     initialize: function(attrs, options) {
-      this.on('change', this.addDate, this)
+      this.listenTo(this, 'change:CREATETIME change:MODTIME change:COMMENTS', this.addDate)
       this.addDate()
     },
       


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1719](https://jira.diamond.ac.uk/browse/LIMS-1719)

**Summary**:

The data collection comments button causes an endless JS loop and will crash the browser tab

**Changes**:
- Only trigger the addDate function if a new comment is added. Previously the addDate function would trigger itself.

**To test**:
- Log in to any visit, press the little speech mark icon (with the tool tip "Comments"). Check a dialog opens showing any existing data collection comments.
- Add a new comment, check it remains after a refresh.