### PR TITLE
LIMS-1426: Allow setting of pipeline when ranking samples

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1176,17 +1176,9 @@ class Sample extends Page
         $tot = intval($tot[0]['TOT']);
 
         # Get stats only for a specific processing pipeline
-        $pipelineids = array(
-            3 => 'fast_dp',
-            4 => 'xia2 (3dii|xds)',
-            5 => 'xia2.multiplex',
-            6 => 'xia2 dials',
-            7 => 'xia2 3d',
-            8 => 'autoPROC',
-        );
         if ($this->has_arg('pipeline')) {
-            $where .= ' AND (app.processingprograms is null or app.processingprograms REGEXP :' . (sizeof($args) + 1) . ')';
-            array_push($args, $pipelineids[$this->arg('pipeline')]);
+            $where .= ' AND (app.processingprograms is null OR app.processingpipelineid is null OR app.processingpipelineid=:' . (sizeof($args) + 1) . ')';
+            array_push($args, $this->arg('pipeline'));
         }
 
         $start = 0;

--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -648,7 +648,7 @@ define(['marionette',
         },
 
         updatePipelines: function() {
-            this.ui.pipeline.html(this.processing_pipelines.opts({ empty: true }))
+            this.ui.pipeline.html('<option value="">All pipelines</option>'+this.processing_pipelines.opts())
         },
 
         updateSchemas: function() {

--- a/client/src/js/templates/shipment/containerplateimage.html
+++ b/client/src/js/templates/shipment/containerplateimage.html
@@ -34,7 +34,7 @@
                         Data Status
                     </label>
                     <label>
-                        Rank By
+                        - Rank By
                         <input type="checkbox" name="rank" />
                     </label>:
                     <select name="param">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1426](https://jira.diamond.ac.uk/browse/LIMS-1426)

**Summary**:

When comparing well sin a plate, you can rank them by auto processing resolution or completeness, but this currently compares all processing pipelines. We should allow choosing a specific pipeline to compare like with like.

**Changes**:
- Data analysis started populating the `AutoProcProgram.processingPipelineId` field in run 2 2025
- Add a dropdown to the plate page, populated with the available processing pipelines
- Pass the pipeline id into the samples query, allowing null for older analysis jobs

**To test**:
- Go to proposal nt37104, and to a plate with some data collections, eg /containers/cid/340603
- Select the Data Status radio button, and tick the Rank By box, choosing AP Resolution
- Check there is another dropdown with default value All Pipelines, and other pipelines eg Fast DP, xia2/DIALS, autoPROC as the other options
- Check changing the pipeline changes the colours on the wells. As an example, location 150 (G3 dot 2) has
  - poor resolution but good completeness for Fast DP
  - good resolution but poor completeness for xia2/DIALS
- Check reverting to All Pipelines puts the colours back as they started
