### PR TITLE
LIMS-1783: Add parent container dropdown for gridboxes

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -124,6 +124,9 @@
     # List of enabled container types, all if empty
     $enabled_container_types = array();
 
+    # Show parent container field for these types
+    $container_types_with_parents = array();
+
     # Zocalo message broker credentials - Set to empty string to disable
     $rabbitmq_zocalo_host = 'rabbitmq.server.ac.uk';
     $rabbitmq_zocalo_port = 5672;

--- a/api/index.php
+++ b/api/index.php
@@ -73,7 +73,7 @@ function setupApplication($mode): Slim
             $valid_components, $enabled_container_types, $synchweb_version, $redirects,
             $shipping_service_app_url, $use_shipping_service_redirect, $use_shipping_service_redirect_incoming_shipments,
             $dials_rest_url_rings, $closed_proposal_link, $ccp4_cloud_upload_url,
-            $only_staff_can_assign;
+            $only_staff_can_assign, $container_types_with_parents;
         $app->contentType('application/json');
         $options = $app->container['options'];
         $app->response()->body(json_encode(array(
@@ -102,7 +102,8 @@ function setupApplication($mode): Slim
             'dials_rest_url_rings' => $dials_rest_url_rings,
             'ccp4_cloud_upload_url' => $ccp4_cloud_upload_url,
             'redirects' => $redirects,
-            'only_staff_can_assign' => $only_staff_can_assign
+            'only_staff_can_assign' => $only_staff_can_assign,
+            'container_types_with_parents' => $container_types_with_parents
         )));
     });
     return $app;

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -131,7 +131,8 @@ class Shipment extends Page
         'SOURCE' => '[\w\-]+',
 
         'CONTAINERREGISTRYID' => '\d+',
-        'PARENTCONTAINERID' => '\d+',
+        'PARENTCONTAINERID' => '\d*',
+        'PARENTCONTAINERLOCATION' => '\d*',
         'PROPOSALID' => '\d+',
         't' => '\w+',
 
@@ -2371,7 +2372,7 @@ class Shipment extends Page
                 count(distinct ci.containerinspectionid) as inspections,
                 c.scheduleid, c.screenid, c.ownerid, c.imagerid, c.bltimestamp, c.samplechangerlocation, c.beamlinelocation, c.containertype, c.capacity, c.barcode,
                 c.containerstatus, c.containerid, c.code as name, c.requestedreturn, c.requestedimagerid, c.comments, c.experimenttype, c.storagetemperature,
-                c.parentcontainerid, pc.code as parentcontainer,
+                c.parentcontainerid, c.parentcontainerlocation, pc.code as parentcontainer,
                 sc.name as screen,
                 i.temperature, i.name as imager,
                 CONCAT(p.proposalcode, p.proposalnumber) as prop, CONCAT(p.proposalcode, p.proposalnumber, '-', ses.visit_number) as visit, ses.beamlinename,
@@ -2527,11 +2528,12 @@ class Shipment extends Page
         if (!sizeof($chkc))
             $this->_error('No such container');
 
-        $fields = array('NAME' => 'CODE', 'REQUESTEDRETURN' => 'REQUESTEDRETURN', 'REQUESTEDIMAGERID' => 'REQUESTEDIMAGERID', 'COMMENTS' => 'COMMENTS', 'BARCODE' => 'BARCODE', 'CONTAINERTYPE' => 'CONTAINERTYPE', 'EXPERIMENTTYPE' => 'EXPERIMENTTYPE', 'STORAGETEMPERATURE' => 'STORAGETEMPERATURE', 'CONTAINERREGISTRYID' => 'CONTAINERREGISTRYID', 'PROCESSINGPIPELINEID' => 'PRIORITYPIPELINEID', 'OWNERID' => 'OWNERID', 'PARENTCONTAINERID' => 'PARENTCONTAINERID');
+        $fields = array('NAME' => 'CODE', 'REQUESTEDRETURN' => 'REQUESTEDRETURN', 'REQUESTEDIMAGERID' => 'REQUESTEDIMAGERID', 'COMMENTS' => 'COMMENTS', 'BARCODE' => 'BARCODE', 'CONTAINERTYPE' => 'CONTAINERTYPE', 'EXPERIMENTTYPE' => 'EXPERIMENTTYPE', 'STORAGETEMPERATURE' => 'STORAGETEMPERATURE', 'CONTAINERREGISTRYID' => 'CONTAINERREGISTRYID', 'PROCESSINGPIPELINEID' => 'PRIORITYPIPELINEID', 'OWNERID' => 'OWNERID', 'PARENTCONTAINERID' => 'PARENTCONTAINERID', 'PARENTCONTAINERLOCATION' => 'PARENTCONTAINERLOCATION');
         foreach ($fields as $k => $f) {
             if ($this->has_arg($k)) {
-                $this->db->pq("UPDATE container SET $f=:1 WHERE containerid=:2", array($this->arg($k), $this->arg('cid')));
-                $this->_output(array($k => $this->arg($k)));
+                $val = $this->arg($k) != '' ? $this->arg($k) : null;
+                $this->db->pq("UPDATE container SET $f=:1 WHERE containerid=:2", array($val, $this->arg('cid')));
+                $this->_output(array($k => $val));
             }
         }
 
