### PR TITLE
LIMS-2139: Dont display special beam as beam dumps

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -75,6 +75,9 @@
 
     # URL to access the PV archiver
     $archive_url = '';
+    # PV to check for beam / no beam, and values that correspond to beam
+    $beam_mode_pv = 'CS-CS-MSTAT-01:MODE';
+    $beam_mode_pv_beam_on_values = array(4, 5);
 
     # URL to access elog logbook
     $elog_base_url = '';

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -935,7 +935,7 @@ class Page
             {
                 $vs = $vals[$i];
                 $v = $vs->val;
-                $t = $vs->secs - 3600;
+                $t = $vs->secs;
                 $inputTZ = new \DateTimeZone($timezone);
                 $transitions = $inputTZ->getTransitions($t, $t);
                 if ($transitions[0]['isdst'])

--- a/api/src/Page/Vstat.php
+++ b/api/src/Page/Vstat.php
@@ -52,6 +52,7 @@ class Vstat extends Page
     function _visit_breakdown()
     {
         ini_set('memory_limit', '512M');
+        global $beam_mode_pv, $beam_mode_pv_beam_on_values;
 
         if ($this->has_arg('visit')) {
             $info = $this->_check_visit();
@@ -341,36 +342,35 @@ class Vstat extends Page
         }
 
         // Beam status 
-        $bs = $this->_get_archive('CS-CS-MSTAT-01:MODE', strtotime($info['ST']), strtotime($info['EN']));
+        $bs = $this->_get_archive($beam_mode_pv, strtotime($info['ST']), strtotime($info['EN']));
 
 
         $lastv = 0;
-        $ex = 3600 * 1000;
         $st = $this->jst($info['ST']);
 
         foreach ($bs as $i => $b) {
-            $v = $b[1] != 4;
-            $c = $b[0] * 1000;
+            $v = !in_array($b[1], $beam_mode_pv_beam_on_values);
+            $c = max($b[0] * 1000, $st);
 
-            if (($v != $lastv) && $v) {
-                $st = $c;
+            if ($v != $lastv) {
+                if ($v) {
+                    $st = $c;
+                } else {
+                    array_push($data, array('data' => array(
+                        array($st, 5, $st),
+                        array($c, 5, $st)
+                    ), 'color' => 'black', 'status' => ' Beam Dump', 'type' => 'nobeam'));
+                }
+
+                $lastv = $v;
             }
-
-            if ($lastv && ($v != $lastv)) {
-                array_push($data, array('data' => array(
-                    array($st + $ex, 5, $st + $ex),
-                    array($c + $ex, 5, $st + $ex)
-                ), 'color' => 'black', 'status' => ' Beam Dump', 'type' => 'nobeam'));
-            }
-
-            $lastv = $v;
         }
 
         // in case visit ends with no beam
-        if ($lastv && $this->jst($info['EN']) > $st + $ex) {
+        if ($lastv && $this->jst($info['EN']) > $st) {
             array_push($data, array('data' => array(
-                array($st + $ex, 5, $st + $ex),
-                array($this->jst($info['EN']), 5, $st + $ex)
+                array($st, 5, $st),
+                array($this->jst($info['EN']), 5, $st)
             ), 'color' => 'black', 'status' => ' Beam Dump', 'type' => 'nobeam'));
         }
 
@@ -396,6 +396,7 @@ class Vstat extends Page
 
     function _pies()
     {
+        global $beam_mode_pv, $beam_mode_pv_beam_on_values;
         $args = array($this->proposalid);
         $where = ' WHERE p.proposalid=:1';
 
@@ -484,30 +485,28 @@ class Vstat extends Page
                 $d['FAULT'] = 0;
 
             // Beam status
-            $bs = $this->_get_archive('CS-CS-MSTAT-01:MODE', strtotime($d['ST']), strtotime($d['EN']));
+            $bs = $this->_get_archive($beam_mode_pv, strtotime($d['ST']), strtotime($d['EN']));
 
             $lastv = 0;
-            $ex = 3600 * 1000;
             $st = $this->jst($d['ST']);
             $total_no_beam = 0;
             foreach ($bs as $i => $b) {
-                $v = $b[1] != 4;
-                $c = $b[0] * 1000;
+                $v = !in_array($b[1], $beam_mode_pv_beam_on_values);
+                $c = max($b[0] * 1000, $st);
 
-                if (($v != $lastv) && $v) {
-                    $st = $c;
+                if ($v != $lastv) {
+                    if ($v) {
+                        $st = $c;
+                    } else {
+                        $total_no_beam += ($c - $st) / 1000;
+                    }
+                    $lastv = $v;
                 }
-
-                if ($lastv && ($v != $lastv)) {
-                    $total_no_beam += ($c - $st) / 1000;
-                }
-
-                $lastv = $v;
             }
 
             // in case visit ends with no beam
-            if ($lastv && $this->jst($d['EN']) > ($ex + $st)) {
-                $total_no_beam += ($this->jst($d['EN']) - ($ex + $st)) / 1000;
+            if ($lastv && $this->jst($d['EN']) > $st) {
+                $total_no_beam += ($this->jst($d['EN']) - $st) / 1000;
             }
 
             $d['NOBEAM'] = $total_no_beam / 3600;
@@ -725,7 +724,7 @@ class Vstat extends Page
         {
             if ($type['name'] == $bl)
             {
-                $logbook = $type['logbook'];
+                $logbook = $type['logbook'] ?? null;
                 break;
             }
         }


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2139](https://jira.diamond.ac.uk/browse/LIMS-2139)

**Summary**:

If the Synchrotron is in "Special Beam" mode, the visit stats page shouldn't record that as a beam dump, as it is usable beam. See eg https://ispyb.diamond.ac.uk/stats/visit/mx41044-27

**Changes**:
- Move the name of the beam mode PV into config
- Also put the "beam on" PV values into the config
- Remove arbitrary 3600 seconds offset removed in one file and re-added in another
- Use the start of the beam dump or the start of the visit, whichever is later, as users should not care about the time before their visit
- Tidy some of the loop logic to make the workings clearer
- Fix bug where beamlines without a defined elog logbook would throw an error

**To test**:
- Add these to the config
```
    $beam_mode_pv = 'CS-CS-MSTAT-01:MODE';
    $beam_mode_pv_beam_on_values = array(4, 5);
```
- Go to the visit stats for a page with lots of special beam time, eg /stats/visit/mx41044-27. Check there are no beam dumps shown in the visit breakdown or the pie chart
- Go to the visit stats page of a visit that has a beam dump, eg /stats/visit/in37773-44. Check the beam dump lasts 2.3 hours
- Go to the visit stats page for a visit that started during a beam dump, eg /stats/visit/mx41137-28. Check the beam dump starts when the visit starts at 14:56, finishes at 09:00, and the beam dump duration is therefore 18.1 hours.
- Go to the visit stats page for a visit that ended during a beam dump, eg /stats/visit/mx40148-41. Check the beam dump starts correctly at 9am March 13th, and runs until the vist ends at 14:43 March 14th, and thus displays as 29.7hrs (32 hours total)
- Go to the visit stats page for a visit during BST, eg /stats/visit/mx40148-20. Check the beam dump starts from 9am.
- Go to the visit stats page for an i02-1 visit eg /stats/visit/mx41137-28. Check no errors occur from the fact that i02-1 has no logbook defined in  `$bl_types`