### PR TITLE
LIMS-1841: Link downstream jobs to their upstream counterpart

### DIFF
--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -16,6 +16,15 @@ class FastEp extends DownstreamPlugin {
             'ATOMS' => array(array('sad_fa.pdb file not found'))
         );
 
+        $integrator = $this->_lookup_autoproc(
+            null,
+            $this->process['PARAMETERS']['scaling_id']
+        );
+        if ($integrator) {
+            $dat['PARENTAUTOPROCPROGRAM'] = $integrator['PROCESSINGPROGRAMS'];
+            $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+        }
+
         $ats = array();
         $pdb = $this->_get_attachments("sad_fa.pdb");
         if ($pdb) {

--- a/client/src/js/modules/dc/views/autointegration.js
+++ b/client/src/js/modules/dc/views/autointegration.js
@@ -184,6 +184,11 @@ define(['marionette',
             }
 
             this.$el.slideDown()
+
+            if (typeof this.getOption('onReady') === 'function') {
+                this.getOption('onReady')(this)
+            }
+
         }
 
     })

--- a/client/src/js/modules/dc/views/dc.js
+++ b/client/src/js/modules/dc/views/dc.js
@@ -167,15 +167,20 @@ define(['marionette',
       } else this.strat.$el.slideToggle()
     },
                             
-    loadAP: function(e) {
+    loadAP: function(e, callback) {
       if (!this.ap) {
         this.ap = new DCAutoIntegrationView({ 
-            id: this.model.get('ID'), 
-            dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA'),
-            el: this.$el.find('div.autoproc'),
-            parent: this.model
-          })
-      } else this.ap.$el.slideToggle()
+          id: this.model.get('ID'),
+          dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA'),
+          el: this.$el.find('div.autoproc'),
+          parent: this.model,
+          onReady: callback
+        })
+      } else {
+        this.ap.$el.slideToggle(() => {
+          if (callback) callback(this.ap);
+        });
+      }
     },
       
       
@@ -185,7 +190,8 @@ define(['marionette',
           id: this.model.get('ID'),
           dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA'),
           el: this.$el.find('div.downstream'),
-          holderWidth: this.$el.find('.holder').width() 
+          holderWidth: this.$el.find('.holder').width(),
+          upstreamLink: true,
         })
       } else this.dp.$el.slideToggle()
     },

