### PR TITLE
LIMS-1715: Clear sessionId from containers if a dewar transfer is requested

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -952,7 +952,7 @@ class Shipment extends Page
         // Remove sessionId from containers and unqueue any pucks, so it doesnt look like a finished UDC dewar
         $this->db->pq("UPDATE container set sessionid=NULL WHERE dewarid=:1", array($this->arg('DEWARID')));
         $this->db->pq("DELETE cq from containerqueue cq
-                        inner join container c ON c.containerid = cq.containerid
+                        INNER JOIN container c ON c.containerid = cq.containerid
                         WHERE dewarid=:1", array($this->arg('DEWARID')));
 
         if ($this->has_arg('NEXTVISIT')) {

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -949,6 +949,11 @@ class Shipment extends Page
 
         // Update dewar status to transfer-requested to keep consistent with history
         $this->db->pq("UPDATE dewar set dewarstatus='transfer-requested' WHERE dewarid=:1", array($this->arg('DEWARID')));
+        // Remove sessionId from containers and unqueue any pucks, so it doesnt look like a finished UDC dewar
+        $this->db->pq("UPDATE container set sessionid=NULL WHERE dewarid=:1", array($this->arg('DEWARID')));
+        $this->db->pq("DELETE cq from containerqueue cq
+                        inner join container c ON c.containerid = cq.containerid
+                        WHERE dewarid=:1", array($this->arg('DEWARID')));
 
         if ($this->has_arg('NEXTVISIT')) {
             $sessions = $this->db->pq(


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1715](https://jira.diamond.ac.uk/browse/LIMS-1715)

**Summary**:

If a user requests a dewar transfer, we should clear the sessionId from any pucks within it (ie UDC pucks). Otherwise it still looks like a UDC visit to our systems. Also need to delete any rows from ContainerQueue otherwise a new visit will be created the next time one of the pucks is scanned in.

**Changes**:
- Clear sessionId from any containers within a dewar that has a transfer requested
- Delete any rows from ContainerQueue for those containers as well

**To test**:
- Go into a proposal, and make a shipment with multiple pucks, and queue them for unattended data collection, check that rows are made in ContainerQueue
- Set a sessionId for those pucks manually in the database (to simulate the pucks being scanned onto a beamline), by eg
`update Container set sessionId=27551223 where dewarId=78301;`
- Go to the shipment page, and click Transfer, fill in the form and click Request Dewar Transfer
- Check the sessionId for each container is null, and the rows in ContainerQueue have been deleted
