### PR TITLE
LIMS-1780 / LIMS-1787: Show strategies on characterizations, auto processing on grid scans

### DIFF
--- a/client/src/css/partials/_content.scss
+++ b/client/src/css/partials/_content.scss
@@ -1821,7 +1821,14 @@ textarea[name=pasted] {
     height: 250px;
 }
 
-
+.strategies {
+    > div {
+        padding: 10px;
+        table tr.stratrow {
+            cursor: auto;
+        }
+    }
+}
 
 @media (max-width: $breakpoint-small) {
 

--- a/client/src/js/modules/dc/views/apstatusitem.js
+++ b/client/src/js/modules/dc/views/apstatusitem.js
@@ -48,14 +48,16 @@ define(['marionette', 'jquery'], function(Marionette, $) {
 
             if (this.getOption('XRC')) {
                 this.ui.xrc.html('Xray Centring: ' + val[res['XrayCentring']])
+            }
 
-            } else if (this.getOption('SCREEN') != 0) {
+            if (this.getOption('showStrategies')) {
                 this.ui.strat.empty()
                 _.each(res['screening'], function(sc, n) {
                     this.ui.strat.append(n+': '+val[sc]+' ')
                 }, this)
-               
-            } else {
+            }
+
+            if (this.getOption('showProcessing')) {
                 _.each({ap: 'autoproc',dp: 'downstream'}, function(ty, id) {
                     this.ui[id].empty()
                     var allResults = []

--- a/client/src/js/modules/dc/views/dc.js
+++ b/client/src/js/modules/dc/views/dc.js
@@ -62,7 +62,15 @@ define(['marionette',
       // edit.create('COMMENTS', 'text')
         
       this.imagestatus = new (this.getOption('imageStatusItem'))({ ID: this.model.get('ID'), TYPE: this.model.get('DCT'), statuses: this.getOption('imagestatuses'), el: this.$el })
-      this.apstatus = new (this.getOption('apStatusItem'))({ ID: this.model.get('ID'), SCREEN: (this.model.get('OVERLAP') != 0 && this.model.get('AXISRANGE')), statuses: this.getOption('apstatuses'), el: this.$el })
+      const isCharacterization = this.model.get('DCT') === "Characterization"
+      const hasStrategies = this.model.get('AXISRANGE') > 0 && this.model.get('OVERLAP') != 0
+      const hasProcessing = this.model.get('AXISRANGE') > 0 || this.model.get('DCT') === "Serial Fixed" || this.model.get('DCT') === "Serial Jet"
+      const showStrategies = isCharacterization || hasStrategies
+      const showProcessing = isCharacterization || (!hasStrategies && hasProcessing)
+      if (!showStrategies) this.ui.strat.hide()
+      if (!showProcessing) this.ui.ap.hide()
+      if (!showProcessing) this.ui.dp.hide()
+      this.apstatus = new (this.getOption('apStatusItem'))({ ID: this.model.get('ID'), showStrategies: showStrategies, showProcessing: showProcessing, statuses: this.getOption('apstatuses'), el: this.$el })
       this.listenTo(this.apstatus, 'status', this.updateAP, this)
       this.apmessagestatus = new (this.getOption('apMessageStatusItem'))({ ID: this.model.get('ID'), statuses: this.getOption('apmessagestatuses'), el: this.$el })
 
@@ -102,6 +110,9 @@ define(['marionette',
       
     ui: {
       rp: 'a.reprocess',
+      strat: 'h1.strat',
+      ap: 'h1.ap',
+      dp: 'h1.dp',
     },
 
     showMessages: function(e) {

--- a/client/src/js/modules/dc/views/dc.js
+++ b/client/src/js/modules/dc/views/dc.js
@@ -68,8 +68,10 @@ define(['marionette',
       const showStrategies = isCharacterization || hasStrategies
       const showProcessing = isCharacterization || (!hasStrategies && hasProcessing)
       if (!showStrategies) this.ui.strat.hide()
-      if (!showProcessing) this.ui.ap.hide()
-      if (!showProcessing) this.ui.dp.hide()
+      if (!showProcessing) {
+          this.ui.ap.hide();
+          this.ui.dp.hide();
+      }
       this.apstatus = new (this.getOption('apStatusItem'))({ ID: this.model.get('ID'), showStrategies: showStrategies, showProcessing: showProcessing, statuses: this.getOption('apstatuses'), el: this.$el })
       this.listenTo(this.apstatus, 'status', this.updateAP, this)
       this.apmessagestatus = new (this.getOption('apMessageStatusItem'))({ ID: this.model.get('ID'), statuses: this.getOption('apmessagestatuses'), el: this.$el })

--- a/client/src/js/templates/dc/dc.html
+++ b/client/src/js/templates/dc/dc.html
@@ -39,14 +39,14 @@
     </ul>
 
     <div class="holder">
-    <% if (AXISRANGE > 0 && OVERLAP != 0) { %>
-        <h1 title="Click to show EDNA/mosflm/xia2 strategies" class="strat" data-testid="dc-strategies">Strategies<span><i class="fa fa-spinner fa-spin"></i></span></h1>
+
+        <h1 title="Click to show strategies" class="strat" data-testid="dc-strategies">Strategies<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="strategies"></div>
-    <% } else if (AXISRANGE > 0 || DCT == "Serial Fixed" || DCT == "Serial Jet") { %>
+
         <h1 title="Click to show autoprocessing results such as Fast_DP and XIA2" class="ap" data-testid="dc-autoprocessing">Auto Processing<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="autoproc"></div>
         <h1 title="Click to show downstream processing results such as Dimple and Fast_EP" class="dp" data-testid="dc-downstream-processing">Downstream Processing<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="downstream"></div>
-    <% } %>
+
     </div>
 </div>

--- a/client/src/js/templates/dc/dc_strategy.html
+++ b/client/src/js/templates/dc/dc_strategy.html
@@ -6,7 +6,7 @@
 
 <table class="reflow cell">
     <thead>
-        <tr>
+        <tr class="stratrow">
             <th>Space Group</th>
             <th>A</th>
             <th>B</th>
@@ -17,7 +17,7 @@
         </tr>
     </thead>
     <tbody>
-        <tr>
+        <tr class="stratrow">
             <td><%-CELL.SG%></td>
             <td><%-CELL.A%></td>
             <td><%-CELL.B%></td>
@@ -32,7 +32,7 @@
 
 <table class="reflow strat">
     <thead>
-        <tr>
+        <tr class="stratrow">
             <th>Strategy</th>
             <th>Description</th>
             <th>Axis</th>
@@ -48,7 +48,7 @@
     </thead>
     
     <% _.each(STRATS, function(r, i) { %>
-    <tr draggable="true" sid="<%-i%>">
+    <tr class="stratrow" draggable="true" sid="<%-i%>">
         <td><%-r.COM%></td>
         <td><%-r.COMMENTS%></td>
         <td><%-r.ROTATIONAXIS%></td>

--- a/client/src/js/templates/dc/dc_strategy.html
+++ b/client/src/js/templates/dc/dc_strategy.html
@@ -1,5 +1,5 @@
 
-<h1><%-TYPE%></h1>
+<h2><%-TYPE%></h2>
 <p class="r">
     <a class="view button" title="Lookup Unit Cell" href="/cell/a/<%-CELL.A%>/b/<%-CELL.B%>/c/<%-CELL.C%>/al/<%-CELL.AL%>/be/<%-CELL.BE%>/ga/<%-CELL.GA%>"><i class="fa fa-search"></i> Lookup Cell</a>
 </p>

--- a/client/src/js/templates/dc/dc_xoalign.html
+++ b/client/src/js/templates/dc/dc_xoalign.html
@@ -4,7 +4,7 @@
 
 <table class="reflow cell">
     <thead>
-        <tr>
+        <tr class="stratrow">
             <th>Axes</th>
             <th>Kappa</th>
             <th>Chi</th>
@@ -13,7 +13,7 @@
     </thead>
     <tbody>
         <% _.each(STRATS, function(r, i) { %>
-        <tr>
+        <tr class="stratrow">
             <td><%-r.COMMENTS %></td>
             <td><%-r.KAPPA %></td>
             <td><%-r.CHI %></td>

--- a/client/src/js/templates/dc/dc_xoalign.html
+++ b/client/src/js/templates/dc/dc_xoalign.html
@@ -1,5 +1,5 @@
 
-<h1><%-TYPE%></h1>
+<h2><%-TYPE%></h2>
 
 
 <table class="reflow cell">

--- a/client/src/js/templates/dc/grid.html
+++ b/client/src/js/templates/dc/grid.html
@@ -34,5 +34,7 @@
     <div class="holder">
         <h1 title="Xray Centring Status and Results" class="xrc">Grid Scan Processing<span><i class="fa fa-spinner fa-spin"></i></span></h1>
         <div class="xrc"></div>
+        <h1 title="Click to show autoprocessing results such as XIA2" class="ap" data-testid="dc-autoprocessing">Auto Processing<span><i class="fa fa-spinner fa-spin"></i></span></h1>
+        <div class="autoproc"></div>
     </div>
 </div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1780](https://jira.diamond.ac.uk/browse/LIMS-1780)
**JIRA ticket**: [LIMS-1787](https://jira.diamond.ac.uk/browse/LIMS-1787)

**Summary**:

The dials.align_crystal strategy pipeline is run on data collections of type 'characterization', we should display the results.
Some grid scans also have xia2.ssx run on them, we should display the results.

**Changes**:
- Move the logic of which result bars to display out of the HTML template and into the JS
- Show both strategies and processing if data collection type is 'characterization', otherwise unchanged
- Give strategy results a h2 header as h1 seems to be ignored (downstream results use h2 also)
- Show auto processing bar on grid scans if results are available

**To test**:
- Go to a characterization data collection (eg /dc/visit/mx37593-47/id/18698689), check bars are shown for Strategies, Auto Processing and Downstream Processing
- Go to a data collection with non-zero overlap (eg /dc/visit/mx39189-13/id/18634663), check only the Strategies bar is shown
- Go to a data collection with zero overlap that is not Characterization (eg /dc/visit/mx23694-138/id/18609703), check only Auto Processing and Downstream Processing bars are shown
- Go to a data collection that is part of a 3d grid scan (eg /dc/visit/mx23694-138/id/18609694), check only an Xray Centring bar is shown
- Go back to /dc/visit/mx37593-47/id/18698689, check the Strategies bar opens, a result is shown, and the program name is underlined. Repeat with /dc/visit/mx39189-13/id/18634663.
- Go to a grid scan with xia2.ssx results (eg /dc/visit/nt37104-159/id/18277888), check the Auto Processing bar is shown
- Go to a grid scan that has no auto processing results and is not part of a 3d grid scan (eg /dc/visit/cm40608-3/id/18713461), check neither bar is shown.
