### PR TITLE
LIMS-1802: Improvements to Add Shipment page

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -98,6 +98,7 @@ class Shipment extends Page
         'LASTMINUTEBEAMTIME' => '1?|Yes|No',
         'DEWARGROUPING' => '.*',
         'EXTRASUPPORTREQUIREMENT' => '.*',
+        'ONSITEUSERS' => '.*',
         'MULTIAXISGONIOMETRY' => '1?|Yes|No',
         'ENCLOSEDHARDDRIVE' => '1?|Yes|No',
         'ENCLOSEDTOOLS' => '1?|Yes|No',
@@ -165,6 +166,7 @@ class Shipment extends Page
         'LASTMINUTEBEAMTIME',
         'DEWARGROUPING',
         'EXTRASUPPORTREQUIREMENT',
+        'ONSITEUSERS',
         'MULTIAXISGONIOMETRY',
         'ENCLOSEDHARDDRIVE',
         'ENCLOSEDTOOLS',
@@ -406,7 +408,9 @@ class Shipment extends Page
             $extra_json = json_decode($s['EXTRA'], true);
             if (is_null($extra_json)) {
                 $extra_json = array();
-                foreach ($this->extra_arg_list as $arg) {
+            }
+            foreach ($this->extra_arg_list as $arg) {
+                if (!array_key_exists($arg, $extra_json)) {
                     $extra_json[$arg] = "";
                 }
             }
@@ -3117,6 +3121,7 @@ class Shipment extends Page
             }
             $dewar_grouping = $this->has_arg('DEWARGROUPING') ? $this->arg('DEWARGROUPING') : '';
             $extra_support_requirement = $this->has_arg('EXTRASUPPORTREQUIREMENT') ? $this->arg('EXTRASUPPORTREQUIREMENT') : '';
