### PR TITLE
LIMS-1771: Don't display zero dose on grouped collections

### DIFF
--- a/client/src/js/templates/dc/dc.html
+++ b/client/src/js/templates/dc/dc.html
@@ -26,7 +26,7 @@
         <li data-testid="dc-resolution">Resolution: <%-RESOLUTION%>&#197;</li>
         <li data-testid="dc-wavelength">Wavelength: <%-WAVELENGTH%>&#197; (<%-ENERGY%>eV)</li>
         <li data-testid="dc-exposure-time">Exposure: <%-EXPOSURETIME%>s</li>
-        <%if (DCC > 1 && TOTALDOSE) { %>
+        <%if (DCC > 1 && TOTALDOSE > 0) { %>
             <li data-testid="dc-dose">Total Dose:  <%-TOTALDOSE%>MGy</li>
         <% } else if (DCC == 1 && TOTALABSDOSE) { %>
             <li data-testid="dc-dose">Dose:  <%-TOTALABSDOSE%>MGy</li>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1771](https://jira.diamond.ac.uk/browse/LIMS-1771)

**Summary**:

If a group of data collections has a total dose of zero, then that is displayed by the GUI. It should be hidden, the same as for individual data collections.

**Changes**:
- Check dose above zero before displaying

**To test**:
- Find a session with grouped data collections on i03, eg /dc/visit/mx35324-92/ty/fc, check the total dose is not displayed on the main page, nor is the individual dose shown when you click into the group
- Find a session with grouped data collections on i04, eg /dc/visit/mx34598-83/ty/fc, check the total dose is displayed on the main page, and when you click into the group the dose for each individual collection is displayed