### PR TITLE
LIMS-1758: Fix slowness with plates with lots of subsamples

### DIFF
--- a/client/src/js/modules/imaging/views/imageviewer.js
+++ b/client/src/js/modules/imaging/views/imageviewer.js
@@ -604,9 +604,11 @@ define(['marionette',
         },
         
         calcZoom: function() {
-            var min = this.ui.canvas.width() < this.ui.canvas.height() ? this.ui.canvas.width()/this.width : this.ui.canvas.height()/this.height
-            this.ui.zoom.slider('option', 'min', 100*min)
-            this.onZoomChange()
+            if (this.ui.zoom.hasClass('ui-slider')) {
+                var min = this.ui.canvas.width() < this.ui.canvas.height() ? this.ui.canvas.width()/this.width : this.ui.canvas.height()/this.height
+                this.ui.zoom.slider('option', 'min', 100*min)
+                this.onZoomChange()
+            }
         },
         
         clampOffsets: function() {

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -707,12 +707,19 @@ define(['marionette',
                 self.ui.applyall.html('Applying...').prop('disabled', true)
                 var promises = await this.applyModel(p, false)
 
+                const updateButtonAfterProcessing = () => {
+                    self.ui.applyall.html('<i class="fa fa-file-text-o"></i> Apply to All').prop('disabled', false)
+                }
+
                 if (promises && promises.length > 0) {
-                    $.when.apply($, promises).always(function() {
-                        self.ui.applyall.html('<i class="fa fa-file-text-o"></i> Apply to All').prop('disabled', false)
-                    });
+                    Promise.allSettled(promises)
+                    .then(updateButtonAfterProcessing)
+                    .catch(error => {
+                        console.error("Error after promises settled: ", error);
+                        updateButtonAfterProcessing()
+                    })
                 } else {
-                     self.ui.applyall.html('<i class="fa fa-file-text-o"></i> Apply to All').prop('disabled', false)
+                     updateButtonAfterProcessing()
                 }
             }
         },

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -700,7 +700,6 @@ define(['marionette',
 
         applyPresetAll:function(e) {
             e.preventDefault()
-
             var self = this
 
             var p = this.plans.findWhere({ DIFFRACTIONPLANID: this.ui.preset.val() })
@@ -727,14 +726,12 @@ define(['marionette',
             }
 
             var promises = []
-
             _.each(models, function(model) {
                 if (modelParameter.get('EXPERIMENTKIND') !== model.get('EXPERIMENTKIND')) return
 
                 _.each(['REQUIREDRESOLUTION', 'PREFERREDBEAMSIZEX', 'PREFERREDBEAMSIZEY', 'EXPOSURETIME', 'BOXSIZEX', 'BOXSIZEY', 'AXISSTART', 'AXISRANGE', 'NUMBEROFIMAGES', 'TRANSMISSION', 'ENERGY', 'MONOCHROMATOR'], function(k) {
                     if (modelParameter.get(k) !== null) model.set(k, modelParameter.get(k), { silent: true })
                 }, this)
-
                 promises.push(model.save())
                 model.trigger('refresh')
             }, this)
@@ -884,9 +881,7 @@ define(['marionette',
             this.getInspectionImages()
             this.refreshQSubSamples()
             this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
-
             this.listenTo(this.unfilteredSubsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
-
             this.listenTo(this.unfilteredSubsamples, 'change', this.updateQueueLength)
             this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.onContainerQueueIdChange)
         },

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -885,21 +885,10 @@ define(['marionette',
             this.refreshQSubSamples()
             this.listenTo(this.subsamples, 'change:isSelected', this.selectSubSample, this)
 
-            this.listenTo(this.unfilteredSubsamples, 'sync add remove', this.refreshQSubSamples, this)
-            this.listenTo(this.unfilteredSubsamples, 'change:READYFORQUEUE', this.handleQueueUnqueue, this)
+            this.listenTo(this.unfilteredSubsamples, 'sync add remove change:READYFORQUEUE', this.refreshQSubSamples, this)
 
             this.listenTo(this.unfilteredSubsamples, 'change', this.updateQueueLength)
             this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.onContainerQueueIdChange)
-        },
-
-        handleQueueUnqueue: function(model) {
-            if (model.get('READYFORQUEUE') === '1') {
-                console.log('Adding '+model.get('BLSUBSAMPLEID')+' to queue')
-                this.qsubsamples.fullCollection.add(model, { merge: true })
-            } else {
-                console.log('Removing '+model.get('BLSUBSAMPLEID')+' from queue')
-                this.qsubsamples.fullCollection.remove(model)
-            }
         },
 
         updateQueueLength: function() {

--- a/client/src/js/templates/imaging/queuecontainer.html
+++ b/client/src/js/templates/imaging/queuecontainer.html
@@ -48,7 +48,7 @@
 
 <h2>Queued Samples</h2>
 
-<div class="filter">
+<div class="filter unqueuesamples">
 <span class="r">
 <a href="#" class="button unqueuesel" title="Remove the selected samples from the queue"><i class="fa fa-minus"></i> Unqueue Selected</a>
 <a href="#" class="button unqueueall" title="Remove all samples from the queue"><i class="fa fa-minus"></i> Unqueue All</a>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1758](https://jira.diamond.ac.uk/browse/LIMS-1758)

**Summary**:

If a plate has a lot of subsamples, then "Add All to Queue", "Unqueue All", and "Apply to All" buttons become very slow.

**Changes**:
- Fix bug where browser complains about slider being set before it exists
- Show/hide the "Unqueue All" and "Unqueue Selected" buttons depending on whether the plate is queued or not
- When queuing or unqueuing subsamples, silently update the model (so as to not trigger any GUI changes), then trigger the GUI changes once all queuing/unqueuing is done
- Modify the "Apply to all" button to show something is happening, return it to normal once the process is done
- Do "Apply to all" as chunks of 500, to avoid failing on very large numbers of subsamples

**To test**:
- Go to /admin/imaging and click on a plate with >500 subsamples, but not too many as it can get very slow (from the containers table)
- Scroll down and click "Prepare For Data Collection"
- If any subsamples are already queued, unqueue them using "Unqueue all", check everything is unqueued by this query, it should return zero:
```
select count(blss.blSubSampleId) from ContainerQueueSample
 inner join BLSubSample blss using (blSubSampleId)
 inner join BLSample bls on bls.blSampleId=blss.blsampleid
 where containerId=<containerId>;
```
- Click "Add all to queue", check it only takes a second or two before the page reflects the changes. Check the query now returns the same as the number of subsamples in the plate (as shown on the /admin/imaging page), and the text at the bottom of the page also shows the correct number
- Click "Unqueue all", check it only takes a second or two before the page reflects the changes. Check the query now returns zero, and the text at the bottom of the page now says "(0 data collections)"
- Add `$preset_proposal = 'cm14559';` to your config.php file to ensure you see about 7 Presets
- If you have your browser dev console open, turn off "Disable cache" as it significantly slows the next part
- Click "Add all to queue" again, then choose a one of the Omega Scan presets from the dropdown, and click "Apply to All". Check the button changes to "Applying...", and then changes back to "Apply to all" once it has finished. This takes about a minute for every 500 subsamples.