### PR TITLE
LIMS-1856: Fix offset for plates

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -112,7 +112,7 @@ class Shipment extends Page
         // Container fields
         'DEWARID' => '\d+',
         'CAPACITY' => '\d+',
-        'CONTAINERTYPE' => '([\w\-])+',
+        'CONTAINERTYPE' => '([\s\w\-])+',
         'NAME' => '([\w\-])+',
         'SCHEDULEID' => '\d+',
         'SCREENID' => '\d+',
@@ -2748,7 +2748,7 @@ class Shipment extends Page
             $where .= ' AND ct.proposaltype = :1';
             array_push($args, $this->arg('PROPOSALTYPE'));
         }
-        $rows = $this->db->pq("SELECT ct.containerTypeId, name, ct.proposalType, ct.capacity, ct.wellPerRow, ct.dropPerWellX, ct.dropPerWellY, ct.dropHeight, ct.dropWidth, ct.wellDrop FROM ContainerType ct WHERE $where", $args);
+        $rows = $this->db->pq("SELECT ct.containerTypeId, name, ct.proposalType, ct.capacity, ct.wellPerRow, ct.dropPerWellX, ct.dropPerWellY, ct.dropHeight, ct.dropWidth, ct.wellDrop, ct.dropOffsetX, ct.dropOffsetY FROM ContainerType ct WHERE $where", $args);
         $this->_output(array('total' => count($rows), 'data' => $rows));
     }
 

--- a/client/src/js/modules/shipment/components/plate-view.vue
+++ b/client/src/js/modules/shipment/components/plate-view.vue
@@ -136,8 +136,8 @@ export default {
         for (let i = 0; i < this.container.drops.x; ++i) {
           if (dropIndex !== this.wellIndex) {
             drops.push({
-              x: this.cell.padding + this.dropWidth * i,
-              y: this.cell.padding + this.dropHeight * j,
+              x: this.cell.padding + this.dropWidth * i + this.container.drops.offsetx * this.cell.width,
+              y: this.cell.padding + this.dropHeight * j + this.container.drops.offsety * this.cell.height,
             })
           }
           dropIndex += 1

--- a/client/src/js/modules/types/mx/samples/valid-container-graphic.vue
+++ b/client/src/js/modules/types/mx/samples/valid-container-graphic.vue
@@ -94,6 +94,8 @@ export default {
       geometry.drops.y = this.containerType.DROPPERWELLY
       geometry.drops.h = this.containerType.DROPHEIGHT
       geometry.drops.w = this.containerType.DROPWIDTH
+      geometry.drops.offsetx = this.containerType.DROPOFFSETX
+      geometry.drops.offsety = this.containerType.DROPOFFSETY
       geometry.well = this.containerType.WELLDROP
       geometry.columns = this.containerType.WELLPERROW
       geometry.containerType = this.containerType.NAME

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -439,6 +439,8 @@ const INITIAL_CONTAINER_TYPE = {
   NAME: null,
   WELLDROP: -1,
   WELLPERROW: null,
+  DROPOFFSETX: null,
+  DROPOFFSETY: null,
 }
 
 export default {
@@ -567,7 +569,9 @@ export default {
               dropPerWellY: this.containerType['DROPPERWELLY'],
               dropWidth: this.containerType['DROPWIDTH'],
               wellDrop: this.containerType['WELLDROP'],
-              wellPerRow: this.containerType['WELLPERROW']
+              wellPerRow: this.containerType['WELLPERROW'],
+              dropOffsetX: this.containerType['DROPOFFSETX'],
+              dropOffsetY: this.containerType['DROPOFFSETY'],
             })
 
           }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1856](https://jira.diamond.ac.uk/browse/LIMS-1856)

**Summary**:

The reservoir for a MRC 2 Drop plate is on the left side, but Synchweb shows it on the right. The database has dropOffsetX=0.5, but this is not used anywhere.

**Changes**:
- Pull the drop offset values from the database and pass them to the client
- Use the offsets to move the drops around in the well. Drop offset values should be between 0 and 1.

**To test**:
- Go to any proposal, then add a container to a shipment
- Choose container type MRC 2 Drop, check the drops are on the right and the reservoir on the left
- Create the container, check there are no errors.
- View the created container, check the layout is still the same (this is rendered in a different way and is unchanged)
