### PR TITLE
LIMS-1833: Fix XPDF DC view

### DIFF
--- a/client/src/js/modules/dc/views/dc.js
+++ b/client/src/js/modules/dc/views/dc.js
@@ -42,8 +42,19 @@ define(['marionette',
       this.strat = null
       this.ap = null
       this.dp = null
+      this.showStrategies = true
+      this.showProcessing = true
+      this.setProcessingVars()
     },
-      
+
+    setProcessingVars: function() {
+      const hasProcessing = this.model.get('AXISRANGE') > 0 || this.model.get('DCT') === "Serial Fixed" || this.model.get('DCT') === "Serial Jet"
+      const isCharacterization = this.model.get('DCT') === "Characterization"
+      const hasStrategies = this.model.get('AXISRANGE') > 0 && this.model.get('OVERLAP') != 0
+      this.showStrategies = isCharacterization || hasStrategies
+      this.showProcessing = isCharacterization || (!hasStrategies && hasProcessing)
+    },
+
     onShow: function() {
       // element not always available at this point?
       var w = 0.175*$(window).width()*0.95
@@ -62,17 +73,13 @@ define(['marionette',
       // edit.create('COMMENTS', 'text')
         
       this.imagestatus = new (this.getOption('imageStatusItem'))({ ID: this.model.get('ID'), TYPE: this.model.get('DCT'), statuses: this.getOption('imagestatuses'), el: this.$el })
-      const isCharacterization = this.model.get('DCT') === "Characterization"
-      const hasStrategies = this.model.get('AXISRANGE') > 0 && this.model.get('OVERLAP') != 0
-      const hasProcessing = this.model.get('AXISRANGE') > 0 || this.model.get('DCT') === "Serial Fixed" || this.model.get('DCT') === "Serial Jet"
-      const showStrategies = isCharacterization || hasStrategies
-      const showProcessing = isCharacterization || (!hasStrategies && hasProcessing)
-      if (!showStrategies) this.ui.strat.hide()
-      if (!showProcessing) {
+      if (!this.showStrategies) this.ui.strat.hide()
+      if (!this.showProcessing) {
           this.ui.ap.hide();
           this.ui.dp.hide();
       }
-      this.apstatus = new (this.getOption('apStatusItem'))({ ID: this.model.get('ID'), showStrategies: showStrategies, showProcessing: showProcessing, statuses: this.getOption('apstatuses'), el: this.$el })
+
+      this.apstatus = new (this.getOption('apStatusItem'))({ ID: this.model.get('ID'), showStrategies: this.showStrategies, showProcessing: this.showProcessing, statuses: this.getOption('apstatuses'), el: this.$el })
       this.listenTo(this.apstatus, 'status', this.updateAP, this)
       this.apmessagestatus = new (this.getOption('apMessageStatusItem'))({ ID: this.model.get('ID'), statuses: this.getOption('apmessagestatuses'), el: this.$el })
 

--- a/client/src/js/modules/types/gen/dc/dc.js
+++ b/client/src/js/modules/types/gen/dc/dc.js
@@ -21,6 +21,8 @@ define([
             'click a.dd': utils.signHandler,
         },
 
+        setProcessingVars: function() {},
+
         associateSample: function(e) {
             e.preventDefault()
             app.dialog.show(new AssocSampleView({ model: this.model }))

--- a/client/src/js/modules/types/pow/dc/dc.js
+++ b/client/src/js/modules/types/pow/dc/dc.js
@@ -18,7 +18,9 @@ define([
             'click a.assoc': 'associateSample',
             'click a.dd': utils.signHandler,
         },
-        
+
+        setProcessingVars: function() {},
+
         showPlot: function(e) {
             e.preventDefault()
             app.dialog.show(new DialogView({ title: '1D Plot', view: new DatPlotLarge({ parent: this.model }), autoSize: true }))

--- a/client/src/js/modules/types/saxs/dc/dc.js
+++ b/client/src/js/modules/types/saxs/dc/dc.js
@@ -18,7 +18,9 @@ define([
             'click a.dd': utils.signHandler,
             'click .holder h1.dp': 'loadAP',
         },
-        
+
+        setProcessingVars: function() {},
+
         showDiff: function(e) {
             e.preventDefault()
             this.$el.find('.diffraction a').eq(0).trigger('click')

--- a/client/src/js/modules/types/sm/dc/dc.js
+++ b/client/src/js/modules/types/sm/dc/dc.js
@@ -8,6 +8,8 @@ define([
         apStatusItem: APStatusItem,
         template: Template,
 
+        setProcessingVars: function() {},
+
         loadAP: function(e) {
             if (!this.ap) {
               this.ap = new DCAutoIntegrationView({ id: this.model.get('ID'), dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA'), el: this.$el.find('div.autoproc') })

--- a/client/src/js/modules/types/tomo/dc/dc.js
+++ b/client/src/js/modules/types/tomo/dc/dc.js
@@ -5,6 +5,9 @@ define([
     return DCItemView.extend({
         template: template,
         plotView: null,
+
+        setProcessingVars: function() {},
+
     })
 
 })

--- a/client/src/js/modules/types/xpdf/dc/dc.js
+++ b/client/src/js/modules/types/xpdf/dc/dc.js
@@ -29,6 +29,8 @@ define([
             params: '.params'
         },
 
+        setProcessingVars: function() {},
+
         onDomRefresh: function() {
             var params = JSON.parse(this.model.get('SCANPARAMS'))
             if(params != null){


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1833](https://jira.diamond.ac.uk/browse/LIMS-1833)

**Summary**:

PR https://github.com/DiamondLightSource/SynchWeb/pull/956 broke the data collection view for some non-MX villages (eg XPDF), by trying to hide a non-existing strategies or auto processing bar.

**Changes**:
- Move setup of showStrategies and showProcessing into it's own function, then override it for each non-MX village.

**To test**:
- Repeat tests from https://github.com/DiamondLightSource/SynchWeb/pull/956
- Go to an XPDF visit (eg /dc/visit/cm40633-3), check data collections are visible, as well as Data Files and Auto Processing bars
- Repeat for an Generic visit (eg /dc/visit/cm40629-2)
- Repeat for a SAXS visit (eg /dc/visit/cm40642-3)
- Repeat for a Small Molecule visit (eg /dc/visit/cm40638-3), this should look more like mx with Auto Processing and Downstream Processing bars
