### PR TITLE
LIMS-1792: Allow container types from multiple villages

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -224,23 +224,26 @@ class Proposal extends Page
             // See if proposal code matches list in config
             $found = False;
             $ty = null;
+            $tys = array();
             foreach ($prop_types as $pty) {
                 if ($r['PROPOSALCODE'] == $pty) {
                     $ty = $pty;
+                    array_push($tys, $pty);
                     $found = True;
                 }
             }
 
             // Proposal code didnt match, work out what beamline the visits are on
-            if (!$found) {
-                $bls = $this->db->pq("SELECT s.beamlinename FROM blsession s WHERE s.proposalid=:1", array($r['PROPOSALID']));
+            $bls = $this->db->pq("SELECT s.beamlinename FROM blsession s WHERE s.proposalid=:1", array($r['PROPOSALID']));
 
-                if (sizeof($bls)) {
-                    foreach ($bls as $bl) {
-                        $b = $bl['BEAMLINENAME'];
-                        $ty = $this->_get_type_from_beamline($b);
-                        if ($ty)
-                            break;
+            if (sizeof($bls)) {
+                foreach ($bls as $bl) {
+                    $b = $bl['BEAMLINENAME'];
+                    $bty = $this->_get_type_from_beamline($b);
+                    array_push($tys, $bty);
+                    if (!$found) {
+                        $ty = $bty;
+                        $found = True;
                     }
                 }
             }
@@ -248,6 +251,7 @@ class Proposal extends Page
             if (!$ty)
                 $ty = 'gen';
             $r['TYPE'] = $ty;
+            $r['TYPES'] = array_unique($tys);
         }
 
         if ($id) {

--- a/client/src/js/app/store/modules/store.proposal.js
+++ b/client/src/js/app/store/modules/store.proposal.js
@@ -8,6 +8,7 @@ const proposalModule = {
     // Proposal / visit info
     proposal: '',        // The proposal string (e.g. mx12345)
     proposalType: 'mx',  // Type of the proposal or default type for the user
+    proposalTypes: [],   // All possible types for the proposal
     proposalModel: null, // A backbone model for the current proposal
     visit: '',
   },
@@ -44,6 +45,11 @@ const proposalModule = {
       state.proposalType = proposalType
       app.type = state.proposalType
     },
+    // Code for all types for this proposal
+    setProposalTypes(state, proposalTypes) {
+      state.proposalTypes = proposalTypes
+      app.types = state.proposalTypes
+    },
     // Set current visit / session number
     setVisit(state, visit) {
       if (visit) {
@@ -79,6 +85,8 @@ const proposalModule = {
               success: function() {
                 let proposalType = proposalModel.get('TYPE')
                 commit('setProposalType', proposalType)
+                let proposalTypes = proposalModel.get('TYPES')
+                commit('setProposalTypes', proposalTypes)
                 commit('setProposalModel', proposalModel)
                 resolve()
               },

--- a/client/src/js/modules/types/mx/shipment/views/container-mixin.js
+++ b/client/src/js/modules/types/mx/shipment/views/container-mixin.js
@@ -137,8 +137,6 @@ export default {
       this.containerRegistry = [{ CONTAINERREGISTRYID: null, BARCODE: ""}, ...result.toJSON()]
     },
     async getContainerTypes() {
-      this.containerFilter = [this.$store.state.proposal.proposalType]
-
       const result = await this.$store.dispatch('getCollection', this.containerTypesCollection)
       this.containerTypes = result.toJSON()
       // Do we have valid start state?
@@ -511,7 +509,7 @@ export default {
   },
   computed: {
     containerFilter: function() {
-      return [this.$store.state.proposal.proposalType]
+      return this.$store.state.proposal.proposalTypes
     },
     isPuck() {
       return this.containerType.WELLPERROW === null


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1792](https://jira.diamond.ac.uk/browse/LIMS-1792)

**Summary**:

Some proposals have visits on multiple villages, eg sm, mx. They should be able to create containers in types that belong to each village.

**Changes**:
- Return an additional field 'TYPES' for each proposal, as an array of all villages associated with the proposal
- Store this in the proposal store
- Use it to display more container types if needed

**To test**:
- Go to a proposal with multiple villages, eg nt40910. Make a new container, check the container type dropdown gives grouped options for sm Puck-16's, as well as mx pucks and plates.
- Go to an mx-only propsosal eg mx23694. Make a new container, check the container type dropdown only shows mx container types.
- Go to an sm-only propsosal eg cm40638. Make a new container, check the container type dropdown only shows sm container types.

