### PR TITLE
LIMS-2054: Dont exclude peaks from MCA spectra

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1251,8 +1251,7 @@ class DC extends Page
                         $max_counts = floatval($l[1]);
                     if (array_key_exists($l[0], $el_to_en)) {
                         $els = $el_to_en[$l[0]];
-                        if (($els[sizeof($els) - 1] * 1000) < ($info['ENERGY'] - 1000))
-                            $elements[$l[0]] = array(array_map('floatval', $els), floatval($l[1]), floatval($l[2]));
+                        $elements[$l[0]] = array(array_map('floatval', $els), floatval($l[1]), floatval($l[2]));
                     } else
                         array_push($el_no_match, $l[0]);
                 }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2054](https://jira.diamond.ac.uk/browse/LIMS-2054)

**Summary**:

The SynchWeb view of MCA spectra uses logic to determine whether to label fitted peaks by comparing the energy of emission lines to a cutoff applied to exclude the Compton scattering region of the spectrum (currently applied as a blanket beam energy - 1 keV cutoff).

This logic is redundant as similar logic is applied at the analysis step and peaks would not be included in the results file if they fall into this cutoff region. The code should therefore be removed to avoid needing to change logic in two locations if the application of the cutoff needs to be modified.

**Changes**:
- Don't exclude peaks within 1keV of the beam energy

**To test**:
- Go to /dc/visit/lb42888-63/ty/mca/id/18384, check there are 2 labelled Zn peaks

**NB**
There is also code to plot the graph within 1100eV as a different colour, just above this change. That is to be addressed in ticket [LIMS-2055](https://jira.diamond.ac.uk/browse/LIMS-2055)