### PR TITLE
LIMS-1848: Fix bug where no container types are available

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -240,7 +240,9 @@ class Proposal extends Page
                 foreach ($bls as $bl) {
                     $b = $bl['BEAMLINENAME'];
                     $bty = $this->_get_type_from_beamline($b);
-                    array_push($tys, $bty);
+                    if (!in_array($bty, $tys)) {
+                        array_push($tys, $bty);
+                    }
                     if (!$found) {
                         $ty = $bty;
                         $found = True;
@@ -251,7 +253,7 @@ class Proposal extends Page
             if (!$ty)
                 $ty = 'gen';
             $r['TYPE'] = $ty;
-            $r['TYPES'] = array_unique($tys);
+            $r['TYPES'] = $tys;
         }
 
         if ($id) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1848](https://jira.diamond.ac.uk/browse/LIMS-1848)

**Summary**:

When creating a new container, for some proposals eg mx34438, no container types are displayed to the user. This was caused by https://github.com/DiamondLightSource/SynchWeb/pull/960

**Changes**:
- Uniquify beamline types before inserting into the $tys array, rather than after

**To test**:
- Go to proposal mx34338, create a container, check container types for mx and saxs are shown
- Repeat for mx23694, check only mx types are shown
- Repeat for nt40910, check mx and sm types are shown
