### PR TITLE
LIMS-2064: Show no of pucks/plates on shipments page

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "apereo/phpcas": "1.6.1",
     "ezyang/htmlpurifier": "4.12.0",
-    "firebase/php-jwt": "6.0.0",
+    "firebase/php-jwt": "^6.0.0",
     "jdorn/sql-formatter": "1.2.9",
     "mpdf/mpdf": "8.1.2",
     "ralouphie/getallheaders": "2.0.5",
@@ -44,6 +44,9 @@
   "config": {
     "platform": {
       "php": "7.3"
+    },
+    "audit": {
+      "ignore": ["PKSA-y2cr-5h3j-g3ys"]
     }
   }
 }

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -316,7 +316,7 @@ class Shipment extends Page
         $tot = $this->db->pq("SELECT count(distinct s.shippingid) as tot 
                 FROM proposal p 
               INNER JOIN shipping s ON p.proposalid = s.proposalid 
-              LEFT OUTER JOIN labcontact c ON s.sendinglabcontactid = c.labcontactid 
+              LEFT OUTER JOIN labcontact lc ON s.sendinglabcontactid = lc.labcontactid
               LEFT OUTER JOIN labcontact c2 ON s.returnlabcontactid = c2.labcontactid 
               LEFT OUTER JOIN dewar d ON d.shippingid = s.shippingid 
               WHERE $where", $args);
@@ -348,8 +348,10 @@ class Shipment extends Page
                 TO_CHAR(s.deliveryagent_deliverydate, 'DD-MM-YYYY') as deliveryagent_deliverydate,
                 s.safetylevel,
                 count(d.dewarid) as dcount,
+                SUM(IFNULL(c.puckcount, 0)) as pcount,
+                SUM(IFNULL(c.platecount, 0)) as plcount,
                 s.sendinglabcontactid,
-                c.cardname as lcout,
+                lc.cardname as lcout,
                 c2.cardname as lcret,
                 s.returnlabcontactid,
                 s.shippingid,
@@ -392,14 +394,21 @@ class Shipment extends Page
             LEFT OUTER JOIN dewar d ON d.shippingid = s.shippingid
             LEFT OUTER JOIN blsession b ON b.sessionid = d.firstexperimentid
             LEFT OUTER JOIN couriertermsaccepted cta ON cta.shippingid = s.shippingid
-            LEFT OUTER JOIN labcontact c ON c.labcontactid = s.sendinglabcontactid
-            LEFT OUTER JOIN person pe ON c.personid = pe.personid
+            LEFT OUTER JOIN labcontact lc ON lc.labcontactid = s.sendinglabcontactid
+            LEFT OUTER JOIN person pe ON lc.personid = pe.personid
             LEFT OUTER JOIN laboratory l ON l.laboratoryid = pe.laboratoryid
             LEFT OUTER JOIN person pe2 ON pe2.personid = s.deliveryagent_flightcodepersonid
+            LEFT OUTER JOIN (
+                SELECT dewarid,
+                COUNT(IF(capacity < 25, 1, NULL)) as puckcount,
+                COUNT(IF(capacity >= 25, 1, NULL)) as platecount
+                FROM container
+                GROUP BY dewarid
+            ) c ON c.dewarid = d.dewarid
             WHERE $where
             GROUP BY
                 s.sendinglabcontactid, s.returnlabcontactid, s.deliveryagent_agentname, s.deliveryagent_agentcode,
-                s.deliveryagent_shippingdate, s.deliveryagent_deliverydate, s.safetylevel, c.cardname, c2.cardname,
+                s.deliveryagent_shippingdate, s.deliveryagent_deliverydate, s.safetylevel, lc.cardname, c2.cardname,
                 s.shippingid, s.shippingname, s.shippingstatus,TO_CHAR(s.creationdate, 'DD-MM-YYYY'),
                 s.isstorageshipping, s.shippingtype, s.comments, s.creationdate
             ORDER BY $order",

--- a/client/src/js/modules/shipment/views/shipments.js
+++ b/client/src/js/modules/shipment/views/shipments.js
@@ -49,11 +49,12 @@ define(['marionette',
     initialize: function(options) {
       var columns = [{ name: 'SHIPPINGNAME', label: 'Name', cell: 'string', editable: false },
                      { name: 'DEWARS', label: 'Dewar(s)', cell: 'string', editable: false },
+                     { name: 'PCOUNT', label: '# Pucks', cell: 'string', editable: false },
+                     { name: 'PLCOUNT', label: '# Plates', cell: 'string', editable: false },
                      { name: 'CREATED', label: 'Creation Date', cell: 'string', editable: false },
                      { name: 'VISIT', label: 'Visit', cell: 'string', editable: false },
                      { name: 'CONTACTS', label: 'Lab Contact', cell: ContactCell, editable: false },
                      { name: 'SHIPPINGSTATUS', label: 'Status', cell: 'string', editable: false },
-                     { name: 'DCOUNT', label: '# Comp', cell: 'string', editable: false },
                      { name: 'COMMENTS', label: 'Comments', cell: 'string', editable: false },
                      ]
         


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2064](https://jira.diamond.ac.uk/browse/LIMS-2064)

**Summary**:

We should list # of plates and pucks to the shipments page, instead of # of dewars.

**Changes**:
- Add a subquery to count pucks and plates in each dewar (based on container capacity)
- Display puck and plate count on /shipments

**To test**:
- Go to a proposal with a mixture of puck shipments and plate shipments, eg mx39669
- Go to the /shipments page, check there are columns for "# Pucks' and '# Plates'
- Check the number of pucks and plates displayed matches what is shown if you click into each shipment
