### PR TITLE
LIMS-2023: Add Basic Auth to UAS for UDC

### DIFF
--- a/api/src/UAS.php
+++ b/api/src/UAS.php
@@ -9,27 +9,36 @@ class UAS
 
     function __construct($user=null, $pass=null) {
         global $uas_url, $vmxi_user, $vmxi_pass;
+        global $uas_auth,
+               $mxautocollect_srv_acc_username,
+               $mxautocollect_srv_acc_password;
 
         $this->url = $uas_url;
-
-        $cas = new CAS();
-
-        if ($user && $pass) $cas->authenticate($user, $pass);
-        else $cas->authenticate($vmxi_user, $vmxi_pass);
-
-        $st = $cas->service($this->url.'/uas/login/cas');
-
-        $uas = $this->_curl(array(
-            'URL' => $this->url.'/uas/login/cas?ticket='.$st,
-            'HEADER' => 1,
-            'GET' => 1,
-        ));
-
+        $this->uas_auth = $uas_auth;
         $this->session = null;
-        foreach (explode("\n", $uas) as $line) {
-            if (preg_match('/^Set-Cookie: JSESSIONID=(\w+);/', $line, $mat)) {
-                $this->session = $mat[1];
+
+        if ($this->uas_auth == 'CAS') {
+            $cas = new CAS();
+
+            if ($user && $pass) $cas->authenticate($user, $pass);
+            else $cas->authenticate($vmxi_user, $vmxi_pass);
+
+            $st = $cas->service($this->url . '/uas/login/cas');
+
+            $uas = $this->_curl(array(
+                'URL' => $this->url . '/uas/login/cas?ticket=' . $st,
+                'HEADER' => 1,
+                'GET' => 1,
+            ));
+
+            foreach (explode("\n", $uas) as $line) {
+                if (preg_match('/^Set-Cookie: JSESSIONID=(\w+);/', $line, $mat)) {
+                    $this->session = $mat[1];
+                }
             }
+        } elseif ($this->uas_auth == 'BASIC') {
+            $this->user = $mxautocollect_srv_acc_username;
+            $this->pass = $mxautocollect_srv_acc_password;
         }
 
         // print_r(array('sess', $this->session));
@@ -44,7 +53,6 @@ class UAS
             'HEADERS' => array(
                 'Content-type: application/json',
                 'Accept: application/json',
-                'Cookie: JSESSIONID='.$this->session,
             ),
         ));
 
@@ -69,7 +77,6 @@ class UAS
             'HEADERS' => array(
                 'Content-type: application/json',
                 'Accept: application/json',
-                'Cookie: JSESSIONID='.$this->session,
             ),
         ));
 
@@ -92,7 +99,6 @@ class UAS
             'HEADERS' => array(
                 'Content-type: application/json',
                 'Accept: application/json',
-                'Cookie: JSESSIONID='.$this->session,
             ),
         ));
 
@@ -106,7 +112,6 @@ class UAS
             'HEADERS' => array(
                 'Content-type: application/json',
                 'Accept: application/json',
-                'Cookie: JSESSIONID='.$this->session,
             ),
         ));
 
@@ -120,6 +125,8 @@ class UAS
 
 
     function _curl($options) {
+        if ($this->uas_auth == 'CAS') $options['HEADERS'][] = 'Cookie: JSESSIONID=' . $this->session;
+
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $options['URL']);
         curl_setopt($ch, CURLOPT_HEADER, array_key_exists('HEADER', $options) ? 1 : 0);
@@ -130,6 +137,16 @@ class UAS
         if (array_key_exists('FIELDS', $options)) curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($options['FIELDS']));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+
+        if (
+            ($this->uas_auth == 'BASIC') &&
+            (strlen($this->user) != 0) &&
+            (strlen($this->pass) != 0)
+        ) {
+            curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+            curl_setopt($ch, CURLOPT_USERNAME, $this->user);
+            curl_setopt($ch, CURLOPT_PASSWORD, $this->pass);
+        }
 
         // if (array_key_exists('FIELDS', $options)) print_r(array('body', json_encode($options['FIELDS'])));
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2023](https://jira.diamond.ac.uk/browse/LIMS-2023)

**Summary**:
Enable SynchWeb to create, update, and close UDC sessions via UAS API using Basic Auth credentials rather than CAS token.

**Changes**:
- Added configuration variable `uas_auth` to specify CAS or BASIC authentication to UAS.
- Added configuration variables `mxautocollect_srv_acc_username` and `mxautocollect_srv_acc_password` for MX UDC service account in UAS. Added credentials to Ansible vault `vault-uas-mxautocollect-srv-acc-prod.yml`.
- When `uas_auth` is CAS, authenticate with CAS and append JSESSION token as cookie to UAS requests.
- When `uas_auth` is BASIC, set Curl option `CURLOPT_HTTPAUTH` to `CURLAUTH_BASIC` and specify `CURLOPT_USERNAME` and `CURLOPT_PASSWORD`.

**To test**:
- Create shipment, add dewar, puck, and sample via SynchWeb. Assuming IP address is permitted, use Curl to create and close a UDC session in UAS with reference to puck's container id:
`curl -X "GET" "https://ispyb.diamond.ac.uk/api/proposal/auto?CONTAINERID=123456&bl=i03" -H 'Accept: application/json'`
`curl -X "DELETE" "https://ispyb.diamond.ac.uk/api/proposal/auto?CONTAINERID=123456" -H 'Accept: application/json'`