@@ -2568,14 +2570,15 @@ class Shipment extends Page
 
         $crid = $this->has_arg('CONTAINERREGISTRYID') ? $this->arg('CONTAINERREGISTRYID') : null;
         $pcid = $this->has_arg('PARENTCONTAINERID') ? $this->arg('PARENTCONTAINERID') : null;
+        $pcl = $this->has_arg('PARENTCONTAINERLOCATION') ? $this->arg('PARENTCONTAINERLOCATION') : null;
 
         $pipeline = $this->has_arg('PROCESSINGPIPELINEID') ? $this->arg('PROCESSINGPIPELINEID') : null;
         $source = $this->has_arg('SOURCE') ? $this->arg('SOURCE') : null;
 
         $this->db->pq(
-            "INSERT INTO container (containerid,dewarid,code,bltimestamp,capacity,containertype,scheduleid,screenid,ownerid,requestedimagerid,comments,barcode,experimenttype,storagetemperature,containerregistryid,parentcontainerid,prioritypipelineid,source)
-              VALUES (s_container.nextval,:1,:2,CURRENT_TIMESTAMP,:3,:4,:5,:6,:7,:8,:9,:10,:11,:12,:13,:14,:15,IFNULL(:16,CURRENT_USER)) RETURNING containerid INTO :id",
-            array($this->arg('DEWARID'), $this->arg('NAME'), $cap, $this->arg('CONTAINERTYPE'), $sch, $scr, $own, $rid, $com, $bar, $ext, $tem, $crid, $pcid, $pipeline, $source)
+            "INSERT INTO container (containerid,dewarid,code,bltimestamp,capacity,containertype,scheduleid,screenid,ownerid,requestedimagerid,comments,barcode,experimenttype,storagetemperature,containerregistryid,parentcontainerid,parentcontainerlocation,prioritypipelineid,source)
+              VALUES (s_container.nextval,:1,:2,CURRENT_TIMESTAMP,:3,:4,:5,:6,:7,:8,:9,:10,:11,:12,:13,:14,:15,:16,IFNULL(:17,CURRENT_USER)) RETURNING containerid INTO :id",
+            array($this->arg('DEWARID'), $this->arg('NAME'), $cap, $this->arg('CONTAINERTYPE'), $sch, $scr, $own, $rid, $com, $bar, $ext, $tem, $crid, $pcid, $pcl, $pipeline, $source)
         );
 
         $cid = $this->db->id();

--- a/client/src/js/app/components/base-input-text.vue
+++ b/client/src/js/app/components/base-input-text.vue
@@ -59,7 +59,7 @@ https://eslint.vuejs.org/rules/no-v-html.html
       </span>
     </span>
     <button
-      v-if="inline && editable"
+      v-if="inline && editable && !errorMessage"
       class="button tw-px-2 tw-py-1"
       @mousedown="onSave"
     >
@@ -132,6 +132,11 @@ export default {
       type: Boolean,
       default: false
     },
