### PR TITLE
LIMS-1752: Create view for Ligand Fit pipeline

### DIFF
--- a/api/src/Downstream/Type/LigandFit.php
+++ b/api/src/Downstream/Type/LigandFit.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SynchWeb\Downstream\Type;
+
+use SynchWeb\Downstream\DownstreamPlugin;
+use SynchWeb\Downstream\DownstreamResult;
+
+class LigandFit extends DownstreamPlugin {
+    var $has_images = true;
+    var $friendlyname = 'LigandFit';
+    var $has_mapmodel = array(1, 0);
+
+    function _get_ligandfit_results_json() {
+        $appid = array($this->autoprocprogramid);
+        $filepath = $this->db->pq(
+            "SELECT app.filePath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like '%.json' ",
+            $appid
+        );
+        return $filepath;
+    }
+
+    function _get_ligandfit_results_png() {
+        $appid = array($this->autoprocprogramid);
+        $filepath = $this->db->pq(
+            "SELECT app.filepath, app.filename from autoprocprogramattachment app where autoprocprogramid = :1 and filename like '%.png' ",
+            $appid
+        );
+        return $filepath;
+    }
+
+    function _get_model_appaid() {
+        $appid = array($this->autoprocprogramid);
+        $filepath = $this->db->pq(
+            "SELECT app.autoprocprogramattachmentid from autoprocprogramattachment app where autoprocprogramid = :1 and filename like '%.html' ",
+            $appid
+        );
+        if (sizeof($filepath)) {
+            return $filepath[0]["AUTOPROCPROGRAMATTACHMENTID"];
+        } else {
+            return;
+        }
+    }
+
+    function results() {
+        $json_filepath = $this->_get_ligandfit_results_json();
+        if (sizeof($json_filepath)) {
+            $json_path = $json_filepath[0]["FILEPATH"] . "/" . $json_filepath[0]["FILENAME"] ;
+            $json_data = file_get_contents($json_path);
+        } else {
+            $json_data = "[]";
+        }
+        $dat = array();
+        $appaid = $this->_get_model_appaid();
+        $dat['BLOBS'] = $appaid ? 1 : 0;
+        $dat['MODEL_APPAID'] = $appaid;
+        $dat['SOLUTIONS'] = json_decode($json_data);
+        $dat['PARENTAUTOPROCPROGRAM'] = $this->process['PROCESSINGCOMMENTS'];
+
+        $results = new DownstreamResult($this);
+        $results->data = $dat;
+
+        return $results;
+    }
+
+    function images($n = 0) {
+        $png = $this->_get_ligandfit_results_png();
+        if (sizeof($png)) {
+            return $png[0]["FILEPATH"] . "/" . $png[0]["FILENAME"];
+        } else {
+            return;
+        }
+    }
+}

