### PR TITLE
LIMS-1839: Fix fast_dp radiation damage plots

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1621,15 +1621,15 @@ class DC extends Page
                 INNER JOIN autoproc ap ON aps.autoprocid = ap.autoprocid 
                 INNER JOIN autoprocprogram app ON api.autoprocprogramid = app.autoprocprogramid 
                 INNER JOIN autoprocprogramattachment appa ON appa.autoprocprogramid = app.autoprocprogramid 
-                WHERE api.datacollectionid = :1 AND api.autoprocprogramid=:2 AND appa.filetype LIKE 'Log'", array($id, $aid));
+                WHERE api.datacollectionid = :1 AND api.autoprocprogramid=:2 AND appa.filename='xdsstat.log'", array($id, $aid));
 
         if (!sizeof($info))
-            $this->_error('The specified auto processing doesnt exist');
+            $this->_error('The xdsstat.log file doesnt exist');
         else
             $info = $info[0];
         $this->db->close();
 
-        $file = $info['FILEPATH'] . '/xdsstat.log';
+        $file = $info['FILEPATH'] . '/' . $info['FILENAME'];
 
         $rows = array();
         if (file_exists($file)) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1839](https://jira.diamond.ac.uk/browse/LIMS-1839)

**Summary**:

Fast dp radiation damage plots stopped working when some fast_dp files were moved to a different folder.

**Changes**:
- Search specifically for the xdsstat.log file, not just any fast_dp file

**To test**:
- Go to a recent data collection with successful fast_dp (eg /dc/visit/cm40607-3/id/19021858)
- Click on Auto Processing, choose the fast_dp tab, then click Radiation Damage. Check a plot appears.
- Repeat for an older data collection before the files were moved (eg /dc/visit/cm40607-1/id/17183638)
