### PR TITLE
LIMS-1796: Display filepath for attachments

### DIFF
--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -368,10 +368,8 @@ class Download extends Page
 
         foreach ($rows as &$r) {
             $r['FILENAME'] = basename($r['FILEFULLPATH']);
-            $info = pathinfo($r['FILENAME']);
-            $r['NAME'] = basename($r['FILENAME'], '.' . $info['extension']);
+            $r['FILEPATH'] = dirname($r['FILEFULLPATH']);
 
-            $r['FILEFULLPATH'] = preg_replace('/.*\/' . $r['VISIT'] . '\//', '', $r['FILEFULLPATH']);
 
             foreach (array('DX_MM', 'DY_MM', 'STEPS_X', 'STEPS_Y', 'SNAKED') as $k) {
                 $r[$k] = floatval($r[$k]);

--- a/client/src/js/modules/dc/views/attachments.js
+++ b/client/src/js/modules/dc/views/attachments.js
@@ -17,7 +17,7 @@ define(['marionette',
             var displayedPath = filePath.split('/').slice(0,4).join('/')+'/...'
 
             this.$el.html(`
-                <span>${displayedPath}</span>
+                <span title="${filePath}">${displayedPath}</span>
                 <button class="copy-path button" title="Copy full path to clipboard">
                     <i class="fa fa-clipboard"/>
                 </button>

--- a/client/src/js/modules/dc/views/attachments.js
+++ b/client/src/js/modules/dc/views/attachments.js
@@ -14,7 +14,7 @@ define(['marionette',
 
         render: function() {
             var filePath = this.model.get('FILEPATH')
-            var displayedPath = filePath.split('/').slice(0,4).join('/')+'/...'
+            var displayedPath = filePath.split('/').length > 4 ? filePath.split('/').slice(0, 4).join('/') + '/...' : filePath
 
             this.$el.html(`
                 <span title="${filePath}">${displayedPath}</span>

--- a/client/src/js/modules/dc/views/attachments.js
+++ b/client/src/js/modules/dc/views/attachments.js
@@ -7,6 +7,44 @@ define(['marionette',
     'utils'], 
     function(Marionette, Backgrid, TableView, attachments, LogView, CloudUploadView, utils) {
 
+    var PathCell = Backgrid.Cell.extend({
+        events: {
+            'click .copy-path': 'copyPathToClipboard'
+        },
+
+        render: function() {
+            var filePath = this.model.get('FILEPATH')
+            var displayedPath = filePath.split('/').slice(0,4).join('/')+'/...'
+
+            this.$el.html(`
+                <span>${displayedPath}</span>
+                <button class="copy-path button" title="Copy full path to clipboard">
+                    <i class="fa fa-clipboard"/>
+                </button>
+            `)
+
+            return this
+        },
+
+        copyPathToClipboard: function(e) {
+            e.preventDefault()
+            var fullPath = this.model.get('FILEPATH')
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(fullPath).then(() => {
+                    var $icon = $(e.currentTarget).find('i')
+                    $icon.removeClass('fa-clipboard').addClass('fa-check')
+                    setTimeout(() => {
+                        $icon.removeClass('fa-check').addClass('fa-clipboard')
+                    }, 2000)
+                }).catch(err => {
+                    alert('Failed to copy path. Please try again or copy manually: ' + fullPath)
+                })
+            } else {
+                alert('Full path: ' + fullPath)
+            }
+        }
+    })
+
     
     var OptionsCell = Backgrid.Cell.extend({
         events: {
@@ -76,7 +114,8 @@ define(['marionette',
             this.attachments.fetch()
 
             var columns = [
-                { name: 'FILEFULLPATH', label: 'File', cell: 'string', editable: false },
+                { name: 'FILEPATH', label: 'File', cell: PathCell, editable: false },
+                { name: 'FILENAME', label: 'File', cell: 'string', editable: false },
                 { name: 'FILETYPE', label: 'Type', cell: 'string', editable: false },
                 { label: '', cell: OptionsCell, editable: false },
             ]

--- a/client/src/js/modules/dc/views/autoprocattachments.js
+++ b/client/src/js/modules/dc/views/autoprocattachments.js
@@ -23,7 +23,7 @@ define(['marionette',
             var displayedPath = filePath.split('/').slice(0,4).join('/')+'/...'
 
             this.$el.html(`
-                <span>${displayedPath}</span>
+                <span title="${filePath}">${displayedPath}</span>
                 <button class="copy-path button" title="Copy full path to clipboard">
                     <i class="fa fa-clipboard"/>
                 </button>

--- a/client/src/js/modules/dc/views/autoprocattachments.js
+++ b/client/src/js/modules/dc/views/autoprocattachments.js
@@ -20,7 +20,7 @@ define(['marionette',
 
         render: function() {
             var filePath = this.model.get('FILEPATH')
-            var displayedPath = filePath.split('/').slice(0,4).join('/')+'/...'
+            var displayedPath = filePath.split('/').length > 4 ? filePath.split('/').slice(0, 4).join('/') + '/...' : filePath
 
             this.$el.html(`
                 <span title="${filePath}">${displayedPath}</span>

--- a/client/src/js/modules/dc/views/autoprocattachments.js
+++ b/client/src/js/modules/dc/views/autoprocattachments.js
@@ -13,6 +13,44 @@ define(['marionette',
     // string for comparison with filepaths. Pulled from config to share across optionsCells.
     var persistentStorageSegment = undefined; 
 
+    var PathCell = Backgrid.Cell.extend({
+        events: {
+            'click .copy-path': 'copyPathToClipboard'
+        },
+
+        render: function() {
+            var filePath = this.model.get('FILEPATH')
+            var displayedPath = filePath.split('/').slice(0,4).join('/')+'/...'
+
+            this.$el.html(`
+                <span>${displayedPath}</span>
+                <button class="copy-path button" title="Copy full path to clipboard">
+                    <i class="fa fa-clipboard"/>
+                </button>
+            `)
+
+            return this
+        },
+
+        copyPathToClipboard: function(e) {
+            e.preventDefault()
+            var fullPath = this.model.get('FILEPATH')
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(fullPath).then(() => {
+                    var $icon = $(e.currentTarget).find('i')
+                    $icon.removeClass('fa-clipboard').addClass('fa-check')
+                    setTimeout(() => {
+                        $icon.removeClass('fa-check').addClass('fa-clipboard')
+                    }, 2000)
+                }).catch(err => {
+                    alert('Failed to copy path. Please try again or copy manually: ' + fullPath)
+                })
+            } else {
+                alert('Full path: ' + fullPath)
+            }
+        }
+    })
+
     var OptionsCell = Backgrid.Cell.extend({
         events: {
             'click a.dl': utils.signHandler,
@@ -157,6 +195,7 @@ define(['marionette',
             this.isPurgedSession = (options && options.dcPurgedProcessedData) ? (options.dcPurgedProcessedData !== "0") : false;
 
             var columns = [
+                { name: 'FILEPATH', label: 'Path', cell: PathCell, editable: false },
                 { name: 'FILENAME', label: 'File', cell: 'string', editable: false },
                 { name: 'FILETYPE', label: 'Type', cell: 'string', editable: false },
                 { 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1796](https://jira.diamond.ac.uk/browse/LIMS-1796)

**Summary**:

Where autoprocessing jobs have run is a bit of a mystery within Synchweb. But one thing we can do simply is to display the filepath to any attachments.

**Changes**:
- Add a file path column to the data collection Attachments view, auto processing attachments view and the downstream processing attachments view
- Truncate the path to prevent it being too wide, but display the full path in a tooltip, and add a button to copy to the clipboard

**To test**:
- Deploy to a https server, otherwise clipboard integration doesn't work. At the time of writing this branch is on ispyb-dev-1
- Go to a data collection with attachments, auto processing attachments and downstream processing attachments (eg /dc/visit/mx23694-139/id/18302860)
- Click the little Attachments icon (next to the reprocessing cog), check that each attachment shows the truncated path, with the full path as a tooltip, with a button to copy it to the clipboard. Check the attachments can still be viewed or downloaded.
- Go to an auto processing job and click "Logs & Files", do the same checks
- Go to a downstream processing job and click "Logs & Files", do the same checks.
