### PR TITLE
LIMS-124: Display Anode results

### DIFF
--- a/api/src/Downstream/Type/Dimple.php
+++ b/api/src/Downstream/Type/Dimple.php
@@ -187,11 +187,11 @@ class Dimple extends DownstreamPlugin {
 
         foreach ($blobs as $n => $blob) {
             array_push($peaks, array(
-                $blob['X'],
-                $blob['Y'],
-                $blob['Z'],
-                $blob['HEIGHT'],
-                $blob['OCCUPANCY'],
+                number_format($blob['X'], 2),
+                number_format($blob['Y'], 2),
+                number_format($blob['Z'], 2),
+                number_format($blob['HEIGHT'], 2),
+                number_format($blob['OCCUPANCY'], 1),
                 $blob['NEARESTATOMDISTANCE'] . ' ' . $blob['NEARESTATOMNAME'] . '_' . $blob['NEARESTATOMCHAINID']
                     . ':' . $blob['NEARESTATOMRESNAME'] . $blob['NEARESTATOMRESSEQ'],
             ));

--- a/client/src/css/partials/_content.scss
+++ b/client/src/css/partials/_content.scss
@@ -790,6 +790,10 @@ li:last-child .visit_users {
             display: none;
             overflow: auto;
 
+            .larger {
+                font-size: 14px;
+            }
+
             .dcap {
                 padding: 1% 1% 0 1%;
 
@@ -895,6 +899,10 @@ li:last-child .visit_users {
                 }
             }
 
+            &.align_center td {
+                text-align: center;
+            }
+
         }
 
 
@@ -997,7 +1005,7 @@ li:last-child .visit_users {
             height: auto;
         }
 
-        .plot_dimple {
+        .plot_dimple, .plot_anode {
             width: 70%;
             float: right;
 

--- a/client/src/js/modules/dc/views/dimple.js
+++ b/client/src/js/modules/dc/views/dimple.js
@@ -8,7 +8,9 @@ define([
     
         ui: {
             plot: '.plot_dimple',
+            plot_anode: '.plot_anode',
             rstats: '.rstats',
+            rstats_div: '.rstats_div',
             blob: '.blobs img',
             blobs: '.blobs',
         },
@@ -39,9 +41,10 @@ define([
             if (app.mobile()) {
                 this.ui.plot.width(0.93*(this.options.holderWidth-14))
             } else {
-                this.ui.rstats.width(0.20*(this.options.holderWidth-14))
-                this.ui.plot.width(0.47*(this.options.holderWidth-14))
+                this.ui.rstats.width(0.25*(this.options.holderWidth-14))
+                this.ui.plot.width(0.42*(this.options.holderWidth-14))
                 this.ui.plot.height(this.ui.plot.width()*0.41-80)
+                this.ui.rstats_div.height(this.ui.plot.width()*0.41-80)
             }
 
             this.ui.blobs.css('min-height', this.ui.plot.width()*0.41-80)
@@ -51,8 +54,18 @@ define([
             var pl = $.extend({}, utils.default_plot, { series: { lines: { show: true }}})
             $.plot(this.ui.plot, data, pl)
             
+            const anodePeaks = this.model.get('ANODE_PEAKS');
+            if (anodePeaks && anodePeaks.TABLE && anodePeaks.TABLE.length > 0) {
+                this.ui.plot_anode.width(0.42 * (this.options.holderWidth - 14))
+                this.ui.plot_anode.height(this.ui.plot.width() * 0.41 - 80)
+
+                var anode_data = [{ data: anodePeaks.PLOT, label: 'Peak Height (sig)' }]
+                var anode_pl = $.extend({}, utils.default_plot, { series: { lines: { show: true }}});
+                $.plot(this.ui.plot_anode, anode_data, anode_pl)
+            }
+
         },
-    
+
     })
 
 })

--- a/client/src/js/templates/dc/dc_dimple.html
+++ b/client/src/js/templates/dc/dc_dimple.html
@@ -12,23 +12,50 @@
 
     <div class="plot_dimple r"></div>
 
-    <table class="rstats">
-        <% if (STATS.length) { %>
-            <% _.each(STATS, function(r, i) { %>
+    <div class="rstats_div">
+        <table class="rstats">
+            <% if (STATS.length) { %>
+                <% _.each(STATS, function(r, i) { %>
+                <tr>
+                    <% _.each(r, function(j) { %>
+                    <td><%-j%></td>
+                    <% }) %>
+                </tr>
+                <% }) %>
+            <% } else { %>
+                <tr>
+                    <td>Refinement Stats</td>
+                </tr>
+                <tr>
+                    <td>No Stats Available</td>
+                </tr>
+            <% } %>
+        </table>
+    </div>
+</div>
+<br /><br />
+<div>
+    <% if (ANODE_PEAKS && ANODE_PEAKS.TABLE && ANODE_PEAKS.TABLE.length) { %>
+        <div class="plot_anode r"></div>
+        <div class="larger">Top 10 Anode Peaks</div>
+        <table class="rstats align_center">
+            <tr>
+                <td>X</td>
+                <td>Y</td>
+                <td>Z</td>
+                <td>Height (sig)</td>
+                <td>SOF</td>
+                <td colspan=2>Nearest Atom</td>
+            </tr>
+            <% _.each(ANODE_PEAKS.TABLE, function(r, i) { %>
             <tr>
                 <% _.each(r, function(j) { %>
                 <td><%-j%></td>
                 <% }) %>
             </tr>
             <% }) %>
-        <% } else { %>
-            <tr>
-                <td>Refinement Stats</td>
-            </tr>
-            <tr>
-                <td>No Stats Available</td>
-            </tr>
-        <% } %>
-    </table>
-    
+        </table>
+    <% } else { %>
+        <div class="larger">No Anode peaks found</div>
+    <% } %>
 </div>

--- a/client/src/js/utils/xhrimage.js
+++ b/client/src/js/utils/xhrimage.js
@@ -33,7 +33,11 @@ define(['marionette'], function() {
 
         xhr.onload = function(e) {
             if (xhr.status == 0 || xhr.status != 200) {
-                self.onerror(xhr.status, e)
+                if (typeof self.onerror === 'function') {
+                    self.onerror(xhr.status, e)
+                } else {
+                    console.error('Image load error:', xhr.status, e)
+                }
                 return
             }
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-124](https://jira.diamond.ac.uk/browse/LIMS-124)

**Summary**:

Anode has been running at the end of Dimple for a few years, we should display the results in Synchweb, not just in obscure log files.

NB This PR does not include a map viewer for Anode results, but that is intended to follow at some point, ticket LIMS-598.

**Screenshot**:

<img width="1730" height="589" alt="image" src="https://github.com/user-attachments/assets/07685d8a-b9f4-4759-956e-1709f0441892" />

**Changes**:
- Add method to the backend to return Anode results with the Dimple results
- Add a table of Anode results to the Dimple view, under the table of Dimple results
- Add a plot of peak height vs site number, under the Dimple plot
- Fix a bug in xhrimage if onerror is not defined

**To test**:
- Go to a data collection with a Dimple success eg /dc/visit/cm40607-3/id/19541770
- Expand the Downstream Processing bar, and click the Dimple tag
- Check there is a table of 10 Anode peaks, and a plot of their heights
- Go to a data collection with Dimple but no Anode results, eg /dc/visit/cm28170-5/id/7330809, check there is a message saying 'No Anode peaks found'