### PR TITLE
LIMS-2078: Fix display of fault reports on visit stats page

### DIFF
--- a/client/src/js/modules/fault/views/list.js
+++ b/client/src/js/modules/fault/views/list.js
@@ -5,7 +5,7 @@ define(['marionette', 'modules/fault/views/filters', 'views/table', 'utils/table
         argument: 'FAULTID',
     })
 
-    
+
     return Marionette.LayoutView.extend({
         className: 'content',
         template: _.template('<h1>Faults</h1><% if (app.user_can(\'fault_add\')) { %><div class="r"><a class="button add" href="/faults/add"><i class="fa fa-plus"></i> Add Fault Report</a></div><% } %><div class="filters"></div><div class="wrapper"></div>'),
@@ -14,6 +14,7 @@ define(['marionette', 'modules/fault/views/filters', 'views/table', 'utils/table
         search: true,
 
         initialize: function(options) {
+            const params = this.getOption('params') || {}
             var columns = [
                 { name: 'TITLE', label: 'Title', cell: table.HTMLCell, editable: false },
                 { name: 'STARTTIME', label: 'Time', cell: 'string', editable: false },
@@ -26,23 +27,23 @@ define(['marionette', 'modules/fault/views/filters', 'views/table', 'utils/table
                 { name: 'NAME', label: 'Reporter', cell: 'string', editable: false },
               
             ]
-            
+
             if (app.mobile()) {
                 _.each([3,4,5,6,8], function(v) {
                     columns[v].renderable = false
                 })
             }
+
+            this.table = new TableView({ collection: options.collection, columns: columns, tableClass: 'proposals', filter: 's', search: params.s, loading: true, backgrid: { row: ClickableRow, emptyText: 'No faults found' } })
             
-            this.table = new TableView({ collection: options.collection, columns: columns, tableClass: 'proposals', filter: 's', search: options.params.s, loading: true, backgrid: { row: ClickableRow, emptyText: 'No faults found' } })
-            
-            if (this.getOption('filters')) this.filters = new FilterView({ collection: options.collection, params: this.getOption('params') })
+            if (this.getOption('filters')) this.filters = new FilterView({ collection: options.collection, params: params })
         },
-                                          
+
         onRender: function() {
             this.wrap.show(this.table)
             if (this.getOption('filters')) this.flts.show(this.filters)
         },
-          
+
         onShow: function() {
             this.table.focusSearch()
         },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2078](https://jira.diamond.ac.uk/browse/LIMS-2078)

**Summary**:

https://github.com/DiamondLightSource/SynchWeb/pull/979 inadvertently broke the display of fault reports on the visit stats page.

**Changes**:
- Make sure there is an object to look for `s` in
- Tidy whitespace

**To test**:
- Go to a visit stats page for a visit that has a fault report, eg /stats/visit/mx38021-41
- Check the fault report is displayed, and also the "Robot Dewar Usage" chart displays (may take a few seconds)
- Check no errors in the dev console
