### PR TITLE
LIMS-1923: Fix downstream accordion if files missing from disk

### DIFF
--- a/api/src/Downstream/Type/LigandFit.php
+++ b/api/src/Downstream/Type/LigandFit.php
@@ -42,12 +42,13 @@ class LigandFit extends DownstreamPlugin {
     }
 
     function results() {
+        $json_data = "[]";
         $json_filepath = $this->_get_ligandfit_results_json();
         if (sizeof($json_filepath)) {
-            $json_path = $json_filepath[0]["FILEPATH"] . "/" . $json_filepath[0]["FILENAME"] ;
-            $json_data = file_get_contents($json_path);
-        } else {
-            $json_data = "[]";
+            $json_path = $json_filepath[0]["FILEPATH"] . "/" . $json_filepath[0]["FILENAME"];
+            if (file_exists($json_path)) {
+                $json_data = file_get_contents($json_path);
+            }
         }
         $dat = array();
         $appaid = $this->_get_model_appaid();

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -42,12 +42,13 @@ class Shelxt extends DownstreamPlugin {
     }
 
     function results() {
+        $json_data = "[]";
         $json_filepath = $this->_get_shelxt_results_json();
         if (sizeof($json_filepath)) {
-            $json_path = $json_filepath[0]["FILEPATH"] . "/shelxt_results.json" ;
-            $json_data = file_get_contents($json_path);
-        } else {
-            $json_data = "[]";
+            $json_path = $json_filepath[0]["FILEPATH"] . "/shelxt_results.json";
+            if (file_exists($json_path)) {
+                $json_data = file_get_contents($json_path);
+            }
         }
         $dat = array();
         $dat['BLOBS'] = 1;


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1923](https://jira.diamond.ac.uk/browse/LIMS-1923)

**Summary**:

If the results files for the LigandFit or Shelxt pipelines are no longer on disk, the Downstream Processing accordion will no longer open. We should check the file exists before trying to read it.

**Changes**:
- Do a file_exists check on files before reading them

**To test**:
- Go to a data collection with a LigandFit result no longer on disk eg /dc/visit/nt37477-28/id/15841906
- Click the Downstream Processing bar, check it opens, even if there are no results for LigandFit
- Go to a data collection with a Shelxt result eg /dc/visit/cm40638-4/id/19599724
- The result file still exists on disk, so temporarily change the filename on line 48 of Shelxt.php to simulate a missing file
- Click the Downstream Processing bar, check it opens, even if there are no results for Shelxt