--- a/client/src/css/partials/_content.scss
+++ b/client/src/css/partials/_content.scss
@@ -1082,6 +1082,11 @@ li:last-child .visit_users {
         width: 40.5%;
         height: 300px;
 
+        &.map {
+            width: 30%;
+            height: auto;
+        }
+
         &.image-third {
             width: 32.4%;
 

--- a/client/src/js/modules/dc/views/downstream.js
+++ b/client/src/js/modules/dc/views/downstream.js
@@ -8,11 +8,12 @@ define(['backbone', 'marionette',
     'modules/dc/views/mrbump',
     'modules/dc/views/bigep',
     'modules/dc/views/shelxt',
+    'modules/dc/views/ligandfit',
     'templates/dc/downstreamerror.html'
 
     ], function(Backbone, Marionette, TabView, DownStreams, DownstreamWrapper, 
         TableView, 
-        FastEP, DIMPLE, MrBUMP, BigEP, Shelxt, downstreamerror) {
+        FastEP, DIMPLE, MrBUMP, BigEP, Shelxt, LigandFit, downstreamerror) {
 
     var dcPurgedProcessedData = "0"; // dataCollection.PURGEDPROCESSEDDATA via options from DC.js
 
@@ -65,6 +66,7 @@ define(['backbone', 'marionette',
                 'Crank2': BigEP,
                 'AutoSHARP': BigEP,
                 'Shelxt': Shelxt,
+                'LigandFit': LigandFit,
             }
             
             if (model.get('PROCESS').PROCESSINGSTATUS != 1) {
@@ -125,6 +127,7 @@ define(['backbone', 'marionette',
                 holderWidth: this.getOption('holderWidth'),
                 downstreams: this.getOption('downstreams'),
                 DCID: this.getOption('id'),
+                mapButton: this.getOption('mapButton'),
             }
         },
 

--- a/client/src/js/modules/dc/views/downstreamwrapper.js
+++ b/client/src/js/modules/dc/views/downstreamwrapper.js
@@ -65,17 +65,12 @@ define(['backbone', 'marionette',
             this.messages.show(new APMessagesView({
                 messages: new Backbone.Collection(this.model.get('MESSAGES')), embed: true 
             }))
-            this.wrappedView = new (this.getOption('childView'))({ 
-                model: this.model,
-                templateHelpers: this.getOption('templateHelpers'),
-                holderWidth: this.getOption('holderWidth'),
-            })
-            this.wrapper.show(this.wrappedView)
 
             if (!this.model.get('AUTOMATIC')) {
                 this.ui.links.html('<i class="fa fa-refresh" title="Reprocessed"></i> ')
             }
 
+            var mapButton = null
             if (this.getOption('links')) {
                 var links = [
                     '<a class="view button" href="/dc/map/id/'+this.getOption('DCID')+'/aid/'+this.model.get('AID')+'"><i class="fa fa-search"></i> Map / Model Viewer</a>',
@@ -88,7 +83,17 @@ define(['backbone', 'marionette',
                 }
 
                 this.ui.links.append(links.join(' '))
+                mapButton = this.ui.links.find('a.view')
             }
+
+            this.wrappedView = new (this.getOption('childView'))({
+                model: this.model,
+                templateHelpers: this.getOption('templateHelpers'),
+                holderWidth: this.getOption('holderWidth'),
+                mapButton: mapButton,
+            })
+            this.wrapper.show(this.wrappedView)
+
         },
 
         onDomRefresh: function() {

--- a/client/src/js/modules/dc/views/ligandfit.js
+++ b/client/src/js/modules/dc/views/ligandfit.js
@@ -1,0 +1,56 @@
+define([
+    'marionette', 'templates/dc/dc_ligandfit.html', 'utils', 'utils/xhrimage'
+], function(Marionette, template, utils, XHRImage) {
+
+    return Marionette.ItemView.extend({
+        template: template,
+        className: 'clearfix',
+
+        ui: {
+            rstats: '.rstats',
+            blob: '.map img',
+        },
+
+        events: {
+            'click a.mapdl': utils.signHandler,
+        },
+
+        setMapButton: function(mapButtonElement) {
+            if (mapButtonElement) {
+                this.ui.mapbtn = mapButtonElement
+                this.ui.mapbtn.attr('href', app.apiurl+'/download/ap/attachments/'+this.model.get('MODEL_APPAID')+'/dl/2')
+                this.ui.mapbtn.on('click', utils.signHandler)
+            }
+        },
+
+        hideMapButton: function(mapButtonElement) {
+            if (mapButtonElement) {
+                this.ui.mapbtn = mapButtonElement
+                this.ui.mapbtn.hide()
+            }
+        },
+
+        showBlob: function() {
+            this.ui.blob.attr('src', this.blob.src).show()
+        },
+
+        onDomRefresh: function() {
+            this.ui.blob.hide()
+            if (this.model.get('BLOBS') > 0) {
+                this.blob = new XHRImage()
+                this.blob.onload = this.showBlob.bind(this)
+                this.blob.load(app.apiurl+'/processing/downstream/images/'+this.model.get('AID'))
+            }
+
+            if (this.model.get('MODEL_APPAID')) {
+                this.setMapButton(this.options.mapButton)
+            } else {
+                this.hideMapButton(this.options.mapButton)
+            }
+
+            if (!app.mobile()) {
+                this.ui.rstats.width('68%')
+            }
+        },
+    })
+})

--- a/client/src/js/templates/dc/dc_ligandfit.html
+++ b/client/src/js/templates/dc/dc_ligandfit.html
@@ -1,0 +1,27 @@
+<div>
+    <div class="map image">
+        <a class="mapdl" href="<%=APIURL%>/download/ap/attachments/<%-MODEL_APPAID%>/dl/2" title="Click to view model">
+            <img alt="Click to view model" />
+        </a>
+    </div>
+
+    <table class="rstats">
+        <% if (SOLUTIONS.length) { %>
+            <% _.each(SOLUTIONS, function(r, i) { %>
+            <tr>
+                <% _.each(r, function(j) { %>
+                <td><%-j%></td>
+                <% }) %>
+            </tr>
+            <% }) %>
+        <% } else { %>
+            <tr>
+                <td>Solutions</td>
+            </tr>
+            <tr>
+                <td>No Solutions Found</td>
+            </tr>
+        <% } %>
+    </table>
+    
+</div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1752](https://jira.diamond.ac.uk/browse/LIMS-1752)

**Summary**:

The new ligand fit pipeline is now running, and generating Molstar model files. We should have a proper view of them.

**Changes**:
- Create a new downstream type for LigandFit
- Make a table with basic stats (similar to shelxt)
- Show the SMILES as a png
- Pass down the AutoProcProgramAttachmentId for the Molstar map HTML page, make clicking on the SMILES image take you to the model 
- Hijack the "Map / Model Viewer" button to take you to the Molstar model as well

**To test**:
- Find a data collection with a successful ligand fit run (eg /dc/visit/nt37477-28/id/15841906. there are several runs but look at the last one)
- Click on Downstream Processing and then LigandFit
- Check it shows what triggered it eg "LigandFit triggered by Dimple"
- Check it shows the Smiles code and the fitting CC value
- Check it shows the molecule as a PNG
- Check clicking on the PNG or the "Map / Model Viewer" button takes you to a new model viewer, and that you can pan/tilt/zoom in the new viewer.
