### PR TITLE
LIMS-2108: Add more pipelines to the summary page

### DIFF
--- a/api/src/Page/Process.php
+++ b/api/src/Page/Process.php
@@ -435,9 +435,15 @@ class Process extends Page
         $status = $this->has_arg('pipelinestatus') ? $this->arg('pipelinestatus') : null;
         $category = $this->has_arg('category') ? $this->arg('category') : null;
 
+        // allow more than one status
         if ($status) {
-            $where .= ' AND pp.pipelinestatus=:'.(sizeof($args)+1);
-            array_push($args, $this->arg('pipelinestatus'));
+            $status_queries = array();
+            $status_array = is_array($status) ? $status : array($status);
+            foreach ($status_array as $s) {
+                array_push($args, $s);
+                array_push($status_queries, 'pp.pipelinestatus=:' . count($args));
+            }
+            $where .= ' AND (' . implode(' OR ', $status_queries) . ')';
         }
         if ($category) {
             $where .= ' AND ppc.name=:'.(sizeof($args)+1);

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -32,7 +32,7 @@ class Processing extends Page {
         'n' => '\d+',
         'sampleGroupId' => '\d+',
         'resultCount' => '\d+',
-        'pipeline' => '[\w\s\+]+',
+        'pipeline' => '\d+',
         'spacegroup' => '(\w|\s|\-|\/)+',
         'resolution' => '[\d\.]+',
         'completeness' => '[\d\.]+',
@@ -403,7 +403,7 @@ class Processing extends Page {
 
         if ($this->has_arg('pipeline')) {
             $st = sizeof($args);
-            $where .= " AND app.processingprograms = :" . ($st + 1);
+            $where .= " AND app.processingpipelineid = :" . ($st + 1);
             array_push($args, $this->arg('pipeline'));
         }
 

--- a/client/src/js/modules/dc/views/summary.js
+++ b/client/src/js/modules/dc/views/summary.js
@@ -6,12 +6,14 @@ define(['backbone',
     'utils/table',
     'utils/kvcollection',
     'collections/spacegroups',
+    'collections/processingpipelines',
     'templates/dc/summary.html'], 
     function(Backbone, Marionette, Backgrid, TableView,
         utils,
         table,
         KVCollection,
         Spacegroups,
+        ProcessingPipelines,
         template) {
 
     var Pipelines = Backbone.Collection.extend(_.extend({
@@ -186,19 +188,20 @@ define(['backbone',
             this.updateData()
         },
 
+        updatePipelines: function() {
+            this.ui.pipeline.html('<option value="">All pipelines</option>'+this.processing_pipelines.opts())
+        },
+
         onRender: function() {
             this.showSpaceGroups()
 
-            this.pipelines = new Pipelines([
-                { NAME: 'Any', VALUE: '' },
-                { NAME: 'Xia2 DIALS', VALUE: 'xia2 dials' },
-                { NAME: 'Xia2 3dii', VALUE: 'xia2 3dii' },
-                { NAME: 'Fast DP', VALUE: 'fast_dp' },
-                { NAME: 'autoPROC', VALUE: 'autoPROC' },
-                { NAME: 'autoPROC+STARANISO', VALUE: 'autoPROC+STARANISO' },
-            ])
-
-            this.ui.pipeline.html(this.pipelines.opts())
+            this.processing_pipelines = new ProcessingPipelines()
+            this.processing_pipelines.fetch({
+                data: {
+                    category: 'processing',
+                    pipelinestatus: ['automatic', 'optional'],
+                }
+            }).done(this.updatePipelines.bind(this));
 
             var columns = [
                 { label: '', cell: table.TemplateCell, editable: false, template: '<a href="/dc/visit/'+this.visit+'/id/<%-ID%>" class="button button-notext"><i class="fa fa-search"></i> <span>View Data Collection</span></a>' },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2108](https://jira.diamond.ac.uk/browse/LIMS-2108)

**Summary**:

The summary page currently has hard-coded pipelines, we should get them from the ProcessingPipelines table. That way we get the Multi pipelines, and any new ones added in future.

**Changes**:
- Get processing pipelines from the DB
- Allow fetching of pipelines with different statuses
- Use the pipeline id to fetch matching processing runs

**To test**:
- Go to a visit with multiple successful processing runs, then click the Summary button to go to eg /dc/summary/visit/mx23694-156
- Check the list of pipelines now includes multi- pipelines
- Check selecting a pipeline only shows results from that pipeline (results from multi-* and STARANISO may not appear yet until Data Analysis start tagging them)
- Go to a shipment, create a puck, check you can still choose from 3 pipelines for priority processing
