### PR TITLE
LIMS-2059: Re-enable reprocess button after any parameter change

### DIFF
--- a/client/src/js/modules/dc/views/downstreamreprocess.js
+++ b/client/src/js/modules/dc/views/downstreamreprocess.js
@@ -74,6 +74,7 @@ define(['backbone', 'marionette', 'views/dialog',
         ui: {
             pipeline: 'select[name=pipeline]',
             warning: '#warning',
+            fields: 'input, select',
         },
 
         buttons: {
@@ -87,6 +88,8 @@ define(['backbone', 'marionette', 'views/dialog',
 
         events: {
             'change @ui.pipeline': 'updatePipeline',
+            'input @ui.fields': 'onFieldChanged',
+            'change @ui.fields': 'onFieldChanged',
         },
 
         templateHelpers: function() {
@@ -144,12 +147,22 @@ define(['backbone', 'marionette', 'views/dialog',
             
         },
 
+        onFieldChanged: function() {
+            this._enableIntegrateButton();
+        },
+
         _disableIntegrateButton: function() {
             var btn = $('.ui-dialog-buttonpane button:contains("Submit")')
-            btn.button('disable').button('option', 'label', 'Submitted!')
-            setTimeout(function() {
-                btn.button('enable').button('option', 'label', 'Submit')
+            btn.addClass('submitted').button('disable').button('option', 'label', 'Submitted!')
+            this.resetTimeout = setTimeout(() => {
+                this._enableIntegrateButton()
             }, 5000)
+        },
+
+        _enableIntegrateButton: function() {
+            var btn = $('.ui-dialog-buttonpane button.submitted')
+            btn.removeClass('submitted').button('enable').button('option', 'label', 'Submit')
+            clearTimeout(this.resetTimeout);
         },
 
         _enqueue: function(options) {

--- a/client/src/js/modules/dc/views/reprocess.js
+++ b/client/src/js/modules/dc/views/reprocess.js
@@ -267,6 +267,7 @@ define(['backbone', 'marionette', 'views/dialog',
             al: 'input[name=alpha]',
             be: 'input[name=beta]',
             ga: 'input[name=gamma]',
+            fields: 'input, select',
         },
 
         buttons: {
@@ -281,6 +282,8 @@ define(['backbone', 'marionette', 'views/dialog',
             'change @ui.pipeline': 'updatePipeline',
             'change @ui.indexingMethod': 'updateIndexingMethod',
             'click a.multicrystal': 'closeDialog',
+            'input @ui.fields': 'onFieldChanged',
+            'change @ui.fields': 'onFieldChanged',
         },
 
         templateHelpers: function() {
@@ -556,12 +559,24 @@ define(['backbone', 'marionette', 'views/dialog',
         },
 
 
+        onFieldChanged: function() {
+            this._enableIntegrateButton();
+        },
+
+
         _disableIntegrateButton: function() {
             var btn = $('.ui-dialog-buttonpane button:contains("Integrate")')
-            btn.button('disable').button('option', 'label', 'Submitted!')
-            setTimeout(function() {
-                btn.button('enable').button('option', 'label', 'Integrate')
+            btn.addClass('submitted').button('disable').button('option', 'label', 'Submitted!')
+            this.resetTimeout = setTimeout(() => {
+                this._enableIntegrateButton()
             }, 5000)
+        },
+
+
+        _enableIntegrateButton: function() {
+            var btn = $('.ui-dialog-buttonpane button.submitted')
+            btn.removeClass('submitted').button('enable').button('option', 'label', 'Integrate')
+            clearTimeout(this.resetTimeout);
         },
 
 

--- a/client/src/js/modules/mc/views/datacollections.js
+++ b/client/src/js/modules/mc/views/datacollections.js
@@ -62,6 +62,8 @@ define(['backbone', 'marionette',
             'click .integrate': 'integrate',
             'click button.opt': 'toggleOpts',
             'change @ui.pipeline': 'updatePipeline',
+            'input @ui.fields': 'onFieldChanged',
+            'change @ui.fields': 'onFieldChanged',
         },
 
         ui: {
@@ -73,6 +75,8 @@ define(['backbone', 'marionette',
             opts: 'div.options',
             sm: 'input[name=sm]',
             sg: 'select[name=sg]',
+            integrateBtn: 'button.integrate',
+            fields: 'input, select',
         },
 
         templateHelpers: function() {
@@ -211,13 +215,23 @@ define(['backbone', 'marionette',
         },
 
 
+        onFieldChanged: function() {
+            this._enableIntegrateButton();
+        },
+
+
         _disableIntegrateButton: function() {
-            var btn = $('button.integrate')
-            var btnHtml = btn.html()
-            btn.prop('disabled', true).html('<i class="fa fa-check"></i> Submitted!');
-            setTimeout(function() {
-                btn.prop('disabled', false).html(btnHtml);
+            this.btnHtml = this.ui.integrateBtn.html()
+            this.ui.integrateBtn.prop('disabled', true).html('<i class="fa fa-check"></i> Submitted!');
+            this.resetTimeout = setTimeout(() => {
+                this._enableIntegrateButton()
             }, 5000)
+        },
+
+
+        _enableIntegrateButton: function() {
+            this.ui.integrateBtn.prop('disabled', false).html(this.btnHtml);
+            clearTimeout(this.resetTimeout);
         },
 
 
@@ -252,6 +266,7 @@ define(['backbone', 'marionette',
         },
                                           
         onRender: function() {
+            this.btnHtml = this.ui.integrateBtn.html()
             this.pages.show(this.paginator)
             this.srch.show(this.search)
             this.ui.opts.hide()


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2059](https://jira.diamond.ac.uk/browse/LIMS-2059)

**Summary**:

https://github.com/DiamondLightSource/SynchWeb/pull/1009 introduced a 5s delay after pushing the reprocessing 'submit' button, to prevent accidental double clicks. This seems very long if you want to submit multiple similar jobs, so the button should re-enable if you change something.

**Changes**:
- Make re-enabling the button it's own function
- Trigger that function after 5s or if any input or select elements are changed
- Do this for normal reprocessing, downstream reprocessing or multicrystal reprocessing

**To test**:
- Use the live database as otherwise the reprocessing jobs will not exist as zocalo expects and may cause problems. Alternatively, comment out the `_enqueue` functions in these files.
- Go to a data collection with some automatic processing, eg /dc/visit/mx23694-154/id/21536724
- Click the small cog item to open the "Reprocess Data" window
- Click Integrate, and check the Integrate button is disabled for 5s
- Click Integrate again, and then change a parameter, eg the pipeline or the high res limit, the Integrate button should be enabled again
- Close that window and view an existing Autoprocessing job. Click the "Downstream Processing" button, and then repeat the above tests with the "Submit" button
- Go to the multicrystal reprocessing page /mc/visit/mx23694-154, and click the crossed arrows next to a data collection to select it. Repeat the above tests with the "Integrate" button.