### PR TITLE
LIMS-1902: Fix plate inspection view for MRC 2 Drop plates

### DIFF
--- a/client/src/js/modules/shipment/models/platetype.js
+++ b/client/src/js/modules/shipment/models/platetype.js
@@ -47,8 +47,8 @@ define(['backbone'], function(Backbone) {
             this.set('drop_widthpx', (this.get('well_width')-this.get('drop_pad')*2) / (this.get('drop_per_well_x') / this.get('drop_width')))
             this.set('drop_heightpx', (this.get('well_height')-this.get('drop_pad')*2) / (this.get('drop_per_well_y') / this.get('drop_height')))
             
-            this.set('drop_offset_x', this.get('drop_offset_x')*(this.get('well_width')-this.get('drop_pad')*2))
-            this.set('drop_offset_y', this.get('drop_offset_y')*(this.get('well_height')-this.get('drop_pad')*2))
+            this.set('drop_offset_x_px', this.get('drop_offset_x')*(this.get('well_width')-this.get('drop_pad')*2))
+            this.set('drop_offset_y_px', this.get('drop_offset_y')*(this.get('well_height')-this.get('drop_pad')*2))
         },
         
         setGeometry: function(width, height, ofx, ofy) {

--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -74,7 +74,6 @@ define(['marionette',
     AutoScoreSchemas, AutoScores,
 
     Users,
-
     Editable, TableView, table, XHRImage, utils,
     template, templateimage){
 
@@ -908,7 +907,9 @@ define(['marionette',
         doOnShow: function() {
             this.ui.ins.html(this.inspections.opts())
 
-            this.type = this.ctypes.findWhere({ name: this.model.get('CONTAINERTYPE') })
+            this.type = this.ctypes.find(m =>
+                m.get('name').toLowerCase() === this.model.get('CONTAINERTYPE').toLowerCase()
+            )
             this.plateView = new PlateView({ collection: this.samples, type: this.type, showImageStatus: this.model.get('INSPECTIONS') > 0 })
             this.listenTo(this.plateView, 'plate:select', this.resetZoom, this)
             this.plate.show(this.plateView)

--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -74,6 +74,7 @@ define(['marionette',
     AutoScoreSchemas, AutoScores,
 
     Users,
+
     Editable, TableView, table, XHRImage, utils,
     template, templateimage){
 

--- a/client/src/js/modules/shipment/views/plate.js
+++ b/client/src/js/modules/shipment/views/plate.js
@@ -215,7 +215,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
 
                         } else this.ctx.strokeStyle = '#ddd'
           
-                        this.ctx.rect(this.pt.get('drop_offset_x')+this.pt.get('offset_x')+row*(this.pt.get('well_width')+this.pt.get('well_pad'))+(j*this.pt.get('drop_widthpx')+this.pt.get('drop_pad')), this.pt.get('drop_offset_y')+this.pt.get('offset_y')+col*(this.pt.get('well_height')+this.pt.get('well_pad'))+(k*this.pt.get('drop_heightpx')+this.pt.get('drop_pad')), this.pt.get('drop_widthpx'), this.pt.get('drop_heightpx'))
+                        this.ctx.rect(this.pt.get('drop_offset_x_px')+this.pt.get('offset_x')+row*(this.pt.get('well_width')+this.pt.get('well_pad'))+(j*this.pt.get('drop_widthpx')+this.pt.get('drop_pad')), this.pt.get('drop_offset_y_px')+this.pt.get('offset_y')+col*(this.pt.get('well_height')+this.pt.get('well_pad'))+(k*this.pt.get('drop_heightpx')+this.pt.get('drop_pad')), this.pt.get('drop_widthpx'), this.pt.get('drop_heightpx'))
                             
 
                         // Highlight Hovered Sample
@@ -319,7 +319,7 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
                             this.ctx.fillStyle = '#000'
                             this.ctx.font = "8px Arial"
                             this.ctx.lineWidth = 1
-                            this.ctx.fillText(sampleid,this.pt.get('drop_offset_x')+2+this.pt.get('offset_x')+row*(this.pt.get('well_width')+this.pt.get('well_pad'))+(j*this.pt.get('drop_widthpx')+this.pt.get('drop_pad')), this.pt.get('drop_offset_y')+10+this.pt.get('offset_y')+col*(this.pt.get('well_height')+this.pt.get('well_pad'))+(k*this.pt.get('drop_heightpx')+this.pt.get('drop_pad')));
+                            this.ctx.fillText(sampleid,this.pt.get('drop_offset_x_px')+2+this.pt.get('offset_x')+row*(this.pt.get('well_width')+this.pt.get('well_pad'))+(j*this.pt.get('drop_widthpx')+this.pt.get('drop_pad')), this.pt.get('drop_offset_y_px')+10+this.pt.get('offset_y')+col*(this.pt.get('well_height')+this.pt.get('well_pad'))+(k*this.pt.get('drop_heightpx')+this.pt.get('drop_pad')));
                         }
                     }
                 }
@@ -333,8 +333,8 @@ define(['marionette', 'backbone', 'utils', 'backbone-validation'], function(Mari
             var x = Math.floor((cur[0] - this.pt.get('offset_x'))/(this.pt.get('well_width')+this.pt.get('well_pad')))
             var y = Math.floor((cur[1] - this.pt.get('offset_y'))/(this.pt.get('well_height')+this.pt.get('well_pad')))
         
-            var wox = cur[0] - this.pt.get('drop_offset_x') - this.pt.get('offset_x') - this.pt.get('drop_pad') - x*(this.pt.get('well_width')+this.pt.get('well_pad'))
-            var woy = cur[1] - this.pt.get('drop_offset_y') - this.pt.get('offset_y') - this.pt.get('drop_pad') - y*(this.pt.get('well_height')+this.pt.get('well_pad'))
+            var wox = cur[0] - this.pt.get('drop_offset_x_px') - this.pt.get('offset_x') - this.pt.get('drop_pad') - x*(this.pt.get('well_width')+this.pt.get('well_pad'))
+            var woy = cur[1] - this.pt.get('drop_offset_y_px') - this.pt.get('offset_y') - this.pt.get('drop_pad') - y*(this.pt.get('well_height')+this.pt.get('well_pad'))
         
             if (wox > 0 && wox < this.pt.get('drop_per_well_x')*this.pt.get('drop_widthpx') && woy > 0 && woy < this.pt.get('drop_per_well_y')*this.pt.get('drop_heightpx')) {
                 var dx = Math.floor(wox / this.pt.get('drop_widthpx'))


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1902](https://jira.diamond.ac.uk/browse/LIMS-1902)

**Summary**:

The MRC 2 Drop plate type is the only one with a drop_offset_x value, and it has not been used much. https://github.com/DiamondLightSource/SynchWeb/pull/973 fixed the display on creating such a plate and on first viewing it, but there is another view once the plate has inspections to view. This is to fix that view.

**Changes**:
- Use a new property to store the drop offset in pixels, so the offset isn't repeatedly converted
- Use the new offset pixels property to display the drop, the drop number, and to calculate the position for clicking/hovering
- Make the container type check be case-insensitive

**To test**:
- View a plate with inspections eg (/containers/cid/349468)
- Edit the plate in the database so the containerType is MRC 2 Drop
```
update Container set containerType='MRC 2 Drop' where containerId=349468;
```
- Check the wells and well numbers appear within the drawing of the plate
- Check you can hover over the wells and they are highlighted
- Check if you click on a well the inspection image is updated
- Change the capitalisation of the containerType and repeat the checks
```
update Container set containerType='mrc 2 drop' where containerId=349468;
```