### PR TITLE
LIMS-1814: Add min images filter to summary page

### DIFF
--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -38,6 +38,7 @@ class Processing extends Page {
         'rmeas' => '[\d\.]+',
         'cchalf' => '[\d\.]+',
         'ccanom' => '[\d\.]+',
+        'images' => '\d+',
         'username' => '(\w|\s|\-|\.)+',
         'cloudrunid' => '(\w|\-)+',
         'AUTOPROCPROGRAMATTACHMENTID' => '\d+',
@@ -338,7 +339,7 @@ class Processing extends Page {
 
         $args = array($info[0]['SESSIONID']);
 
-        $where = 'dc.sessionid=:1 AND dc.overlap = 0 AND dc.axisrange > 0 AND dc.numberOfImages > 150 AND app.processingstatus = 1';
+        $where = 'dc.sessionid=:1 AND dc.overlap = 0 AND dc.axisrange > 0 AND app.processingstatus = 1';
 
         if ($this->has_arg('pipeline')) {
             $st = sizeof($args);
@@ -386,6 +387,12 @@ class Processing extends Page {
             $st = sizeof($args);
             $where .= " AND apssinner.ccanomalous >= :" . ($st + 1);
             array_push($args, $this->arg('ccanom'));
+        }
+
+        if ($this->has_arg('images')) {
+            $st = sizeof($args);
+            $where .= " AND dc.numberOfImages >= :" . ($st + 1);
+            array_push($args, $this->arg('images'));
         }
 
         if ($this->has_arg('s')) {

--- a/client/src/js/modules/dc/views/summary.js
+++ b/client/src/js/modules/dc/views/summary.js
@@ -37,6 +37,7 @@ define(['backbone',
             'change @ui.maxrmeas': 'changeRmeas',
             'change @ui.mincchalf': 'changeCCHalf',
             'change @ui.minccanom': 'changeCCAnom',
+            'change @ui.minimages': 'changeImages',
         },
         
         ui: {
@@ -48,10 +49,16 @@ define(['backbone',
             maxrmeas: 'input[name=maxrmeas]',
             mincchalf: 'input[name=mincchalf]',
             minccanom: 'input[name=minccanom]',
+            minimages: 'input[name=minimages]',
         },
         
         initialize: function(options) {
             this.visit = options.model.get('VISIT')
+        },
+
+        updateData: function() {
+            this.collection.state['currentPage'] = 1
+            this.collection.fetch()
         },
 
         changePipeline: function() {
@@ -60,7 +67,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.pipeline
             }
-            this.collection.fetch()
+            this.updateData()
         },
 
         showSpaceGroups: async function() {
@@ -75,7 +82,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.spacegroup
             }
-            this.collection.fetch()
+            this.updateData()
         },
         
         changeResolution: function() {
@@ -84,7 +91,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.resolution
             }
-            this.collection.fetch()
+            this.updateData()
         },
 
         changeCompleteness: function() {
@@ -93,7 +100,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.completeness
             }
-            this.collection.fetch()
+            this.updateData()
         },
 
         changeAnomCompleteness: function() {
@@ -102,7 +109,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.anomcompleteness
             }
-            this.collection.fetch()
+            this.updateData()
         },
 
         changeRmeas: function() {
@@ -111,7 +118,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.rmeas
             }
-            this.collection.fetch()
+            this.updateData()
         },
 
         changeCCHalf: function() {
@@ -120,7 +127,7 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.cchalf
             }
-            this.collection.fetch()
+            this.updateData()
         },
 
         changeCCAnom: function() {
@@ -129,7 +136,16 @@ define(['backbone',
             } else {
                 delete this.collection.queryParams.ccanom
             }
-            this.collection.fetch()
+            this.updateData()
+        },
+
+        changeImages: function() {
+            if (this.ui.minimages.val()) {
+                this.collection.queryParams.images = this.ui.minimages.val()
+            } else {
+                delete this.collection.queryParams.images
+            }
+            this.updateData()
         },
 
         onRender: function() {

--- a/client/src/js/templates/dc/summary.html
+++ b/client/src/js/templates/dc/summary.html
@@ -13,6 +13,7 @@
     <label>Max Rmeas: <input type="text" name="maxrmeas" /></label>
     <label>Min CC½: <input type="text" name="mincchalf" /></label>
     <label>Min CCanom: <input type="text" name="minccanom" /></label>
+    <label>Min Images: <input type="text" name="minimages" /></label>
 </div>
 
 <div class="wrapper"></div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1814](https://jira.diamond.ac.uk/browse/LIMS-1814)

**Summary**:

The summary page (eg https://ispyb.diamond.ac.uk/dc/summary/visit/nt37104-180) only shows data collections with more than 150 images, to avoid showing Characterization experiments. But this excludes lots of data from eg VMXi, so we should remove it, and replace with an optional filter.

**Changes**:
- Add a filter for minimum number of images, rather than a hard-coded 150 image minimum
- Fix a bug where going to a late page number and then filtering would crash the page

**To test**:
- Go to /dc/summary/visit/nt37104-180
- Check the number of pages of results is 23, and the last result is "image_253141"
- Add a filter of minimum images = 151, check the number of pages reduces to 19, and the last result is "image_255476"
- Go to the last page of results, then add a filter that would reduce the number of pages to less than the page you are on (eg 99% completeness). Check you are taken to page 1 of the results.
- Clear the filters and check the number of pages returns to 23.
