### PR TITLE
LIMS-1777: Fix download of autoprocessing attachments on sm beamlines

### DIFF
--- a/client/src/js/modules/dc/views/autoprocattachments.js
+++ b/client/src/js/modules/dc/views/autoprocattachments.js
@@ -154,7 +154,7 @@ define(['marionette',
             var iCatProposalRootURL = this.getICatProposalRootUrl(proposalID);
 
             this.isIndustry = this.hasIndustryPrefix(proposalID); // ! FIXME: Naive check.
-            this.isPurgedSession = options.dcPurgedProcessedData !== "0";
+            this.isPurgedSession = (options && options.dcPurgedProcessedData) ? (options.dcPurgedProcessedData !== "0") : false;
 
             var columns = [
                 { name: 'FILENAME', label: 'File', cell: 'string', editable: false },

--- a/client/src/js/modules/types/sm/dc/dc.js
+++ b/client/src/js/modules/types/sm/dc/dc.js
@@ -10,7 +10,7 @@ define([
 
         loadAP: function(e) {
             if (!this.ap) {
-              this.ap = new DCAutoIntegrationView({ id: this.model.get('ID'), el: this.$el.find('div.autoproc') })
+              this.ap = new DCAutoIntegrationView({ id: this.model.get('ID'), dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA'), el: this.$el.find('div.autoproc') })
             } else this.ap.$el.slideToggle()
         },
     })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1777](https://jira.diamond.ac.uk/browse/LIMS-1777)

**Summary**:

Similar to https://github.com/DiamondLightSource/SynchWeb/pull/944, the attachments view of autoprocessing on 'sm' beamlines is broken as it thinks every visit has been purged.

**Changes**:
- Pass the purged status down to DCAutoIntegrationView
- Also, assume not purged if the purged status is undefined

**To test**:
- Go to an I19 visit eg /dc/visit/cm40638-2, find a data collection with auto processing, click Logs & Files, check there are Download and View buttons, not just an iCat button.
