### PR TITLE
[LIMS-1636] Make LDAP server ID field configurable

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -40,6 +40,8 @@
     # CAS CA Cert (for SSO)
     $cacert = '/etc/certs/ca-bundle.crt';
 
+    # Field to get user ID from in LDAP
+    $ldap_id_field = "cn";
     # ldap server, used for lookup and authentication (if using, set to null if not)
     # Update the ldap(s) prefix, hostname and search settings as required
     $ldap_server = 'ldaps://ldap.example.com';

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -758,7 +758,7 @@ class Page
      */
     function _get_name($fedid)
     {
-        $src = $this->_ldap_search('uid=' . $fedid);
+        $src = $this->_ldap_search($ldap_id_field . '=' . $fedid);
         return array_key_exists($fedid, $src) ? $src[$fedid] : '';
     }
 
@@ -770,7 +770,7 @@ class Page
      */
     function _get_email($fedid)
     {
-        $src = $this->_ldap_search('uid=' . $fedid, True);
+        $src = $this->_ldap_search($ldap_id_field . '=' . $fedid, True);
         return array_key_exists($fedid, $src) ? $src[$fedid] : $fedid;
     }
 
@@ -853,7 +853,7 @@ class Page
      * Search LDAP for name or email
      *
      * @param boolean $email Search for an email adddress if true, search for name if false
-     * @param string $search ldap query, typically uid=fedid or name search
+     * @param string $search ldap query, typically cn=fedid or name search
      * @return array Returns array of results, either fedid=>emailAddresses or fedid=>"givenname sn" from ldap records
      */
     function _ldap_search($search, $email = False)
@@ -881,7 +881,7 @@ class Page
             {
                 // Strictly speaking we could set anything as the key here, since only the first record is used in e.g. _get_email_fn
                 // But as the logic maps fedid=>email, use similar keys here
-                $fedid = $info[$i]['uid'][0];
+                $fedid = $info[$i][$ldap_id_field][0];
                 if ($email)
                 {
                     $ret[$fedid] = array_key_exists('mail', $info[$i]) ? $info[$i]['mail'][0] : '';

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -758,6 +758,8 @@ class Page
      */
     function _get_name($fedid)
     {
+        global $ldap_id_field;
+
         $src = $this->_ldap_search($ldap_id_field . '=' . $fedid);
         return array_key_exists($fedid, $src) ? $src[$fedid] : '';
     }
@@ -770,6 +772,8 @@ class Page
      */
     function _get_email($fedid)
     {
+        global $ldap_id_field;
+
         $src = $this->_ldap_search($ldap_id_field . '=' . $fedid, True);
         return array_key_exists($fedid, $src) ? $src[$fedid] : $fedid;
     }
@@ -858,7 +862,7 @@ class Page
      */
     function _ldap_search($search, $email = False)
     {
-        global $ldap_server, $ldap_search;
+        global $ldap_server, $ldap_search, $ldap_id_field;
 
         $ret = array();
         if (is_null($ldap_server)) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1636](https://jira.diamond.ac.uk/browse/LIMS-1636)

**Summary**:

This PR allows users to configure which field is used to get the user ID from in LDAP, to make it easier to switch between LDAP providers.

**Changes**:
- Add `ldap_id_field` configuration key

**To test**:
- Go to proposal `mx23694`, navigate to the shipments page, add a new shipment
- Click `transfer` on the dewar that was just created, check if the LC email is pre-populated
- Click `dispatch` for the same dewar, ensure the same is still true
- If you have dispatch/transfer emails set up, and you're set as one of the recipients, then you should be sent an email. If you are dumping emails to `email.txt`, then these emails should appear in there
- OPTIONAL: there is an unused function named `_get_name` to get names from LDAP, you can modify the code to call it and ensure it still works
