### PR TITLE
LIMS-1804: Make barcode be required for new plates

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -104,18 +104,21 @@
             </div>
 
             <div v-show="plateType === 'plate'">
-              <div class="tw-flex tw-w-full tw-relative">
+              <validation-provider
+                v-if="plateType === 'plate'"
+                v-slot="{ errors }"
+                tag="div"
+                class="tw-mb-2 tw-py-2"
+                rules="required"
+                name="Barcode"
+                vid="barcode"
+              >
                 <base-input-text
                   v-model="BARCODE"
-                  outer-class="tw-mb-2 tw-py-2 tw-flex tw-flex-1"
                   label="Barcode"
-                  name="Barcode"
+                  :error-message="getBarcodeErrorMessage(errors)"
                 />
-                <span
-                  v-if="barcodeMessage"
-                  class="barcode-message tw-text-xs tw-ml-4 tw-bg-content-light-background tw-rounded tw-p-2 tw-absolute"
-                >{{ barcodeMessage }}</span>
-              </div>
+              </validation-provider>
 
               <validation-provider
                 v-slot="{ errors }"
@@ -717,8 +720,14 @@ export default {
         // Reset state of form
         this.$refs.containerForm.reset()
       } catch (error) {
+        let errorMessage = 'Something went wrong creating this container, please try again'
+        if (error.response && error.response.data && error.response.data.message) {
+          errorMessage = error.response.data.message
+        } else if (error.message) {
+          errorMessage = error.message
+        }
         this.$store.commit('notifications/addNotification', {
-          message: 'Something went wrong creating this container, please try again',
+          message: errorMessage,
           level: 'error'
         })
       } finally {
@@ -822,6 +831,12 @@ export default {
 
         this.$store.commit('samples/updateSamplesField', { path: `samples/${index}/SCREENCOMPONENTGROUPID`, value: data })
       })
+    },
+    getBarcodeErrorMessage(veeValidateErrors) {
+      if (veeValidateErrors && veeValidateErrors.length > 0) {
+        return veeValidateErrors[0];
+      }
+      return this.barcodeMessage || '';
     },
   }
 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1804](https://jira.diamond.ac.uk/browse/LIMS-1804)

**Summary**:

Barcode should be a required field for plates

**Changes**:
- Add a validation of required to the barcode field
- Combine the error message with the message about uniqueness
- If a user does try and add a barcode that is already used, catch the database error and return a sensible message

**To test**:
- Go to any shipment in any proposal, eg /shipments/sid/65577, and click Add Container
- Create a puck, checking that barcode is not a required field
- Create a plate (eg container type of CrystalQuickX), try to leave the barcode field blank, check you get an error
- Try a barcode that already exists (eg "a"), check you get a sensible error message
- Try a unique barcode, check you can create the plate (no samples are needed)