--- a/client/src/js/modules/dc/views/downstream.js
+++ b/client/src/js/modules/dc/views/downstream.js
@@ -9,18 +9,17 @@ define(['backbone', 'marionette',
     'modules/dc/views/bigep',
     'modules/dc/views/shelxt',
     'modules/dc/views/ligandfit',
-    'templates/dc/downstreamerror.html'
 
     ], function(Backbone, Marionette, TabView, DownStreams, DownstreamWrapper, 
         TableView, 
-        FastEP, DIMPLE, MrBUMP, BigEP, Shelxt, LigandFit, downstreamerror) {
+        FastEP, DIMPLE, MrBUMP, BigEP, Shelxt, LigandFit) {
 
     var dcPurgedProcessedData = "0"; // dataCollection.PURGEDPROCESSEDDATA via options from DC.js
 
     var DownstreamsCollection = Backbone.Collection.extend()
 
     var DownStreamError = Marionette.ItemView.extend({
-        template: downstreamerror
+        template: _.template('<p>This processing job failed: <%-PROCESS.PROCESSINGMESSAGE%></p>')
     })
 
     var DownStreamRunning = Marionette.ItemView.extend({
@@ -69,12 +68,17 @@ define(['backbone', 'marionette',
                 'LigandFit': LigandFit,
             }
             
-            if (model.get('PROCESS').PROCESSINGSTATUS != 1) {
+            if (model.get('PROCESS').PROCESSINGSTATUS == null) {
                 return DownstreamWrapper.extend({
                     links: false,
                     dcPurgedProcessedData,
-                    childView: model.get('PROCESS').PROCESSINGSTATUS == null
-                        ?  DownStreamRunning : DownStreamError
+                    childView: DownStreamRunning
+                })
+            } else if (model.get('PROCESS').PROCESSINGSTATUS != 1) {
+                return DownstreamWrapper.extend({
+                    mapLink: false,
+                    dcPurgedProcessedData,
+                    childView: DownStreamError
                 })
             }
 
@@ -106,6 +110,7 @@ define(['backbone', 'marionette',
                     }
                 },
                 DCID: this.getOption('DCID'),
+                upstreamLink: this.getOption('upstreamLink'),
             }
         },
 
@@ -128,6 +133,7 @@ define(['backbone', 'marionette',
                 downstreams: this.getOption('downstreams'),
                 DCID: this.getOption('id'),
                 mapButton: this.getOption('mapButton'),
+                upstreamLink: this.getOption('upstreamLink'),
             }
         },
 
@@ -175,7 +181,8 @@ define(['backbone', 'marionette',
                     downstreams: this.collection,
                     id: this.getOption('id'),
                     el: this.$el.find('.res'),
-                    holderWidth: this.$el.parent().width()
+                    holderWidth: this.$el.parent().width(),
+                    upstreamLink: this.getOption('upstreamLink'),
                 }))
             } else {
                 this.$el.addClass('ui-tabs')

--- a/client/src/js/modules/dc/views/downstreamwrapper.js
+++ b/client/src/js/modules/dc/views/downstreamwrapper.js
@@ -29,6 +29,30 @@ define(['backbone', 'marionette',
             'click .logf': 'showLog',
             'click a.pattach': 'showAttachments',
             'click .dll': utils.signHandler,
+            'click a.viewupstream': 'viewUpstream',
+        },
+
+        viewUpstream: function(e) {
+            e.preventDefault()
+
+            const pappid = this.model.get('PARENTAUTOPROCPROGRAMID')
+            const downstream = this.$el.closest('.downstream')
+            const ap = downstream.siblings('.ap')
+            const autoproc = downstream.siblings('.autoproc')
+
+            const clickTab = (apView) => {
+                let tab = autoproc.find('a[href="#tabs-' + pappid + '"]')
+                if (tab.length) {
+                    tab.trigger('click')
+                    $('html, body').animate({ scrollTop: tab.offset().top })
+                }
+            }
+
+            if (autoproc.is(':visible')) {
+                clickTab(this.ap)
+            } else {
+                ap.trigger('click', clickTab)
+            }
         },
 
         showAttachments: function(e) {
@@ -80,6 +104,10 @@ define(['backbone', 'marionette',
 
                 if (!this.getOption('mapLink')) {
                     links = links.slice(1)
+                }
+
+                if (this.getOption('upstreamLink')) {
+                    links.push('<a class="viewupstream button" href="#"><i class="fa fa-chevron-up"></i> View Upstream</a>')
                 }
 
                 this.ui.links.append(links.join(' '))

--- a/client/src/js/modules/types/sm/dc/dc.js
+++ b/client/src/js/modules/types/sm/dc/dc.js
@@ -10,11 +10,6 @@ define([
 
         setProcessingVars: function() {},
 
-        loadAP: function(e) {
-            if (!this.ap) {
-              this.ap = new DCAutoIntegrationView({ id: this.model.get('ID'), dcPurgedProcessedData: this.model.get('PURGEDPROCESSEDDATA'), el: this.$el.find('div.autoproc') })
-            } else this.ap.$el.slideToggle()
-        },
     })
 
 })

--- a/client/src/js/templates/dc/downstreamerror.html
+++ b/client/src/js/templates/dc/downstreamerror.html
@@ -1,6 +1,0 @@
-<p class="r downloads">
-    <a class="pattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>
-    <a class="view button dll" href="<%-APIURL%>/download/ap/archive/<%-AID%>"><i class="fa fa-cloud-download"></i> Download Zip</a>
-</p>
-
-<p>This processing job failed: <%-PROCESS.PROCESSINGMESSAGE%></p>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1841](https://jira.diamond.ac.uk/browse/LIMS-1841)

**Summary**:

Each downstream processing job should have a link to it's upstream counterpart job.

**Changes**:
- Add identification of upstream pipeline to FastEP
- Remove redundant downstream error template file, buttons can be added by setting links to true
- Remove redundant overriding of the loadAP function for 'sm' data collections
- Add a 'View Upstream' button for data collection types that require it
- Make the button open the Auto Processing bar (if needed), then select the correct pipeline, using a callback (if needed)
- Scroll the window to the Auto Processing pipeline

**To test**:
- Open an mx data collection with various auto processing and downstream processing jobs (eg /dc/visit/cm40607-4/id/19735138)
- Without opening the Auto Processing bar, open the Downstream Processing bar. Click on one of the 'View Upstream' buttons, check the Auto Processing bar opens and the correct pipeline tab is selected.
- Check the View Upstream button works if the Auto Processing bar is already open, or has been opened and is now closed
- Check the button works for downstream processing failures
- Check the button works for FastEP jobs specifically
- Open an sm data collection (eg /dc/visit/cm40638-4/dcg/16241965) and repeat the checks
- Open a saxs data collection (eg /dc/visit/cm40642-3/id/19578730) and check there is no View Upstream button
- Open an xpdf data collection (eg /dc/visit/cm40633-4/id/19719976) and check there is no View Upstream button
