### PR TITLE
LIMS-742: Remove redundant 'pid' check

### DIFF
--- a/api/src/Controllers/UserController.php
+++ b/api/src/Controllers/UserController.php
@@ -166,18 +166,12 @@ class UserController extends Page
 
     function _get_users()
     {
-        // remove this after successfully completing LIMS-742 ticket
-        if($this->has_arg('pid')){
-            error_log("pid used (for ticket: https://jira.diamond.ac.uk/browse/LIMS-742)");
-        }
-        
         $rows = $this->userData->getUsers(
             false,
             $this->staff,
             $this->argOrEmptyString('s'),
             $this->argOrEmptyString('page'),
             $this->argOrEmptyString('sort_by'),
-            $this->argOrEmptyString('pid'),
             $this->proposalid,        
             $this->argOrEmptyString('PERSONID'),
             $this->user->hasPermission('manage_users'),
@@ -206,7 +200,6 @@ class UserController extends Page
                 $this->argOrEmptyString('s'),
                 $this->argOrEmptyString('page'),
                 $this->argOrEmptyString('sort_by'),
-                $this->argOrEmptyString('pid'),
                 $this->proposalid,
                 $this->argOrEmptyString('PERSONID'),
                 $this->user->hasPermission('manage_users'),

--- a/api/src/Model/Services/UserData.php
+++ b/api/src/Model/Services/UserData.php
@@ -64,7 +64,7 @@ class UserData
     }
 
 
-    function getUsers($getCount, $isStaffMember, $stringMatch, $page, $sortBy = null, $pid=null,  $proposalid = null, $personId = null, $isManager = false, $currentUserId = null, $gid = null, $pjid = null, $visitName = null, $perPage = 15, $isAscending = true, $isAll = false, $onlyLogins = false)
+    function getUsers($getCount, $isStaffMember, $stringMatch, $page, $sortBy = null, $proposalid = null, $personId = null, $isManager = false, $currentUserId = null, $gid = null, $pjid = null, $visitName = null, $perPage = 15, $isAscending = true, $isAll = false, $onlyLogins = false)
     {
         $args = array();
 
@@ -99,8 +99,7 @@ class UserData
         // This blocks means that non-staff can only see users on their proposal, except when they looking at a visit 
         //  (i.e. the proposal that was checking is added to the where clause)
         if ((($personId && !$isManager) // if you're not a manager: you're looking for a person
-            || (!$isStaffMember && !$visitName)) // if you are not a staff member and not looking at a specific visit
-            || $pid) // if you are looking for user based on a proposal, but this 
+            || (!$isStaffMember && !$visitName))) // if you are not a staff member and not looking at a specific visit
         {
             $where .= ' AND (prhp.proposalid=:' . (sizeof($args) + 1) . ' OR lc.proposalid=:' . (sizeof($args) + 2) . ' OR p.personid=:' . (sizeof($args) + 3) . ')';
             array_push($args, $proposalid, $proposalid, $currentUserId);


### PR DESCRIPTION
**JIRA ticket**: [LIMS-742](https://jira.diamond.ac.uk/browse/LIMS-742)

**Summary**:

Since https://github.com/DiamondLightSource/SynchWeb/pull/566, there has been code left in to check if $pid was being sent to the api/users/ endpoint. As it doesn't seem to be, we can remove that logging, and also remove the $pid variable.

**Changes**:
- Remove $pid and logging of $pid

**To test**:
- Go to the home page, hover over the users icon for a visit, check a list of users appears
- Go to a visit, hover over the Users icon at the top, check a list of users appears
- Go to /projects, and create a new project. Add a user to the project by searching, and check they remain after refreshing the page
- Go to /contacts and click Add Home Lab Contact. Check your name appears in the dropdown labelled Login.
- Go to a shipment and click to add a container. Check a list of people appears in the dropdown labelled Owner.
