### PR TITLE
LIMS-2033: Fix count of autoprocessing errors

### DIFF
--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -648,32 +648,53 @@ class Processing extends Page {
 
         $rows = $this->db->union(
             array(
-                "SELECT app.autoprocprogramid, dc.datacollectionid as id, SUM(IF(appm.severity = 'ERROR', 1, 0)) as errors, SUM(IF(appm.severity = 'WARNING', 1, 0)) as warnings, SUM(IF(appm.severity = 'INFO', 1, 0)) as infos
+                "SELECT DISTINCT dc.datacollectionid as id, dc.datacollectiongroupid as dcg, appm.autoprocprogrammessageid, appm.severity
             FROM autoprocprogrammessage appm
             INNER JOIN autoprocprogram app ON app.autoprocprogramid = appm.autoprocprogramid
             INNER JOIN autoprocintegration api ON api.autoprocprogramid = app.autoprocprogramid
             INNER JOIN datacollection dc ON dc.datacollectionid = api.datacollectionid
             INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
             INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-            WHERE $where
-            GROUP BY dc.datacollectionid",
-                "SELECT app.autoprocprogramid, dc.datacollectionid as id, SUM(IF(appm.severity = 'ERROR', 1, 0)) as errors, SUM(IF(appm.severity = 'WARNING', 1, 0)) as warnings, SUM(IF(appm.severity = 'INFO', 1, 0)) as infos
+            WHERE $where",
+                "SELECT DISTINCT dc.datacollectionid as id, dc.datacollectiongroupid as dcg, appm.autoprocprogrammessageid, appm.severity
             FROM autoprocprogrammessage appm
             INNER JOIN autoprocprogram app ON app.autoprocprogramid = appm.autoprocprogramid
             INNER JOIN processingjob pj ON pj.processingjobid = app.processingjobid
             INNER JOIN datacollection dc ON dc.datacollectionid = pj.datacollectionid
             INNER JOIN datacollectiongroup dcg ON dcg.datacollectiongroupid = dc.datacollectiongroupid
             INNER JOIN blsession s ON s.sessionid = dcg.sessionid
-            WHERE $where
-            GROUP BY dc.datacollectionid
-        ",
+            WHERE $where",
             ),
             $args,
             false,
-            "SELECT autoprocprogramid, id, sum(errors) as errors, sum(warnings) as warnings, sum(infos) as infos FROM (:QUERY) inq GROUP BY id"
+            "SELECT id, dcg, SUM(IF(severity = 'ERROR', 1, 0)) as errors, SUM(IF(severity = 'WARNING', 1, 0)) as warnings, SUM(IF(severity = 'INFO', 1, 0)) as infos FROM (:QUERY) inq GROUP BY id"
         );
 
-        $this->_output($rows);
+        $ids  = $this->has_arg('ids') ? (array)$this->arg('ids') : array();
+        $dcgs = $this->has_arg('dcg') ? (array)$this->arg('dcg') : array();
+        $grouped = array();
+
+        foreach ($rows as $row) {
+            if (in_array($row['ID'], $ids)) {
+                $groupKey = "ID_" . $row['ID'];
+                unset($row['DCG']);
+            } else if (in_array($row['DCG'], $dcgs)) {
+                $groupKey = "DCG_" . $row['DCG'];
+                unset($row['ID']);
+            } else {
+                continue;
+            }
+
+            if (!isset($grouped[$groupKey])) {
+                $grouped[$groupKey] = $row;
+            } else {
+                $grouped[$groupKey]['ERRORS'] += $row['ERRORS'];
+                $grouped[$groupKey]['WARNINGS'] += $row['WARNINGS'];
+                $grouped[$groupKey]['INFOS'] += $row['INFOS'];
+            }
+        }
+
+        $this->_output(array_values($grouped));
     }
 
     /**

--- a/client/src/js/collections/apmessages.js
+++ b/client/src/js/collections/apmessages.js
@@ -6,7 +6,7 @@ define(['backbone.paginator', 'models/apmessage'], function(PageableCollection, 
         url: '/processing/messages',
 
         state: {
-            pageSize: 15,
+            pageSize: 9999,
         },
     })
 })

--- a/client/src/js/modules/dc/views/apmessagestatusitem.js
+++ b/client/src/js/modules/dc/views/apmessagestatusitem.js
@@ -13,7 +13,10 @@ define(['marionette', 'jquery'], function(Marionette, $) {
         },
         
         getModel: function() {
-            var m = this.getOption('statuses').findWhere({ ID: this.getOption('ID') })
+            var m = this.getOption('statuses').find(m =>
+                m.get('ID') === this.getOption('ID') ||
+                m.get('DCG') === this.getOption('DCG')
+            )
             if (m != this.model) {
                 this.undelegateEvents()
                 this.model = m

--- a/client/src/js/modules/dc/views/dc.js
+++ b/client/src/js/modules/dc/views/dc.js
@@ -82,7 +82,7 @@ define(['marionette',
 
       this.apstatus = new (this.getOption('apStatusItem'))({ ID: this.model.get('ID'), DCG: this.model.get('DCG'), showStrategies: this.showStrategies, showProcessing: this.showProcessing, statuses: this.getOption('apstatuses'), el: this.$el })
       this.listenTo(this.apstatus, 'status', this.updateAP, this)
-      this.apmessagestatus = new (this.getOption('apMessageStatusItem'))({ ID: this.model.get('ID'), statuses: this.getOption('apmessagestatuses'), el: this.$el })
+      this.apmessagestatus = new (this.getOption('apMessageStatusItem'))({ ID: this.model.get('ID'), DCG: this.model.get('DCG'), statuses: this.getOption('apmessagestatuses'), el: this.$el })
 
       this.updateInPlace(true)
     },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2033](https://jira.diamond.ac.uk/browse/LIMS-2033)

**Summary**:

The autoprocessing pipelines produce messages as either INFOS, WARNINGS or ERRORS. These are displayed by the data collection or group, but the number shown is wrong.

**Changes**:
- Get all the messages first, via both sets of possible joins, then Union them, then Sum them only at the end
- Ignore autoprocprogramid so the Union command correctly ignores duplicates
- Return totals with the dataCollectionId or dataCollectionGroupId passed in, if using a DCG then sum the totals together
- Display the total for the group if a group is displayed
- Dont limit the page size to 15, some jobs give more than 15 messages

**To test**:
- Go to a visit with a mix of grouped and ungrouped data collections, eg /dc/visit/cm40608-5/ty/fc
- Look for the colourful little button on each data collection like this
<img width="139" height="47" alt="image" src="https://github.com/user-attachments/assets/3145cc50-0be3-4df2-a866-c54c81448033" />
- Look at an ungrouped data collection, check the numbers on the button match those displayed if you click the button (summing the tabs together)
- Look at a data collection group (coloured blue), check the numbers on the button match those displayed if you click the button (summing all the tabs). These numbers may be higher as they are for all processing jobs on all DCs in the group
- Click into the group, check the numbers on the buttons in the group match those displayed if you click the buttons, and add up to those shown on the whole group. (Eg group shows 87 "infos", comprising of 2 data collections with 53 and 34 "infos" respectively, see /dc/visit/cm40608-5/dcg/17176266)
