### PR TITLE
LIMS-2129: Fix permissions for Goods Handling

### DIFF
--- a/api/src/Page/Proposal.php
+++ b/api/src/Page/Proposal.php
@@ -156,7 +156,9 @@ class Proposal extends Page
             array_push($args, $id);
         }
 
-        if ($this->staff) {
+        if ($this->user->hasPermission('all_dewars')) {
+            // allow to see shipments on all proposals
+        } else if ($this->staff) {
             if (!$this->user->hasPermission('super_admin')) {
                 $bls = array();
                 foreach ($this->user->perms as $p) {
@@ -172,8 +174,6 @@ class Proposal extends Page
                 $where .= " AND (shp.personid=:" . (sizeof($args) + 1) . " OR s.beamlinename in ('" . implode("','", $bls) . "'))";
                 array_push($args, $this->user->personId);
             }
-        } else if ($this->user->hasPermission('all_dewars')) {
-            // allow to see shipments on all proposals
         } else {
             $where = " INNER JOIN session_has_person shp ON shp.sessionid = s.sessionid  " . $where;
             $where .= " AND shp.personid=:" . (sizeof($args) + 1);
@@ -919,7 +919,9 @@ class Proposal extends Page
         $args = array();
 
 
-        if ($this->staff) {
+        if ($field == 'SHIPPINGID' && $this->user->hasPermission('all_dewars')) {
+            // allow to see shipments
+        } else if ($this->staff) {
             if (!$this->user->hasPermission('super_admin')) {
                 $bls = array();
                 foreach ($this->user->perms as $p) {
@@ -933,8 +935,6 @@ class Proposal extends Page
 
                 $where .= " AND ses.beamlinename in ('" . implode("','", $bls) . "')";
             }
-        } else if ($field == 'SHIPPINGID' && $this->user->hasPermission('all_dewars')) {
-            // allow to see shipments
         } else {
             $where = " INNER JOIN session_has_person shp ON shp.sessionid = ses.sessionid  " . $where;
             $where .= " AND shp.personid=:" . (sizeof($args) + 1);


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2129](https://jira.diamond.ac.uk/browse/LIMS-2129)

**Summary**:

All members of DLS staff have been added to the group b01-1_admin and thus Synchweb treats them as staff, which means we were never testing whether they had all_dewars permission, as https://github.com/DiamondLightSource/SynchWeb/pull/752 was not well written.

**Changes**:
- Swap the order of `if` clauses to test the all_dewars permission first

**To test**:
- Log in as someone from goods handling, test you can navigate via a proposal to a shipment and print shipping labels
- Test a direct link to a shipment as someone from goods handling
- Test you cannot see visits or data collections
- Log in as a 'normal' user, test you can only get to shipments from your proposal
- Test a direct link to a shipment you should not be able to see
- Log in as staff, test you can see everything as normal