### PR TITLE
LIMS-1688: Downstream processing wont display if filesystem not mounted

### DIFF
--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -10,7 +10,11 @@ class FastEp extends DownstreamPlugin {
     var $has_mapmodel = array(1, 1);
 
     function results() {
-        $dat = array();
+        $dat = array(
+            'FOM' => 'sad.lst file not found',
+            'CC' => 'sad.lst file not found',
+            'ATOMS' => array(array('sad_fa.pdb file not found'))
+        );
 
         $ats = array();
         $pdb = $this->_get_attachments("sad_fa.pdb");

--- a/client/src/js/modules/dc/views/fastep.js
+++ b/client/src/js/modules/dc/views/fastep.js
@@ -16,29 +16,32 @@ define(['marionette',
             else {
                 this.ui.plot.width(0.47*(this.options.holderWidth-14))
             }
-                    
-            var data = [{ data: this.model.get('PLOTS').FOM, label: 'FOM' },
-                        { data: this.model.get('PLOTS').CC, label: 'mapCC' }]
-            var options = { 
-                series: {
-                    lines: { show: true }
-                },
-                xaxis: {
-                    ticks: function (axis) {
-                        var res = [], nticks = 6, step = (axis.max - axis.min) / nticks
-                        for (i = 0; i <= nticks; i++) {
-                            res.push(axis.min + i * step)
-                        }
-                        return res
+
+            var plotsData = this.model.get('PLOTS');
+            if (plotsData && Array.isArray(plotsData.FOM) && plotsData.FOM.length > 0 && Array.isArray(plotsData.CC) && plotsData.CC.length > 0) {
+                var data = [{ data: plotsData.FOM, label: 'FOM' },
+                            { data: plotsData.CC, label: 'mapCC' }]
+                var options = {
+                    series: {
+                        lines: { show: true }
                     },
-                    tickFormatter: function (val, axis) {
-                        return (1.0/Math.sqrt(val)).toFixed(axis.tickDecimals)
-                    },
-                    tickDecimals: 2
+                    xaxis: {
+                        ticks: function (axis) {
+                            var res = [], nticks = 6, step = (axis.max - axis.min) / nticks
+                            for (i = 0; i <= nticks; i++) {
+                                res.push(axis.min + i * step)
+                            }
+                            return res
+                        },
+                        tickFormatter: function (val, axis) {
+                            return (1.0/Math.sqrt(val)).toFixed(axis.tickDecimals)
+                        },
+                        tickDecimals: 2
+                    }
                 }
+                var pl = $.extend({}, utils.default_plot, options)
+                $.plot(this.ui.plot, data, pl)
             }
-            var pl = $.extend({}, utils.default_plot, options)
-            $.plot(this.ui.plot, data, pl)
         },
     })
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1688](https://jira.diamond.ac.uk/browse/LIMS-1688)

**Summary**:

If the filesystem with FastEP results on is not mounted, (or we cannot get the files for some reason), the whole downstream processing bar won't display.

**Changes**:
- Prepopulate the results data with error messages, that will be overwritten when results are found
- Check there is plotting data returned before attempting to plot a graph

**To test**:
- Start a synchweb instance on a machine without /dls/ mounted
- Go to a data collection with FastEP results, eg /dc/visit/cm40607-3/id/18552850
- Click on Downstream Processing, check it expands to show results
- Click on FastEP, check it displays that the files are not found, and no graph is displayed
- Mount /dls and refresh the page
- Check there are now results for FOM and CC, atoms listed with coordinates and occupancy, and a graph is displayed