+    // Force validation on input, even to an inline field
+    validateOnInput: {
+      type: Boolean,
+      default: false
+    },
     // If using the input within a table, set quiet mode to suppress error messages
     // Keeps the styling around input fields
     quiet: {
@@ -190,7 +195,7 @@ export default {
     updateValue(event) {
       // If we are in inline editing mode, only update model on save
       // If not them update value via input event
-      if (!this.inline) this.$emit("input", event.target.value);
+      if (!this.inline || this.validateOnInput) this.$emit("input", event.target.value);
     },
     onBlur() {
       // If in inline edit mode cancel edit

--- a/client/src/js/modules/types/mx/shipment/views/container-mixin.js
+++ b/client/src/js/modules/types/mx/shipment/views/container-mixin.js
@@ -5,6 +5,7 @@ import AnomalousList from 'utils/anoms.js'
 import ExperimentKindsList from 'utils/experimentkinds.js'
 import DistinctProteins from 'modules/shipment/collections/distinctproteins'
 import ContainerRegistry from 'modules/shipment/collections/containerregistry'
+import ContainersCollection from 'collections/containers'
 import ContainerTypes from 'modules/shipment/collections/containertypes'
 import SampleGroups from 'collections/samplegroups'
 import ImagingImager from 'modules/imaging/collections/imagers'
@@ -40,6 +41,8 @@ export default {
       containerRegistryCollection: new ContainerRegistry(),
       containerRegistry: [],
       containerRegistryId: '',
+      parentContainersCollection: new ContainersCollection(),
+      parentContainers: [],
       containerTypeDetails: {},
 
       experimentTypes: [
@@ -135,6 +138,13 @@ export default {
       this.containerRegistryCollection = new ContainerRegistry(null, { state: { pageSize: 9999 }})
       const result = await this.$store.dispatch('getCollection', this.containerRegistryCollection)
       this.containerRegistry = [{ CONTAINERREGISTRYID: null, BARCODE: ""}, ...result.toJSON()]
+    },
+    async getParentContainers() {
+      this.parentContainersCollection = new ContainersCollection(null, { state: { pageSize: 9999 }})
+      this.parentContainersCollection.dewarID = this.container ? this.container.DEWARID : this.DEWARID
+      const result = await this.$store.dispatch('getCollection', this.parentContainersCollection)
+      const filteredResult = this.container ? result.toJSON().filter(item => item.CONTAINERID !== this.container.CONTAINERID) : result.toJSON()
+      this.parentContainers = [{ PARENTCONTAINERID: null, NAME: ""}, ...filteredResult]
     },
     async getContainerTypes() {
       this.containerFilter = [this.$store.state.proposal.proposalType]
@@ -512,6 +522,14 @@ export default {
   computed: {
     containerFilter: function() {
       return [this.$store.state.proposal.proposalType]
+    },
+    showParentContainer() {
+        if (!app.options.get('container_types_with_parents')) return false
+        if (this.container) {
+            return app.options.get('container_types_with_parents').indexOf(this.container.CONTAINERTYPE) > -1
+        } else {
+            return app.options.get('container_types_with_parents').indexOf(this.CONTAINERTYPE) > -1
+        }
     },
     isPuck() {
       return this.containerType.WELLPERROW === null

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -8,7 +8,7 @@
         ref="containerForm"
         v-slot="{ invalid, errors }"
       >
-        <!-- Old Add containers had an assign button here - try leaving it out as there is a menu item for /assign -->
+
         <form
           id="add_container"
           class="tw-flex"
@@ -67,6 +67,18 @@
                   :error-message="errors[0]"
                 />
               </validation-provider>
+
+              <base-input-select
+                v-show="showParentContainer"
+                dataTestId="add-container-parent-container"
+                v-model="PARENTCONTAINERID"
+                outer-class="tw-mb-2 tw-py-2"
+                label="Parent Container"
+                name="PARENTCONTAINERID"
+                :options="parentContainers"
+                option-value-key="CONTAINERID"
+                option-text-key="NAME"
+              />
 
               <base-input-select
                 v-model="PROCESSINGPIPELINEID"
@@ -475,6 +487,7 @@ export default {
       PROCESSINGPIPELINEID: null,
       NAME: "",
       CONTAINERREGISTRYID: null,
+      PARENTCONTAINERID: null,
       AUTOMATED: 0,
       BARCODE: "",
       PERSONID: "",
@@ -619,6 +632,7 @@ export default {
     this.getProteins()
     this.getContainerTypes()
     this.getContainerRegistry()
+    this.getParentContainers()
     this.getProcessingPipelines()
     this.formatExperimentKindList()
     this.getSampleGroups()
@@ -667,6 +681,7 @@ export default {
         containerAttributes = {
           ...containerAttributes,
           CONTAINERREGISTRYID: this.CONTAINERREGISTRYID,
+          PARENTCONTAINERID: this.PARENTCONTAINERID,
           PROCESSINGPIPELINEID: this.PROCESSINGPIPELINEID,
           SPACEGROUP: this.SPACEGROUP
         }
@@ -711,6 +726,7 @@ export default {
         this.NAME = ''
         this.BARCODE = ''
         this.CONTAINERREGISTRYID = ''
+        this.PARENTCONTAINERID = ''
         // Trigger default setting of UDC fields if selected
         this.selectQueueForUDC(this.AUTOMATED)
 

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -57,7 +57,7 @@
                 v-slot="{ errors }"
                 tag="div"
                 class="tw-mb-2 tw-py-2"
-                rules="required"
+                rules="required|alpha_dash"
                 name="Container Name"
                 vid="container-name"
               >
@@ -79,6 +79,22 @@
                 option-value-key="CONTAINERID"
                 option-text-key="NAME"
               />
+
+              <validation-provider
+                v-slot="{ errors }"
+                tag="div"
+                class="tw-mb-2 tw-py-2"
+                rules="numeric"
+                name="Parent Container Location"
+                vid="parent-container-location"
+              >
+                <base-input-text
+                  v-show="showParentContainer"
+                  v-model="PARENTCONTAINERLOCATION"
+                  label="Parent Container Location"
+                  :error-message="errors[0]"
+                />
+              </validation-provider>
 
               <base-input-select
                 v-model="PROCESSINGPIPELINEID"
@@ -488,6 +504,7 @@ export default {
       NAME: "",
       CONTAINERREGISTRYID: null,
       PARENTCONTAINERID: null,
+      PARENTCONTAINERLOCATION: null,
       AUTOMATED: 0,
       BARCODE: "",
       PERSONID: "",
@@ -682,6 +699,7 @@ export default {
           ...containerAttributes,
           CONTAINERREGISTRYID: this.CONTAINERREGISTRYID,
           PARENTCONTAINERID: this.PARENTCONTAINERID,
+          PARENTCONTAINERLOCATION: this.PARENTCONTAINERLOCATION,
           PROCESSINGPIPELINEID: this.PROCESSINGPIPELINEID,
           SPACEGROUP: this.SPACEGROUP
         }
@@ -727,6 +745,7 @@ export default {
         this.BARCODE = ''
         this.CONTAINERREGISTRYID = ''
         this.PARENTCONTAINERID = ''
+        this.PARENTCONTAINERLOCATION = ''
         // Trigger default setting of UDC fields if selected
         this.selectQueueForUDC(this.AUTOMATED)
 

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -92,6 +92,22 @@
                 @save="save('BARCODE')"
               />
             </li>
+            <li
+              v-if="showParentContainer"
+              class="tw-flex tw-flex-row tw-w-full"
+            >
+              <span class="label">Parent Container</span>
+              <base-input-select
+                v-model="container.PARENTCONTAINERID"
+                :initial-text="container.PARENTCONTAINER ? container.PARENTCONTAINER : 'Click to edit'"
+                name="PARENTCONTAINERID"
+                :options="parentContainers"
+                :inline="true"
+                option-value-key="CONTAINERID"
+                option-text-key="NAME"
+                @save="save('PARENTCONTAINERID')"
+              />
+            </li>
             <li v-if="container.PIPELINE">
               <span class="label">Priority Processing</span>
               <base-input-select
@@ -363,6 +379,7 @@ export default {
     this.getGlobalProteins()
     this.getProteins()
     this.getContainerRegistry()
+    this.getParentContainers()
     this.getHistory()
     this.getContainerTypes()
     this.getUsers()


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1783](https://jira.diamond.ac.uk/browse/LIMS-1783)

**Summary**:

VMXm grid boxes are containers, but each belongs inside a Cryo-EM puck. If someone is making or viewing a grid box, we should have a selector to choose the parent container and the location within it.

**Changes**:
- Add a list to the config of container types which have parent containers
- Add backend methods for setting, getting, updating or deleting the parentContainerId and parentContainerLocaton fields
- Display a list of potential parent containers from the same dewar as the grid box being created
- Display an input for the location, with validation for only numeric values
- Add validation to the container name field in the same way

**To test**:
- Add to the config
```
$container_types_with_parents = array("VMXm-GridBox");
```
- Go to a shipment (eg /shipments/sid/69454) and click Add Container
- Check the Parent Container fields are not displayed unless the container type is a VMXm-GridBox
- Check the dropdown shows the other containers from the same dewar
- Check the Parent Container Location field only accepts numeric values
- Check the Container Name field only accepts alpha-numeric, dashes and underscores
- Create a gridbox with the parent container fields filled in, no samples are required
- Click to view the container, check you are shown the parent container fields
- Check you can edit the parent container and location, and only numeric values are accepted for location
- Check you can edit the container name, and only alpha-numeric, dashes and underscores are accepted
- Check you can set the parent container fields to nothing
- Check you cannot set the container name to nothing
- Go to a different container type (eg /containers/cid/329485), check no parent container fields are shown