### PR TITLE
LIMS-1845: Fix broken VMXi attachment names

### DIFF
--- a/api/src/Page/Download.php
+++ b/api/src/Page/Download.php
@@ -369,7 +369,8 @@ class Download extends Page
         foreach ($rows as &$r) {
             $r['FILENAME'] = basename($r['FILEFULLPATH']);
             $r['FILEPATH'] = dirname($r['FILEFULLPATH']);
-
+            $info = pathinfo($r['FILENAME']);
+            $r['NAME'] = basename($r['FILENAME'], '.' . $info['extension']);
 
             foreach (array('DX_MM', 'DY_MM', 'STEPS_X', 'STEPS_Y', 'SNAKED') as $k) {
                 $r[$k] = floatval($r[$k]);


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1845](https://jira.diamond.ac.uk/browse/LIMS-1845)

**Summary**:

PR https://github.com/DiamondLightSource/SynchWeb/pull/959 broke the dropdown for VMXi grid scans, where it shows the name of each attachment on a dropdown. This is to fix that.

**Changes**:
- Re-add the 'NAME' field to the returned info

**To test**:
- Go to a VMXi grid scan, eg /dc/visit/nt37104-125/id/19041028
- Check there are 2 dropdowns on the image, one for choosing between image 1-4 (unchanged) and one for choosing between 'pia_total_intensity', 'pia_n_spots_total', 'pia_estimated_d_min', 'pia_n_spots_no_ice' and 'None'
- Check each one shows the data slightly differently
