### PR TITLE
LIMS-1799: Checks for safety level should be case insensitive

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -116,8 +116,8 @@
               <span v-else-if="shippingSafetyLevel === null">
                 Cannot queue container until shipment safety level is set
               </span>
-              <span v-else-if="shippingSafetyLevel != 'Green'">
-                Cannot queue containers in {{ shippingSafetyLevel }} shipments
+              <span v-else-if="shippingSafetyLevel.toLowerCase() !== 'green'">
+                Cannot queue containers in {{ shippingSafetyLevel.toLowerCase() }} shipments
               </span>
               <span v-else-if="containerQueueError">
                 There was an error submitting the container to the queue. Please fix any errors in the samples table.

--- a/client/src/js/text.js
+++ b/client/src/js/text.js
@@ -203,7 +203,7 @@ define(['module'], function (module) {
         },
 
         write: function (pluginName, moduleName, write, config) {
-            if (buildMap.hasOwnProperty(moduleName)) {
+            if (Object.prototype.hasOwnProperty.call(buildMap, moduleName)) {
                 var content = text.jsEscape(buildMap[moduleName]);
                 write.asModule(pluginName + "!" + moduleName,
                                "define(function () { return '" +
@@ -270,7 +270,7 @@ define(['module'], function (module) {
             //Allow plugins direct access to xhr headers
             if (headers) {
                 for (header in headers) {
-                    if (headers.hasOwnProperty(header)) {
+                    if (Object.prototype.hasOwnProperty.call(headers, header)) {
                         xhr.setRequestHeader(header.toLowerCase(), headers[header]);
                     }
                 }

--- a/client/src/js/views/search.js
+++ b/client/src/js/views/search.js
@@ -7,7 +7,7 @@ define(['backbone'], function(Backbone) {
         "click a[data-backgrid-action=clear]": "clear",
         "submit": "search"
     },
-      
+
     /**
        @param {Object} options
        @param {Backbone.Collection} options.collection
@@ -22,7 +22,7 @@ define(['backbone'], function(Backbone) {
         this.value = options.value || this.value;
         this.placeholder = options.placeholder || this.placeholder
         this.template = options.template || this.template;
-            
+
         //this.url = options.url || this.url
         if (options.url == false) this.url = false
         this.urlFragment = options.urlFragment || this.urlFragment
@@ -38,7 +38,7 @@ define(['backbone'], function(Backbone) {
         }
         this.search = _.debounce(this.search, 400)
     },
-  
+
     /** @property */
     tagName: 'div',
 
@@ -159,18 +159,18 @@ define(['backbone'], function(Backbone) {
       }
       else collection.fetch({reset: true});
     },
-    
+
 
     /**
        Renders a search form with a text box, optionally with a placeholder and
        a preset value if supplied during initialization.
     */
     render: function () {
-      $('input.search-mobile').focus().keyup(function() {
-        $('input[type=search]').val($(this).val()).trigger('keyup')
-      }).parent('span').addClass('enable')
-      $('#sidebar,.cont_wrap').addClass('searchbox')
-        
+      this.$('input.search-mobile').focus().keyup(function() {
+        this.$('input[type=search]').val($(this).val()).trigger('keyup');
+      }).parent('span').addClass('enable');
+      this.$('#sidebar,.cont_wrap').addClass('searchbox');
+
       this.$el.empty().append(this.template({
         name: this.name,
         placeholder: this.placeholder,
@@ -180,14 +180,14 @@ define(['backbone'], function(Backbone) {
       this.delegateEvents();
       return this;
     },
-      
+
     destroy: function() {
-      $('input.search-mobile').unbind('keyup').parent('span').removeClass('enable')
-      $('#sidebar,.cont_wrap').removeClass('searchbox')
+      this.$('input.search-mobile').unbind('keyup').parent('span').removeClass('enable');
+      this.$('#sidebar,.cont_wrap').removeClass('searchbox');
     },
-      
-      
+
+
   });
-       
+
   return Search
 })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1799](https://jira.diamond.ac.uk/browse/LIMS-1799)

**Summary**:

https://github.com/DiamondLightSource/SynchWeb/pull/827 introduced a check on the shipment safety level, for queueing containers, but the check was case sensitive. This makes it case-insensitive as the field is text, not an enum.
Also fix a couple of minor things that github complains about in PRs.

**Changes**:
- Make the check for shipping safety level be case insensitive
- Do not access Object.prototype method 'hasOwnProperty' from target object, use `Object.prototype.hasOwnProperty.call` instead
- Use `this.$` instead of `$` in views

**To test**:
- Set a shipment to safety level 'GREEN', eg 
```
update Shipping set SAFETYLEVEL='GREEN' where shippingId=71932;
```
- Go to /containers/cid/341023 and check the puck can be unqueued and queued freely
- Set the same shipment to 'YELLOW' (or any capitalisation, refresh the page and check the puck cannot be queued any more.