### PR TITLE
LIMS-1718: Display cluster info on multiplex jobs

### DIFF
--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -978,6 +978,7 @@ class Processing extends Page {
             (SELECT COUNT(api1.autoprocintegrationid) FROM autoprocintegration api1 WHERE api1.autoprocprogramid = app.autoprocprogramid) as imagesweepcount,
             app.processingstatus,
             app.processingmessage,
+            app.processingenvironment,
             count(distinct pjis.datacollectionid) as dccount,
             max(pjis.processingjobid) as processingjobid,
             (SELECT IFNULL(blsg.name, bls.name) FROM processingjobparameter pjp
@@ -1058,6 +1059,9 @@ class Processing extends Page {
                         }
                         if ($row['GROUPNAME']) {
                             $value .= ' ('.$row['GROUPNAME'].')';
+                        }
+                        if ($row['PROCESSINGENVIRONMENT'] && strpos($row['PROCESSINGENVIRONMENT'], 'cluster=') !== false) {
+                            $value .= ' ('.$row['PROCESSINGENVIRONMENT'].')';
                         }
                     }
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1718](https://jira.diamond.ac.uk/browse/LIMS-1718)

**Summary**:

We are now running extra multiplex jobs using clusters of data, and recording the cluster number in the AutoProcProgram.processingEnvironment column. We should display this info in the name of the job displayed.

(The cluster number cannot be stored in ProcessingJobParameters as all clusters are from the same processingJobId)

**Changes**:
- if the processingEnvironment starts with `cluster=`, display it as part of the job name

**To test**:
- Go to /dc/visit/nt37104-145/id/16755310, check some of the multiplex autoprocessing jobs have "cluster=0" or "cluster=1" as part of the job name