### PR TITLE
LIMS-1713: Allow sm beamlines to use mx Create Container page

### DIFF
--- a/client/src/js/modules/shipment/components/container-add-wrapper.vue
+++ b/client/src/js/modules/shipment/components/container-add-wrapper.vue
@@ -101,6 +101,7 @@ export default {
                 if (!this.mview) {
                     const newAddContainers = {
                         mx: 'mx-container-add',
+                        sm: 'mx-container-add',
                     }
 
                     this.componentType = newAddContainers[this.proposalType]

--- a/client/src/js/modules/shipment/components/container-map.js
+++ b/client/src/js/modules/shipment/components/container-map.js
@@ -16,6 +16,7 @@ export const ContainerListMap = {
 // We assign null to the view property because we want to use new components
 export const ContainerViewMap = {
   mx:     { title: 'Container', view: null },
+  sm:     { title: 'Container', view: null },
   xpdf:   { title: 'Container', view: XpdfContainerView },
   default:{ title: 'Container', view: ContainerView }
 }
@@ -29,6 +30,8 @@ export const ContainerPlateViewMap = {
 export const ContainerAddMap = {
     xpdf:   { title: 'Container', view: XpdfContainerAddView },
     default:{ title: 'Container', view: ContainerAddView },
+    sm: { title: 'Container', view: null },
     mx: { title: 'Container', view: null }
+
 }
 

--- a/client/src/js/modules/shipment/components/container-view-wrapper.vue
+++ b/client/src/js/modules/shipment/components/container-view-wrapper.vue
@@ -101,6 +101,7 @@ export default {
         if (!this.mview) {
           const newViewContainers = {
             mx: 'mx-container-view',
+            sm: 'mx-container-view',
           }
 
           this.componentType = newViewContainers[this.proposalType]


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1713](https://jira.diamond.ac.uk/browse/LIMS-1713)

**Summary**:

I19 is the only small molecule ('sm') beamline at Diamond, and they would rather use the 'mx' Create Container and View Container pages, as we sometimes break their versions.

**Changes**:
- Add sm to the container maps and point them the same as mx

**To test**:
- Check you have something like this in your config:
```
$bl_types = array(
    array('name' => 'i03', 'group' => 'mx', 'logbook' => 'BLI03' ),
    array('name' => 'i04', 'group' => 'mx', 'logbook' => 'BLI04' ),
    array('name' => 'i04-1', 'group' => 'mx', 'logbook' => 'BLI04J' ),
    array('name' => 'i23', 'group' => 'mx', 'logbook' => 'BLI23' ),
    array('name' => 'i24', 'group' => 'mx', 'logbook' => 'BLI24' ),
    array('name' => 'i22', 'group' => 'saxs', 'logbook' => 'BLI22' ),
    array('name' => 'i19', 'group' => 'sm', 'logbook' => 'BLI19' ),
    array('name' => 'i19-1', 'group' => 'sm' ),
    array('name' => 'i19-2', 'group' => 'sm' ),
    array('name' => 'i15', 'group' => 'xpdf', 'logbook' => 'BLI15' ),
    array('name' => 'i15-1', 'group' => 'xpdf' ),
);
```
- Go to an i19-1 proposal, eg cm40638, go to a shipment and click Add Container. Check you get directed to the MX view with 3 tabs (Basic, Extra Fields and UDC).
- Create the puck and then click to view it. Check all the samples are displayed and any parameters you filled in are also displayed. Check you can edit the samples.
- Repeat the test for an mx proposal eg mx23694
- Repeat the test for an xpdf proposal eg cm40633, check you still get redirected to the "Add new Sample Stage" page
- Repeat the test for a saxs proposal eg cm40643, check you still get redirected to the old "Add new container" page with no tabs.
