### PR TITLE
LIMS-2077: Individual grid scans show boxes for group of grid scans

### DIFF
--- a/client/src/js/modules/dc/views/dcbase.js
+++ b/client/src/js/modules/dc/views/dcbase.js
@@ -87,6 +87,7 @@ define(['marionette',
             console.log('updateDCC', this.ui.dcglink, this.model)
             if (this.model.get('DCC') > 1) {
                 this.$el.find('li.group').show()
+                this.$el.find('.gridsize2').show()
                 this.$el.find('.dcglink').show()
                 this.$el.find('.dclink').hide()
                 this.$el.find('.reprocess').hide()
@@ -95,6 +96,7 @@ define(['marionette',
                 }
             } else {
                 this.$el.find('li.group').hide()
+                this.$el.find('.gridsize2').hide()
                 this.$el.find('.dcglink').hide()
                 this.$el.find('.dclink').show()
                 this.$el.find('.reprocess').show()

--- a/client/src/js/modules/dc/views/grid.js
+++ b/client/src/js/modules/dc/views/grid.js
@@ -46,6 +46,7 @@ define(['marionette',
       xrcholder: '.holder h1.xrc',
       apholder: '.holder h1.ap',
       gridsize: '.gridsize',
+      gridsize2: '.gridsize2',
     },
 
     toggleZoom: function(e) {
@@ -126,9 +127,8 @@ define(['marionette',
         if (this.ui.bx.text) this.ui.by.text((gi.get('DY_MM')*1000).toFixed(0))
 
         if (gi.get('STEPS_Y') > 10 && this.ui.zoom.show) this.ui.zoom.show()
-        var gridsize = gi.get('STEPS_X') + ' x ' + gi.get('STEPS_Y')
-        if (gi.get('STEPS_Z')) { gridsize += ' x ' + gi.get('STEPS_Z') }
-        this.ui.gridsize.html(gridsize)
+        this.ui.gridsize.html(gi.get('STEPS_X') + ' x ' + gi.get('STEPS_Y'))
+        if (gi.get('STEPS_Z')) { this.ui.gridsize2.html(' x ' + gi.get('STEPS_Z')) }
     },
 
     checkXRCandAP: function() {

--- a/client/src/js/templates/dc/grid.html
+++ b/client/src/js/templates/dc/grid.html
@@ -13,7 +13,7 @@
         <li>Transmission: <%-TRANSMISSION%>%</li>
         <li>Beamsize: <%-BSX%>x<%-BSY%>&mu;m</li>
         <li>Boxsize: <span class="boxx"></span>x<span class="boxy"></span>&mu;m</li>
-        <li>Grid scan size: <span class="gridsize"></span></li>
+        <li>Grid scan size: <span class="gridsize"></span><span class="gridsize2"></span></li>
         <li class="comment">Comment: <span class="COMMENTS"><%-COMMENTS%></span></li>
         <% if (!STATE) { %><li>Status: <span class="b">Stopped</span></li><% } %>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2077](https://jira.diamond.ac.uk/browse/LIMS-2077)

**Summary**:

Groups of grid scans for Xray centring correctly show the number of boxes in 3 dimensions on the main page, but when you click into the group, it should show the individual grid scans with the 2d number of boxes.

**Changes**:
- Put the 3rd dimension of the grid scan group (`STEPS_Z`) into a separate span
- Hide the span if viewing inside a data collection group

**To test**:
- Go to a visit with grid scan groups eg /dc/visit/cm40608-5
- Check the groups of grid scans on the main page show 3 dimensions for Grid Scan Size, eg 30 x 10 x 15
- Click into one of the groups eg /dc/visit/cm40608-5/dcg/17214375
- Check each grid scan only shows 2 dimensions eg 30 x 10 or 30 x 15
- Click into an individual grid scan eg /dc/visit/cm40608-5/id/20910753
- Check it only shows 2 dimensions again eg 30 x 10