### PR TITLE
LIMS-2037: Remove manual check for duplicate acronyms

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "backgrid-paginator": "0.3.9",
         "backgrid-select-all": "0.3.5",
         "ci": "^2.2.0",
-        "csv-file-validator": "^1.7.4",
+        "csv-file-validator": "^1.10.2",
         "d3-scale": "^3.2.3",
         "d3-scale-chromatic": "^2.0.0",
         "d3-selection": "^2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -66,7 +66,7 @@
     "backgrid-paginator": "0.3.9",
     "backgrid-select-all": "0.3.5",
     "ci": "^2.2.0",
-    "csv-file-validator": "^1.7.4",
+    "csv-file-validator": "^1.10.2",
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "d3-selection": "^2.0.0",

--- a/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
+++ b/client/src/js/modules/types/xpdf/samples/views/vue-simplesample.vue
@@ -287,6 +287,10 @@
                 inputName: 'acronym',
                 required: true,
                 requiredError,
+                unique: true,
+                uniqueError: function(headerName, rowNumber){
+                    return `${headerName} is not unique in row ${rowNumber}`
+                },
                 headerError
             },
             {
@@ -385,8 +389,6 @@
                 csvData: [],
                 csvErrors: [],
                 commaInComments: false,
-                duplicateAcronym: false,
-                duplicateAcronymRows: [],
                 proteinid: null,
                 externalid: null,
                 sampleGroupCollection: null,
@@ -700,8 +702,6 @@
             setCSVFile: function(event){
                 this.csvData = []
                 this.csvErrors = []
-                this.duplicateAcronym = false
-                this.duplicateAcronymRows = []
 
                 if(event.target.files.length === 0){
                     this.fileValid = false
@@ -729,9 +729,6 @@
                                 self.csvErrors.push("Only headers have been submitted, please add some sample information")
                             }
 
-                            if(self.duplicateAcronym)
-                                self.csvErrors = self.csvErrors.concat(self.duplicateAcronymRows)
-
                             if(self.csvErrors.length === 0)
                                 self.fileValid = true
                             else {
@@ -758,44 +755,8 @@
                     self.commaInComments = false;
                     var newLineSplit = e.target.result.split("\n")
                     newLineSplit.forEach(function(row){
-                        var cells = row.split(',')
-                        if(cells.length > 5){
-                            self.commaInComments = true
-                            ready = true
-                        }
+                        if(row.split(',').length > 5) self.commaInComments = true
                     })
-
-                    // Display duplicate acronyms and the row they are on (only in file duplicates, not against database)
-                    // Hopefully this issue gets implemented then we can remove all this. https://github.com/shystruk/csv-file-validator/issues/20
-                    var acronyms = []
-                    var acronymIndex = 5
-
-                    for(var i=0; i<newLineSplit.length; i++){
-                        var cells = newLineSplit[i].split(',')
-
-                        for(var j=0; j<cells.length; j++){
-                            // if first row check which column is the Acronym
-                            if(i === 0){
-                                if(cells[j] === 'Acronym'){
-                                    acronymIndex = j
-                                    break
-                                }
-                            }
-                            // ignore any non acronym columns
-                            if(j !== acronymIndex) break
-
-                            for(let k=0; k < acronyms.length; k++){
-                                if(acronyms[k] === cells[j]){
-                                    var currentRow = i
-                                    self.duplicateAcronym = true
-                                    self.duplicateAcronymRows.push(cells[j] + ' is a duplicate acronym on row ' + ++currentRow)
-                                    break
-                                }
-                            }
-
-                            acronyms[i] = cells[acronymIndex]
-                        }
-                    }
 
                     // Remove all leading and trailing white space
                     // Also clean up trailing commas on each row to ensure new line works as expected
@@ -803,13 +764,11 @@
                     newLineSplit.forEach(function(row){
                         var cells = row.split(',')
                         cells.forEach(function(cell, index){
-                            i = index + 1
                             trimmed += cell.trim()
-                            if(cells.length !== i){
+                            if(cells.length !== index + 1){
                                 trimmed += ','
                             } else {
-                                if(trimmed.endsWith(','))
-                                    trimmed = trimmed.substring(0, trimmed.length-1)
+                                if(trimmed.endsWith(',')) trimmed = trimmed.slice(0, -1)
                                 trimmed += "\n"
                             }
                         })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2037](https://jira.diamond.ac.uk/browse/LIMS-2037)

**Summary**:

Previously csv-file-validator wouldn't identify which rows had duplicate acronyms, so we had to manually check ourselves. Version 1.10.2 onwards has this functionality built in.

**Changes**:
- Ensure csv-file-validator is at least 1.10.2 (we have been using 1.13.1 for years)
- Remove manual check for duplicate acronyms, and variables used in that
- Add `unique` constraint to acronym column, with suitable error message
- Slightly simplify the check for extra commas and reforming the csv data blob

**To test**:
- Go to an I15-1 proposal, eg cm37261
- Go to Phases from the main menu, then click on a Phase
- Click "Add new simple sample"
- Choose "File upload for multiple samples"
- Select this file [duplicate_acronym.csv](https://github.com/user-attachments/files/25345297/duplicate_acronym.csv)
- Check an error appears about a duplicate acronym on row 3
- Edit the file to have a unique acronym, refresh the page and re-select the file, check no errors occur, click "Add Sample" and check it uploads as expected
