### PR TITLE
Fix proposal type assignment

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -243,7 +243,7 @@ class Proposal extends Page
                     if (!in_array($bty, $tys)) {
                         array_push($tys, $bty);
                     }
-                    if (!$found) {
+                    if (!$found && $bty) {
                         $ty = $bty;
                         $found = True;
                     }


### PR DESCRIPTION
**Summary**:

Sometimes, the proposal type is set to "null" during the process in which we determine the proposal type, and therefore, defaults to "gen". This checks that the determined proposal type is not null before assigning it to the final proposal object.

**Changes**:
- Fix proposal type assignment

**To test**:
- Go to any older proposal that may get a `null` proposal type from `_get_type_from_beamline` (such as sw30864)
- Check that the menu displays all MX options, instead of the generic, shortened menu
- Go to any "recent" proposal such as cm40607, check that MX options are displayed
- Go to any recent VMXi proposal, such as cm40605, check that VMXi options are displayed
- Repeat for other experiment types if so desired
