### PR TITLE
LIMS-2044: Remove luxon

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -11,7 +11,8 @@ module.exports = {
     'backbone/model-defaults': 0, // widely abused issue - so unlikely to be addressed without considerable effort
     'backbone/collection-model': 0, // ditto
     'backbone/defaults-on-top': 0, // ditto
-    'backbone/initialize-on-top': 0 // ditto
+    'backbone/initialize-on-top': 0, // ditto
+    'backbone/no-silent': 0
     },
     env: {
     es6: true,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -35,7 +35,7 @@
         "jquery.flot": "^0.8.3",
         "jquery.flot.tooltip": "^0.9.0",
         "lodash-es": "^4.17.21",
-        "luxon": "^1.25.0",
+        "luxon": "^3.7.2",
         "markdown": "^0.5.0",
         "plotly.js": "^1.52.2",
         "portal-vue": "2.1.7",
@@ -11723,11 +11723,12 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -35,7 +35,6 @@
         "jquery.flot": "^0.8.3",
         "jquery.flot.tooltip": "^0.9.0",
         "lodash-es": "^4.17.21",
-        "luxon": "^3.7.2",
         "markdown": "^0.5.0",
         "plotly.js": "^1.52.2",
         "portal-vue": "2.1.7",
@@ -11720,15 +11719,6 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/client/package.json
+++ b/client/package.json
@@ -83,7 +83,6 @@
     "jquery.flot": "^0.8.3",
     "jquery.flot.tooltip": "^0.9.0",
     "lodash-es": "^4.17.21",
-    "luxon": "^3.7.2",
     "markdown": "^0.5.0",
     "plotly.js": "^1.52.2",
     "portal-vue": "2.1.7",

--- a/client/package.json
+++ b/client/package.json
@@ -83,7 +83,7 @@
     "jquery.flot": "^0.8.3",
     "jquery.flot.tooltip": "^0.9.0",
     "lodash-es": "^4.17.21",
-    "luxon": "^1.25.0",
+    "luxon": "^3.7.2",
     "markdown": "^0.5.0",
     "plotly.js": "^1.52.2",
     "portal-vue": "2.1.7",

--- a/client/src/js/models/visit.js
+++ b/client/src/js/models/visit.js
@@ -50,10 +50,14 @@ define(['backbone', 'backbone-validation', 'luxon'], function(Backbone, BackBone
       
     addDate: function() {
         var { DateTime } = luxon
-        
-        this.set('ENISO', DateTime.fromISO(this.get('ENISO'), { zone: this.dateTimeZone }))
-        this.set('STISO', DateTime.fromISO(this.get('STISO'), { zone: this.dateTimeZone }))
-        this.set('LEN', Number(this.get('ENISO').diff(this.get('STISO'))/(3600*1000)).toFixed(2))
+
+        var start = DateTime.fromISO(this.get('STISO'), { zone: this.dateTimeZone })
+        var end   = DateTime.fromISO(this.get('ENISO'), { zone: this.dateTimeZone })
+        var hours = end.diff(start, 'hours').hours.toFixed(2)
+
+        this.set('ENISO', end)
+        this.set('STISO', start)
+        this.set('LEN', hours)
         this.set('VISITDETAIL', this.get('VISIT')+' ('+this.get('BL')+': '+this.get('ST')+')')
     },
 

--- a/client/src/js/models/visit.js
+++ b/client/src/js/models/visit.js
@@ -1,11 +1,10 @@
-define(['backbone', 'backbone-validation', 'luxon'], function(Backbone, BackBoneValidation, luxon) {
+define(['backbone', 'backbone-validation'], function(Backbone, BackBoneValidation) {
   var Visit = Backbone.Model.extend({
     idAttribute: 'VISIT',
     urlRoot: '/proposal/visits',
       
     initialize: function(attributes, options) {
       this.on('change', this.addDate, this)
-      this.dateTimeZone = window.app.options.get('timezone')
       this.addDate()
     },
 
@@ -47,21 +46,14 @@ define(['backbone', 'backbone-validation', 'luxon'], function(Backbone, BackBone
             pattern: 'number',
         },
     },
-      
+
     addDate: function() {
-        var { DateTime } = luxon
-
-        var start = DateTime.fromISO(this.get('STISO'), { zone: this.dateTimeZone })
-        var end   = DateTime.fromISO(this.get('ENISO'), { zone: this.dateTimeZone })
-        var hours = end.diff(start, 'hours').hours.toFixed(2)
-
-        this.set('ENISO', end)
-        this.set('STISO', start)
-        this.set('LEN', hours)
-        this.set('VISITDETAIL', this.get('VISIT')+' ('+this.get('BL')+': '+this.get('ST')+')')
-    },
-
-    dateTimeZone: 'Europe/London'
+        const enDate = new Date(this.get('ENISO'))
+        const stDate = new Date(this.get('STISO'))
+        const diffInHours = (enDate - stDate) / (3600 * 1000)
+        this.set('LEN', Number(diffInHours).toFixed(2))
+        this.set('VISITDETAIL', this.get('VISIT') + ' (' + this.get('BL') + ': ' + this.get('ST') + ')')
+    }
       
   })
 

--- a/client/src/js/modules/calendar/views/calendar-view.vue
+++ b/client/src/js/modules/calendar/views/calendar-view.vue
@@ -157,7 +157,6 @@ import Visits from 'collections/visits'
 import Beamlines from 'collections/bls'
 import FilterPills from 'app/components/filter-pills.vue'
 import CalendarDayEvents from 'modules/calendar/views/components/calendar-day-events.vue'
-import { DateTime } from 'luxon'
 
 export default {
   name: 'CalendarView',
@@ -220,9 +219,9 @@ export default {
   },
   mounted() {
     const dateTime = this.todayDate
-    this.currentMonth = dateTime.month - 1
-    this.currentDay = dateTime.day
-    this.currentYear = dateTime.year
+    this.currentMonth = dateTime.getMonth()
+    this.currentDay = dateTime.getDate()
+    this.currentYear = dateTime.getFullYear()
     this.fetchBeamlinesByType()
     this.fetchVisitsCalendar()
   },
@@ -330,19 +329,16 @@ export default {
       }, {})
     },
     isToday(date) {
-      const { month, day, year } = this.todayDate
-      return date === day && month - 1 === this.currentMonth && year === this.currentYear
+      const today = this.todayDate
+      return (
+        date === today.getDate() &&
+        this.currentMonth === today.getMonth() &&
+        this.currentYear === today.getFullYear()
+      )
     },
     isPastDate(date) {
-      const dateItem = DateTime.fromObject({
-        year: this.currentYear,
-        month: this.currentMonth + 1,
-        day: date,
-        zone: this.timezone
-      })
-
+      const dateItem = new Date(this.currentYear, this.currentMonth, date);
       return dateItem < this.todayDate
-
     },
     onHover(ref, addHover) {
       const hoveredRef = this.$refs[ref][0].$el
@@ -409,7 +405,9 @@ export default {
       return this.appOption['timezone']
     },
     todayDate() {
-      return DateTime.local().setZone(this.timezone)
+      const d = new Date()
+      d.setHours(0, 0, 0, 0)
+      return d
     },
     currentSelectedMonth() {
       return this.months[this.currentMonth]
@@ -439,20 +437,12 @@ export default {
       return this.currentYear + 1
     },
     daysInMonth() {
-      return DateTime.fromObject({
-        year: this.currentYear,
-        month: this.currentMonth + 1,
-        day: 1,
-        zone: this.timezone
-      }).daysInMonth
+      return new Date(this.currentYear, this.currentMonth + 1, 0).getDate()
     },
     startDayOfMonth() {
-      return DateTime.fromObject({
-        year: this.currentYear,
-        month: this.currentMonth + 1,
-        day: 1,
-        zone: this.timezone
-      }).weekday - 1
+      const dateItem = new Date(this.currentYear, this.currentMonth, 1)
+      const day = dateItem.getDay()
+      return (day === 0) ? 6 : day - 1
     },
     sortedVisitsByDay() {
       return Array(this.daysInMonth).fill('').reduce((acc, curr, index) => {

--- a/client/src/js/modules/samples/controller.js
+++ b/client/src/js/modules/samples/controller.js
@@ -18,7 +18,7 @@ define(['marionette',
   GetView,
   Sample, Samples, 
   Protein, Proteins,
-  Ligand, Ligands
+  Ligand, Ligands,
   Crystal, Crystals,
   Instance,
   ProposalLookup) {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2044](https://jira.diamond.ac.uk/browse/LIMS-2044)

**Summary**:

Remove the luxon library.

**Changes**:
- Remove luxon from package.json and package-lock.json
- Convert calendar functions to native JS
- Use native JS and don't worry about time zones when calculating length of visits (this would seem to mostly apply to creating visits in Synchweb, which we don't do, but the code is called by various pages)
- Fix a rogue missing comma I found
- Add a new linting rule as we are ignoring it anyway

**To test**:
- View the list of visits for a proposal, check no errors occur
- View the data collection page, check no errors occur
- View the calendar page, check no errors, check days of the week, check days in the month etc.
- (Dev DB only) Go to the 'Add New Visit' page at eg /admin/proposals/visit/add/mx23694, check you can add a new visit