+            $onsite_users = $this->has_arg('ONSITEUSERS') ? $this->arg('ONSITEUSERS') : '';
             $multi_axis_goniometry = null;
             if ($this->has_arg('MULTIAXISGONIOMETRY')) {
                 $multi_axis_goniometry = $this->arg('MULTIAXISGONIOMETRY') ? "Yes" : "No";
@@ -3131,6 +3136,7 @@ class Shipment extends Page
                 "LASTMINUTEBEAMTIME" => $last_minute_beamtime,
                 "DEWARGROUPING" => $dewar_grouping,
                 "EXTRASUPPORTREQUIREMENT" => $extra_support_requirement,
+                "ONSITEUSERS" => $onsite_users,
                 "MULTIAXISGONIOMETRY" => $multi_axis_goniometry
             );
 

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -373,7 +373,8 @@ define(['marionette',
             this.edit.create("SCHEDULINGRESTRICTIONS", 'text')
             this.edit.create("LASTMINUTEBEAMTIME", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
             this.edit.create("DEWARGROUPING", 'select', { data: {'Yes': 'Yes', 'No': 'No', 'Don\'t mind': 'Don\'t mind'}})
-            this.edit.create("EXTRASUPPORTREQUIREMENT", 'text');
+            this.edit.create("EXTRASUPPORTREQUIREMENT", 'text', { placeholder: 'No' });
+            this.edit.create("ONSITEUSERS", 'text', { placeholder: 'No' });
             this.edit.create("MULTIAXISGONIOMETRY", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
 
             this.updateGUI()

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -64,6 +64,8 @@ define(['marionette', 'views/form',
             'change @ui.safetylevel': 'changeSafetyLevel',
             'change @ui.dynamic': 'updateFirstExp',
             'change @ui.longwavelengthsel': 'updateLongWavelength',
+            'change @ui.extrasupportsel': 'updateExtraSupport',
+            'change @ui.onsiteusersel': 'updateOnsiteUser',
         },
         
         ui: {
@@ -82,6 +84,8 @@ define(['marionette', 'views/form',
             safetylevel: 'select[name=SAFETYLEVEL]',
             longwavelengthsel: 'select[name=LONGWAVELENGTH]',
             longwavelengthli: '.longwavelength',
+            extrasupportsel: 'select[name=EXTRASUPPORTYESNO]',
+            onsiteusersel: 'select[name=ONSITEUSERYESNO]',
         },
         
         addLC: function(e) {
@@ -168,6 +172,22 @@ define(['marionette', 'views/form',
             }
         },
 
+        updateExtraSupport: function() {
+            if (this.ui.extrasupportsel.val() === 'No') {
+                this.$el.find(".extrasupportdetail").hide()
+            } else {
+                this.$el.find(".extrasupportdetail").show()
+            }
+        },
+
+        updateOnsiteUser: function() {
+            if (this.ui.onsiteusersel.val() === 'No') {
+                this.$el.find(".onsiteuserdetail").hide()
+            } else {
+                this.$el.find(".onsiteuserdetail").show()
+            }
+        },
+
         isIndustrialProposal: function() {
             industrial_codes = app.options.get('industrial_prop_codes')
             return industrial_codes.includes(app.prop.slice(0,2))
@@ -216,6 +236,8 @@ define(['marionette', 'views/form',
             this.$el.find('li.d .floated').append(new FCodes({ collection: this.fcodes, dewars: this.dewars }).render().el)
 
             this.$el.find(".remoteform").hide()
+            this.$el.find(".extrasupportdetail").hide()
+            this.$el.find(".onsiteuserdetail").hide()
             this.$el.find(".remoteormailin").hide()
             
             this.checkFCodes()

--- a/client/src/js/templates/shipment/shipment.html
+++ b/client/src/js/templates/shipment/shipment.html
@@ -112,6 +112,7 @@
                 EXTRASUPPORTREQUIREMENT=(typeof EXTRASUPPORTREQUIREMENT !== 'undefined')? EXTRASUPPORTREQUIREMENT : null;
                 MULTIAXISGONIOMETRY=(typeof MULTIAXISGONIOMETRY !== 'undefined')? MULTIAXISGONIOMETRY : null;
                 LONGWAVELENGTH=(typeof LONGWAVELENGTH !== 'undefined')? LONGWAVELENGTH : null;
+                ONSITEUSER=(typeof ONSITEUSERS !== 'undefined')? ONSITEUSERS : null;
             %>
             <li>
                 <span class="label">Hard drive enclosed</span>
@@ -165,12 +166,17 @@
                 </li>
 
                 <li class="remoteform">
-                    <span class="label">Group Dewars</span>
+                    <span class="label">Group Shipments</span>
                     <span class="DEWARGROUPING"><%-DEWARGROUPING %></span>
                 </li>
 
                 <li class="remoteform">
-                    <span class="label">Extra Support Requirement</span>
+                    <span class="label">On-site Users</span>
+                    <span class="ONSITEUSERS"><%-ONSITEUSERS %></span>
+                </li>
+
+                <li class="remoteform">
+                    <span class="label">Extra Support Required</span>
                     <span class="EXTRASUPPORTREQUIREMENT"><%-EXTRASUPPORTREQUIREMENT %></span>
                 </li>
 

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -59,7 +59,7 @@
                         <input type="radio" name="DYNAMIC" value="UDC" id="udc" data-testid="add-shipment-automated"> I am sending pucks for Unattended Data Collection
                     </label><br />
                     <label class="secondary tw-mr-2">
-                        <input type="radio" name="DYNAMIC" value="Imaging" id="imaging" data-testid="add-shipment-imaging"> I am sending plates for in situ imaging
+                        <input type="radio" name="DYNAMIC" value="Imaging" id="imaging" data-testid="add-shipment-imaging"> I am sending plates for an in situ experiment
                     </label><br />
                     <label class="secondary tw-mr-2">
                         <input type="radio" name="DYNAMIC" value="Yes" id="responsive" data-testid="add-shipment-responsive"> I would like a session to be scheduled
@@ -92,7 +92,8 @@
 
             <li class="remoteform">
                 <label>Session length
-                    <span class="small">Requested beamline session length [hours]</span>
+                    <span class="small">Requested beamline session length [hours].<br />
+                    Feel comfortable asking for additional time for your experiment and training needs.</span>
                 </label>
                 <input name="SESSIONLENGTH" data-testid="add-shipment-length"/>
             </li>
@@ -102,6 +103,22 @@
                     <span class="small">Specify any energy/wavelength requirements [eV/&#8491;]</span>
                 </label>
                 <input type="text" name="ENERGY" data-testid="add-shipment-energy"/>
+            </li>
+
+            <li class="remoteform">
+                <label>Do you require one or more participants to be on-site?
+                    <span class="small">Other users can be remote</span>
+                </label>
+                <select name="ONSITEUSERYESNO" data-testid="add-shipment-onsite-user-yesno">
+                    <option value="No">No</option>
+                    <option value="Yes">Yes</option>
+                </select>
+            </li>
+
+            <li class="onsiteuserdetail">
+                <label>Please list each on-site user, and whether they have a user badge and a valid safety test
+                </label>
+                <textarea name="ONSITEUSERS" data-testid="add-shipment-onsite-users"></textarea>
             </li>
 
             <li class="remoteform">
@@ -116,14 +133,15 @@
 
             <li class="remoteform">
                 <label>Scheduling restrictions for data collection
-                    <span class="small">Are there times in the two weeks after delivery when the people collecting data are unavailable, including weekends?:</span>
+                    <span class="small">Are there times in the two weeks after delivery when the people collecting data are unavailable, including weekends? Not all requirements can be met.</span>
                 </label>
                 <textarea name="SCHEDULINGRESTRICTIONS" data-testid="add-shipment-restrictions"></textarea>
             </li>
 
             <li class="remoteform">
                 <label>Short-notice beam time
-                    <span class="small">Would you like to be considered for short-notice beamtime, generally with only 1-3 days notice?</span>
+                    <span class="small">Would you like to be considered for short-notice beamtime, generally with only 1-3 days notice?<br />
+                    We cannot consider it for short-notice beamtime until all pucks are defined.</span>
                 </label>
                 <select name="LASTMINUTEBEAMTIME" data-testid="add-shipment-last-minute">
                     <option value="0">No</option>
@@ -132,8 +150,8 @@
             </li>
 
             <li class="remoteform">
-                <label>Dewar grouping
-                    <span class="small">Would you prefer your beam time for this dewar to be grouped with beam time for other dewars?:</span>
+                <label>Shipment grouping
+                    <span class="small">Would you prefer your beam time for this shipment to be grouped with beam time for other people from your proposal?:</span>
                 </label>
                 <select name="DEWARGROUPING" data-testid="add-shipment-grouping">
                     <option value="Yes">Yes</option>
@@ -143,8 +161,17 @@
             </li>
 
             <li class="remoteform">
-                <label>Extra support requirement
+                <label>Extra support required
                     <span class="small">Do you need extra support from your Local Contact, for instance, relating to operating the beamlines, or new/specific functionality?</span>
+                </label>
+                <select name="EXTRASUPPORTYESNO" data-testid="add-shipment-extra-support-yesno">
+                    <option value="No">No</option>
+                    <option value="Yes">Yes</option>
+                </select>
+            </li>
+
+            <li class="extrasupportdetail">
+                <label>Please detail the support required
                 </label>
                 <textarea name="EXTRASUPPORTREQUIREMENT" data-testid="add-shipment-extra-support"></textarea>
             </li>
@@ -249,6 +276,8 @@
                 </label>
                 <input type="text" name="DELIVERYAGENT_AGENTCODE" data-testid="add-shipment-account" />
             </li>
+
+            <li>Please define all pucks and samples, and ensure you have attached all the labels, before dispatch.</li>
 
             <button name="submit" value="1" type="submit" class="button submit" data-testid="add-shipment-submit">Add Shipment</button>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1802](https://jira.diamond.ac.uk/browse/LIMS-1802)

**Summary**:

A few minor improvements to the Add Shipment page, to help with scheduling.

**Changes**:
- Add a No/Yes dropdown to the Extra Support question, only showing the text box if they answer 'Yes'
- Add a new No/Yes dropdown to ask if they need any on site users, with a text box appearing if they answer 'Yes', to check if they have a badge etc
- Add a new message at the bottom, reminding users to attach labels and complete the dewar contents before shipping
- Minor wording tweaks

**To test**:
- Go to any proposal, eg mx23694, and click Add Shipment
- Select 'I would like a session to be scheduled', check new questions appear
- Select 'Yes' to the Extra Support question, check a text box appears
- Select 'Yes' to the on site users question, check another text box appears
- Check anything you put in those fields appears on the next page
- Make another shipment, leave those fields as 'No', check that appears on the next page
- Make another shipment as eg 'I am sending pucks for Unattended Data Collection', check no extra questions appear, check you can create a shipment without errors
