### PR TITLE
LIMS-1716: Multicrystal processing only shows one DC per group

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -37,6 +37,7 @@ class DC extends Page
         'PERSONID' => '\d+',
         'AUTOPROCPROGRAMMESSAGEID' => '\d+',
         'PROCESSINGJOBID' => '\d+',
+        'expandgroups' => '\d',
         'debug' => '\d',
         'sgid' => '\d+'
     );
@@ -381,7 +382,7 @@ class DC extends Page
         }
 
         # Set Count field
-        if ($this->has_arg('dcg') || $this->has_arg('PROCESSINGJOBID') || $this->has_arg('sgid')) {
+        if ($this->has_arg('dcg') || $this->has_arg('PROCESSINGJOBID') || $this->has_arg('sgid') || $this->has_arg('expandgroups')) {
             $count_field = 'dc.datacollectionid';
         } else {
             $count_field = 'distinct dc.datacollectiongroupid';
@@ -614,6 +615,9 @@ class DC extends Page
                     IFNULL(max(dc.rotationaxis), 'Omega') as rotationaxis,
                     dc.detector2theta";
             $groupby = "GROUP BY dc.datacollectiongroupid";
+            if ($this->has_arg('expandgroups')) {
+                $groupby = "GROUP BY dc.datacollectionid";
+            }
         }
 
         // We don't want to remove duplicates, since if two counts are equal, one might go uncounted

--- a/client/src/js/modules/mc/controller.js
+++ b/client/src/js/modules/mc/controller.js
@@ -11,7 +11,7 @@ define(['marionette',
         dcs:  function(visit, page, search) {
             app.loading()
             app.cookie(visit.split('-')[0])
-            var dcs = new DCs(null, { queryParams: { visit: visit, s: search, t: 'fc' } })
+            var dcs = new DCs(null, { queryParams: { visit: visit, s: search, t: 'fc', expandgroups: 1 } })
             dcs.setPageSize(app.mobile() ? 5 : 16)
 
             page = page ? parseInt(page) : 1

--- a/client/src/js/modules/mc/routes.js
+++ b/client/src/js/modules/mc/routes.js
@@ -18,6 +18,7 @@ const routes = [
                         visit: route.params.visit, 
                         s: route.params.search, 
                         t: 'fc',
+                        expandgroups: 1,
                     },
                     state: { currentPage: route.params.page ? parseInt(route.params.page) : 1}
                 }),


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1716](https://jira.diamond.ac.uk/browse/LIMS-1716)

**Summary**:

If you go to the multicrystal data processing page (eg /mc/visit/mx23694-136), it only shows the first data collection for any that are in a group. It should show all data collections.

**Changes**:
- Add a new `expandgroups` parameter
- Use that parameter to change the grouping on the select (and also on the counting)

**To test**:
- Go to a visit with data collection groups eg /dc/visit/mx23694-136, check groups still appear as one entry on the main page, with a link to the group ("Group: 2 Data Collections")
- Click the cog icon on any data collection, then click the "Multi Crystal" button to take you to eg /mc/visit/mx23694-136
- Check all data collections from groups are now shown separately (in the lower half of the page), eg 20250424-mp0701_9 and 20250424-mp0701_8 are shown separately
- Check you can click through the pages to the last data collection (ie that the count of data collections is correct)
