### PR TITLE
LIMS-2031: Add toggle to expand data collection groups

### DIFF
--- a/client/src/css/partials/_utility.scss
+++ b/client/src/css/partials/_utility.scss
@@ -270,3 +270,44 @@ ul.ui-autocomplete {
         }
     }
 }
+
+.aic {
+    align-items: center;
+}
+
+.gap2 {
+    gap: 2px;
+}
+
+.toggle-input {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 40px;
+    height: 22px;
+    background: #ccc;
+    border-radius: 20px;
+    position: relative;
+    cursor: pointer;
+    transition: background 0.3s;
+    outline: none;
+}
+
+.toggle-input::before {
+    content: "";
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    top: 1px;
+    left: 1px;
+    background: white;
+    transition: transform 0.3s;
+}
+
+.toggle-input:checked {
+    background: #4CAF50;
+}
+
+.toggle-input:checked::before {
+    transform: translateX(18px);
+}

--- a/client/src/js/collections/datacollections.js
+++ b/client/src/js/collections/datacollections.js
@@ -1,8 +1,15 @@
-define(['underscore', 'backbone', 'backbone.paginator', 'models/datacollection'], function(_, Backbone, PageableCollection, dc) {
+define(['underscore', 'backbone', 'backbone.paginator', 'utils', 'models/datacollection'],
+function(_, Backbone, PageableCollection, utils, dc) {
   return PageableCollection.extend({
     model: dc,
     mode: 'server',
     url: '/dc',
+
+    queryParams: {
+        expandgroups: function () {
+            return utils.getLocalStorage('expandgroups') === '1' ? 1 : null
+        }
+    },
                                       
     state: {
       pageSize: 15,

--- a/client/src/js/modules/dc/datacollections.js
+++ b/client/src/js/modules/dc/datacollections.js
@@ -1,5 +1,6 @@
 define(['marionette',
         'views/pages',
+        'utils',
     
         'modules/dc/dclist',
         'modules/dc/views/samplechanger',
@@ -16,7 +17,7 @@ define(['marionette',
 
         'templates/dc/dclist.html',
         ],
-function(Marionette, Pages, DCListView,
+function(Marionette, Pages, utils, DCListView,
          SampleChanger, StatusView, Search, Filter, DialogView, QueueBuilderView, UserView, DewarsView,
          ReprocessOverview,
          template) {
@@ -42,6 +43,7 @@ function(Marionette, Pages, DCListView,
 
     ui: {
         ar: 'input[name=autorefresh]',
+        expand: 'input[name=expand]',
     },
       
     events: {
@@ -52,12 +54,22 @@ function(Marionette, Pages, DCListView,
       'mouseout a.dewars': 'hideDewars',
       'click a.refresh': 'refreshDCs',
       'click @ui.ar': 'setAutoRefresh',
+      'click @ui.expand': 'setExpandGroups',
       'click a.rpo': 'showReprocess',
     },
 
     setAutoRefresh: function(e) {
         if (this.ui.ar.is(':checked')) this.collection.run()
         else this.collection.stop()
+    },
+
+    setExpandGroups: function(e) {
+        if (this.ui.expand.is(':checked')) {
+            utils.setLocalStorage('expandgroups', '1')
+        } else {
+            utils.setLocalStorage('expandgroups', '0')
+        }
+        this.collection.fetch({ reset: true })
     },
 
     refreshDCs: function(e) {
@@ -141,6 +153,8 @@ function(Marionette, Pages, DCListView,
     },
                                       
     onRender: function() {    
+        const expandgroups = utils.getLocalStorage('expandgroups') === '1'
+        this.ui.expand.prop('checked', expandgroups)
         this.data_collections.show(this.dclist)
         this.pages.show(this.paginator)
         this.pages2.show(this.paginator2)

--- a/client/src/js/templates/dc/dclist.html
+++ b/client/src/js/templates/dc/dclist.html
@@ -34,9 +34,6 @@
         <% if (IS_STAFF) { %>
         <a class="button"  href="/status/bl/<%-BL%>" title="Beamline Status" class="blstat"><i class="fa fa-wrench"></i> <span>Beamline Status</span></a>
         <% } %>
-        <% if (!IS_DCG) { %>
-        <label class="r flex aic gap2">Expand groups <input type="checkbox" name="expand" class="toggle-input"></label>
-        <% } %>
     </div>
     <% } %>
 
@@ -52,6 +49,9 @@
 
     <div class="srch"></div>
     <div class="filter type"></div>
+    <% if (!IS_DCG && !IS_PJ && !IS_SINGLE) { %>
+    <label class="r flex aic gap2">Expand groups <input type="checkbox" name="expand" class="toggle-input"></label>
+    <% } %>
 
     <div class="page_wrap one"></div>    
     <div class="data_collections" data-testid="dc-data-collections"></div>

--- a/client/src/js/templates/dc/dclist.html
+++ b/client/src/js/templates/dc/dclist.html
@@ -34,6 +34,9 @@
         <% if (IS_STAFF) { %>
         <a class="button"  href="/status/bl/<%-BL%>" title="Beamline Status" class="blstat"><i class="fa fa-wrench"></i> <span>Beamline Status</span></a>
         <% } %>
+        <% if (!IS_DCG) { %>
+        <label class="r flex aic gap2">Expand groups <input type="checkbox" name="expand" class="toggle-input"></label>
+        <% } %>
     </div>
     <% } %>
 

--- a/client/src/js/utils.js
+++ b/client/src/js/utils.js
@@ -221,6 +221,14 @@ define(['backbone',
         return array
     },
 
+    setLocalStorage: function(key, value) {
+        localStorage.setItem(key, value);
+    },
+
+    getLocalStorage: function(key) {
+        const value = localStorage.getItem(key);
+        return value ? value : "";
+    },
 
     jsonError: function(model, xhr, status) {
         var json = {}

--- a/client/src/js/views/cloudupload.js
+++ b/client/src/js/views/cloudupload.js
@@ -1,10 +1,12 @@
 define([
     'backbone',
     'views/dialog',
+    'utils',
     'templates/dc/cloudupload.html'
 ], function(
     Backbone,
     DialogView,
+    utils,
     template
 ) {
 
@@ -23,32 +25,10 @@ define([
             remember: 'input[name=remember]',
         },
         
-        setCookie: function(cname, cvalue, exdays) {
-            const d = new Date();
-            d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
-            let expires = "expires="+d.toUTCString();
-            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-        },
-
-        getCookie: function(cname) {
-            let name = cname + "=";
-            let ca = document.cookie.split(';');
-            for (let i = 0; i < ca.length; i++) {
-                let c = ca[i];
-                while (c.charAt(0) == ' ') {
-                    c = c.substring(1);
-                }
-                if (c.indexOf(name) == 0) {
-                    return c.substring(name.length, c.length);
-                }
-            }
-            return "";
-        },
-
         upload: function() {
             if (this.ui.remember.is(':checked')) {
-                this.setCookie('ccp4_username', this.ui.username.val(), 365)
-                this.setCookie('ccp4_cloudrunid', this.ui.cloudrunid.val(), 365)
+                utils.setLocalStorage('ccp4_username', this.ui.username.val())
+                utils.setLocalStorage('ccp4_cloudrunid', this.ui.cloudrunid.val())
             }
             let data = { cloudrunid: this.ui.cloudrunid.val(), username: this.ui.username.val() }
             if (this.model.get('AUTOPROCPROGRAMATTACHMENTID')) {
@@ -78,8 +58,8 @@ define([
         },
         
         onRender: function() {
-            let ccp4_username = this.getCookie('ccp4_username')
-            let ccp4_cloudrunid = this.getCookie('ccp4_cloudrunid')
+            let ccp4_username = utils.getLocalStorage('ccp4_username')
+            let ccp4_cloudrunid = utils.getLocalStorage('ccp4_cloudrunid')
             if (ccp4_username) this.ui.username.val(ccp4_username)
             if (ccp4_cloudrunid) this.ui.cloudrunid.val(ccp4_cloudrunid)    
             if (ccp4_username || ccp4_cloudrunid) this.ui.remember.prop('checked', true)


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2031](https://jira.diamond.ac.uk/browse/LIMS-2031)

**Summary**:

Some people might prefer to view all data collections, rather than them grouped together. The backend already supports this (see multicrystal processing page), so just need a UI element for it.

**Changes**:
- Add a nice looking toggle (really a checkbox) at the top of the data collection page
- Store the value in local storage
- Send the value as a query parameter when fetching data collections
- Switch ccp4 cloud credentials to use local storage rather than cookies. Cookies are sent to the server on every request, which is unnecessary, and can also lead to surprising results where cookies and url parameters clash.

**To test**:
- Go to a visit with grouped data collections, eg /dc/visit/mx23694-154 should have grouped grid scans on the first page
- Check a toggle appears in the top right, and that turning it on shows all the grid scans separately, not grouped together
- Check switching the toggle off groups the grid scans again
- Check the toggle remains visible and in the same position if you go to View All Data from the main menu (ie /dc)
- Check the toggle remains visible and in the same position if you view a sample with data collections (eg /samples/sid/7093140)
- Check the toggle is not displayed if you click into a group (eg /dc/visit/mx23694-154/dcg/17555052), a processing job group (eg /dc/pjid/35444304), or a single data collection (eg /dc/visit/mx23694-154/id/21392025)