### PR TITLE
LIMS-1770: Fix download of attachments on saxs and xpdf beamlines

### DIFF
--- a/client/src/js/modules/types/saxs/dc/dc.js
+++ b/client/src/js/modules/types/saxs/dc/dc.js
@@ -26,7 +26,7 @@ define([
 
         loadAP: function(e) {
             if (!this.ap) {
-              this.ap = new DCDownstreamView({ id: this.model.get('ID'), el: this.$el.find('div.downstream') })
+              this.ap = new DCDownstreamView({ id: this.model.get('ID'), el: this.$el.find('div.downstream'), dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA') })
             } else this.ap.$el.slideToggle()
         },
         

--- a/client/src/js/modules/types/xpdf/dc/dc.js
+++ b/client/src/js/modules/types/xpdf/dc/dc.js
@@ -44,7 +44,7 @@ define([
 
         loadAP: function() {
             if (!this.ap) {
-              this.ap = new DCDownstreamView({ id: this.model.get('ID'), el: this.$el.find('div.downstream') })
+              this.ap = new DCDownstreamView({ id: this.model.get('ID'), el: this.$el.find('div.downstream'), dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA') })
             } else this.ap.$el.slideToggle()
         },
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1770](https://jira.diamond.ac.uk/browse/LIMS-1770)

**Summary**:

Since https://github.com/DiamondLightSource/SynchWeb/pull/921 was deployed, visits on B18 and B21 don't allow you to download attachments, only giving you a link to iCat instead.

**Changes**:
- Pass the dcPurgedProcessedData variable down into the downstream view from SAXS dc.js and XPDF dc.js

**To test**:
- Go to a B18 visit (eg /dc/visit/cm40637-2), click on an AutoProcessing line, then click Logs & Files. Check the Download and View buttons appear, not just a link to iCat
- Repeat for a B21 visit (eg /dc/visit/cm40642-2)
