### PR TITLE
LIMS-2109: Require an email address when creating a plate

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "apereo/phpcas": "1.6.1",
     "ezyang/htmlpurifier": "4.12.0",
-    "firebase/php-jwt": "6.0.0",
+    "firebase/php-jwt": "^6.0.0",
     "jdorn/sql-formatter": "1.2.9",
     "mpdf/mpdf": "8.1.2",
     "ralouphie/getallheaders": "2.0.5",
@@ -44,6 +44,9 @@
   "config": {
     "platform": {
       "php": "7.3"
+    },
+    "audit": {
+      "ignore": ["PKSA-y2cr-5h3j-g3ys"]
     }
   }
 }

--- a/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-add.vue
@@ -264,32 +264,36 @@
 
             <validation-provider
               tag="div"
+              v-slot="{ errors }"
               class="tw-mb-2 tw-py-2"
-              rules="required"
+              :rules="(plateType === 'plate' && !ownerEmail) ? 'required|excluded:' + PERSONID : 'required'"
               name="owner"
+              vid="owner"
             >
               <base-input-select
                 dataTestId="add-container-owner"
                 v-model="PERSONID"
-                outer-class="tw-flex tw-w-full tw-items-center"
+                outer-class="tw-flex tw-w-full"
                 label="Owner"
                 description="This user will be emailed with container updates. Check your email is up to date!"
                 name="PERSONID"
                 :options="users"
                 option-value-key="PERSONID"
                 option-text-key="FULLNAME"
+                :error-message="errors[0]"
+                :quiet="!ownerEmail"
               >
-                <template #error-msg>
-                  <span
-                    v-show="!ownerEmail"
-                    class="emsg tw-bg-content-light-background tw-text-xxs tw-ml-1 tw-p-1 tw-h-6"
-                  >Please update your email address by clicking view</span>
-                </template>
                 <template #actions>
                   <a
                     :href="`/contacts/user/${PERSONID}`"
-                    class="button edit_user tw-w-16 tw-text-center tw-h-6 tw-text-xxs"
+                    class="button edit_user tw-w-16 tw-text-center tw-h-6 tw-text-xxs tw-ml-2"
                   ><i class="fa fa-search" /> View</a>
+                  <span
+                    v-show="!ownerEmail"
+                    class="emsg tw-bg-content-light-background tw-text-xxs tw-ml-1 tw-p-1 tw-h-6"
+                  >
+                    Click View to update your email address
+                  </span>
                 </template>
               </base-input-select>
             </validation-provider>
@@ -358,7 +362,10 @@
               v-show="error.length > 0"
               class="tw-black"
             >
-              {{ error[0] }}
+              {{ (index === 'owner' && !ownerEmail)
+                ? 'The selected owner has no email address. Please update it by clicking View.'
+                : error[0]
+              }}
             </p>
           </div>
         </div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2109](https://jira.diamond.ac.uk/browse/LIMS-2109)

**Summary**:

If a plate is created and the owner does not have an email address in ISPyB, then errors occur on the beamline. We should make email address required for plate owners.

**Changes**:
- Fail validation if the container type is a plate and the owner has no email address
- Hide the default error message and show custom ones instead
- Remove the tw-items-center class so all the items in the row are aligned vertically

**To test**:
- Go to an proposal mx23694
- Go to any shipment and click "Add Container"
- Keep the container type as Puck, and choose Sue Pulford-Fletcher as the Owner. Check an advisory message appears to encourage filling in the email address, but that you can create the puck regardless
- On a new container, change the container type to a plate (eg CrystalQuickX), and choose Sue as the owner again. Check the box turns red and you are not allowed to create the container
- Change the owner to someone with an email address, check you can now create the container
