### PR TITLE
LIMS-167: Don't default to mx type for calendar/logistics views

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -388,7 +388,11 @@ class Proposal extends Page
         }
 
         if ($this->has_arg('ty')) {
-            $beamlines = $this->_get_beamlines_from_type($this->arg('ty'));
+            if ($this->arg('ty') == 'calendar') {
+                $beamlines = $this->_get_beamlines_from_type($this->ty);
+            } else {
+                $beamlines = $this->_get_beamlines_from_type($this->arg('ty'));
+            }
 
             if (!empty($beamlines)) {
                 $bls = implode("', '", $beamlines);

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1664,7 +1664,11 @@ class Shipment extends Page
         }
 
         if ($this->has_arg('ty')) {
-            $bls_tmp = $this->_get_beamlines_from_type($this->arg('ty'));
+            if ($this->arg('ty') == 'overview') {
+                $bls_tmp = $this->_get_beamlines_from_type($this->ty);
+            } else {
+                $bls_tmp = $this->_get_beamlines_from_type($this->arg('ty'));
+            }
             if (!empty($bls_tmp)) {
                 $bls = implode("', '", $bls_tmp);
                 $where .= " AND se.beamlinename IN ('$bls')";

--- a/client/src/js/modules/calendar/views/calendar-view.vue
+++ b/client/src/js/modules/calendar/views/calendar-view.vue
@@ -244,7 +244,7 @@ export default {
           all: 1,
         }
 
-        if (app.staff) queryParams.ty = this.proposalType
+        if (app.staff) queryParams.ty = 'calendar'
         if (this.selectedBeamline !== 'all') queryParams.bl = this.selectedBeamline
 
         const visitsCollection = new Visits(null, {

--- a/client/src/js/modules/shipment/components/dewars-overview-wrapper.vue
+++ b/client/src/js/modules/shipment/components/dewars-overview-wrapper.vue
@@ -54,7 +54,7 @@ export default {
             }
         },
         proposalType : function() {
-            return this.$store.state.proposal.proposalType
+            return 'overview'
         }
     },
     created: function() {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-167](https://jira.diamond.ac.uk/browse/LIMS-167)

**Summary**:

When non-MX staff log in and then click Calendar, the view defaults to MX visits. The same applies to the Logistics page and MX dewars.

**Changes**:
- Tell the backend that you are looking at the calendar or dewars overview pages
- Let the backend figure out your type based on your proposal or which _admin privileges you have

**To test**:
- Log in as someone with mx_admin privileges (eg ndg63276).
- Without choosing a proposal or session, click Calendar, check MX visits are shown. Click Logistics, check MX dewars are shown.
- Click Proposals and select cy42322. Click Calendar, check I19 visits are shown. Click Logistics, check I19 dewars are shown.
- Log in as someone with sm_admin privileges (eg wcx62662).
- Without choosing a proposal or session, click Calendar, check I19 visits are shown. Click Logistics, check I19 dewars are shown.
- Log in as a user with no _admin privileges. Click Calendar, check their visits are shown, whatever beamline each is on. Check the Logistics button is not shown.

