### PR TITLE
LIMS-2104: Fix autoproc labels on mobile

### DIFF
--- a/client/src/css/partials/_tables.scss
+++ b/client/src/css/partials/_tables.scss
@@ -658,12 +658,14 @@ html[xmlns] .dataTables_wrapper { display: block; }
         &.procsummary {
             td:nth-of-type(1):before { content: "Type"; }
             td:nth-of-type(2):before { content: "Resolution"; }
-            td:nth-of-type(3):before { content: "Space Group"; }
-            td:nth-of-type(4):before { content: "Mn<I/sig(I)>"; }
-            td:nth-of-type(5):before { content: "Rmerge Inner"; }
-            td:nth-of-type(6):before { content: "Rmerge Outer"; }
-            td:nth-of-type(7):before { content: "Completeness"; }
-            td:nth-of-type(8):before { content: "Cell"; }
+            td:nth-of-type(3):before { content: "Resolution I/sig(I)=2"; }
+            td:nth-of-type(4):before { content: "Space Group"; }
+            td:nth-of-type(5):before { content: "Mn<I/sig(I)>"; }
+            td:nth-of-type(6):before { content: "Rmerge Inner"; }
+            td:nth-of-type(7):before { content: "Rmerge Outer"; }
+            td:nth-of-type(8):before { content: "Completeness"; }
+            td:nth-of-type(9):before { content: "Cell"; }
+            td:nth-of-type(10):before { content: "Message"; }
         }
 
         &.autoprocess {

--- a/client/src/css/partials/_tables.scss
+++ b/client/src/css/partials/_tables.scss
@@ -661,8 +661,8 @@ html[xmlns] .dataTables_wrapper { display: block; }
             td:nth-of-type(3):before { content: "Resolution I/sig(I)=2"; }
             td:nth-of-type(4):before { content: "Space Group"; }
             td:nth-of-type(5):before { content: "Mn<I/sig(I)>"; }
-            td:nth-of-type(6):before { content: "Rmerge Inner"; }
-            td:nth-of-type(7):before { content: "Rmerge Outer"; }
+            td:nth-of-type(6):before { content: "Rmeas Inner"; }
+            td:nth-of-type(7):before { content: "Rmeas Outer"; }
             td:nth-of-type(8):before { content: "Completeness"; }
             td:nth-of-type(9):before { content: "Cell"; }
             td:nth-of-type(10):before { content: "Message"; }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2104](https://jira.diamond.ac.uk/browse/LIMS-2104)

**Summary**:

Previously, autoprocessing values were mislabelled as resolution I/sig(I)=2 would be included in the table, but not accounted for, "pushing" all values one row down. This properly labels that value

**Changes**:
- Fix autoproc labels on mobile

**To test**:
<img width="336" height="258" alt="image" src="https://github.com/user-attachments/assets/e8903f09-49fb-4c43-9736-fc167c675c4a" />

- Go to a MX visit, such as https://ispyb.diamond.ac.uk/dc/visit/cm44137-1, hit F12, toggle "responsive design mode" (or equivalent in your browser), expand autoprocessing for any data collection, check if values are properly labelled
- Go to https://local-oidc-test.diamond.ac.uk:8082/dc/visit/lb42014-3 (or any other VMXi visit), check if it labels values correctly
- Go to a non-MX visit like https://local-oidc-test.diamond.ac.uk:8082/dc/visit/mm39816-1, check if it renders as normal
