### PR TITLE
LIMS-2135: Update PHP Libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup PHP 7.3
+      - name: Setup PHP 7.4
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
-          tools: psalm:4
+          php-version: 7.4
+          tools: psalm:5
           # Added extensions and coverage here so they are ready for the native run
-          extensions: mysqli, zip, xdebug
+          extensions: mysqli, zip, xdebug, bcmath
           coverage: xdebug
 
       - name: Validate composer.json and composer.lock
@@ -59,7 +59,7 @@ jobs:
           XDEBUG_MODE: coverage
 
       - name: Run Psalm
-        run: psalm --output-format=github
+        run: vendor/bin/psalm --output-format=github
 
   js_build:
     name: JavaScript build, test and lint

--- a/api/composer.json
+++ b/api/composer.json
@@ -15,19 +15,18 @@
   ],
   "require": {
     "apereo/phpcas": "1.6.1",
-    "ezyang/htmlpurifier": "4.12.0",
+    "ezyang/htmlpurifier": "^4.12.0",
     "firebase/php-jwt": "^6.0.0",
-    "jdorn/sql-formatter": "1.2.9",
-    "mpdf/mpdf": "8.1.2",
-    "ralouphie/getallheaders": "2.0.5",
-    "slim/slim": "2.6.2",
-    "php-amqplib/php-amqplib": "^2.0",
+    "jdorn/sql-formatter": "^1.2.9",
+    "mpdf/mpdf": "^8.1.2",
+    "slim/slim": "^2.6.2",
+    "php-amqplib/php-amqplib": "^3.0",
     "symfony/http-foundation": "^5.4",
     "symfony/filesystem": "^5.4",
     "mpdf/qrcode": "^1.2",
     "mtcmedia/dhl-api": "dev-master#9b4b6315",
-    "maennchen/zipstream-php": "2.1.0",
-    "phpseclib/bcmath_compat": "^2.0"
+    "maennchen/zipstream-php": "^2.1.0",
+    "ext-bcmath": "*"
   },
   "autoload": {
     "psr-4": {
@@ -39,11 +38,11 @@
     "phpunit/phpunit": "^9",
     "php-mock/php-mock-phpunit": "^2.6",
     "mockery/mockery": "^1.5",
-    "vimeo/psalm": "^4.27"
+    "vimeo/psalm": "^5.0"
   },
   "config": {
     "platform": {
-      "php": "7.3"
+      "php": "7.4.33"
     },
     "audit": {
       "ignore": ["PKSA-y2cr-5h3j-g3ys"]

--- a/api/psalm.xml
+++ b/api/psalm.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="7"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -268,7 +268,7 @@ class AuthenticationController
     {
         global $jwt_key;
 
-        $headers = getallheaders();
+        $headers = \getallheaders();
         $auth_header = '';
         if (array_key_exists('Authorization', $headers))
         {

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -281,7 +281,7 @@ class AuthenticationController
 
             try
             {
-                $token = JWT::decode($jwt, new Key($jwt_key, 'HS512'), array('HS512'));
+                $token = JWT::decode($jwt, new Key($jwt_key, 'HS512'));
                 $this->loginId = $token->data->login;
             }
             catch (\Exception $e)

--- a/api/src/Page.php
+++ b/api/src/Page.php
@@ -966,7 +966,7 @@ class Page
         if (array_key_exists('HEADERS', $options)) {
             curl_setopt($ch, CURLOPT_HTTPHEADER, $options['HEADERS']);
         }
-        $headers = getallheaders();
+        $headers = \getallheaders();
         if (array_key_exists('Authorization', $headers) && array_key_exists('jwt', $options))
         {
             curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: ' . $headers['Authorization']));

--- a/api/tests/Controllers/AssignControllerTest.php
+++ b/api/tests/Controllers/AssignControllerTest.php
@@ -87,7 +87,9 @@ final class AssignControllerTest extends TestCase
         $this->assignController->args['visit'] = 3;
         $this->assignController->args['cid'] = 4;
         $this->assignController->args['pos'] = 5;
-        $this->dataLayerStub->expects($this->exactly(1))->method('getContainer')->with(3, 4)->willReturn(array(1,2,3));
+        $this->dataLayerStub->expects($this->exactly(1))->method('getContainer')->with(3, 4)->willReturn(array(
+            array('DEWARID' => 1, 'BEAMLINENAME' => 'p45', 'CONTAINERID' => 4, 'CODE' => 'ABC-001'),
+        ));
         $this->dataLayerStub->expects($this->exactly(1))->method('assignContainer')->with(1, 5);
 
         $this->assignController->assignContainer();
@@ -112,7 +114,9 @@ final class AssignControllerTest extends TestCase
         $this->assignController->args['visit'] = 3;
         $this->assignController->args['cid'] = 4;
         $this->assignController->args['pos'] = 5;
-        $this->dataLayerStub->expects($this->exactly(1))->method('getContainer')->with(3, 4)->willReturn(array(1,2,3));
+        $this->dataLayerStub->expects($this->exactly(1))->method('getContainer')->with(3, 4)->willReturn(array(
+            array('DEWARID' => 1, 'BEAMLINENAME' => 'p45', 'CONTAINERID' => 4, 'CODE' => 'ABC-001'),
+        ));
         $this->dataLayerStub->expects($this->exactly(1))->method('unassignContainer')->with(1);
 
         $this->assignController->unassignContainer();

--- a/api/tests/Controllers/AssignControllerTest.php
+++ b/api/tests/Controllers/AssignControllerTest.php
@@ -81,6 +81,7 @@ final class AssignControllerTest extends TestCase
         $this->assignController->assignContainer();
         $this->assertEquals(0, $response->getBody());
     }
+
     public function testAssignContainerReturnsOneWhenContainerFound(): void
     {
         $response = $this->setUpCommonResponse();
@@ -90,7 +91,7 @@ final class AssignControllerTest extends TestCase
         $this->dataLayerStub->expects($this->exactly(1))->method('getContainer')->with(3, 4)->willReturn(array(
             array('DEWARID' => 1, 'BEAMLINENAME' => 'p45', 'CONTAINERID' => 4, 'CODE' => 'ABC-001'),
         ));
-        $this->dataLayerStub->expects($this->exactly(1))->method('assignContainer')->with(1, 5);
+        $this->dataLayerStub->expects($this->exactly(1))->method('assignContainer')->with($this->isType('array'), 5);
 
         $this->assignController->assignContainer();
         $this->assertEquals(1, $response->getBody());
@@ -108,6 +109,7 @@ final class AssignControllerTest extends TestCase
         $this->assignController->unassignContainer();
         $this->assertEquals(0, $response->getBody());
     }
+
     public function testUnassignContainerReturnsOneWhenContainerFound(): void
     {
         $response = $this->setUpCommonResponse();
@@ -117,7 +119,7 @@ final class AssignControllerTest extends TestCase
         $this->dataLayerStub->expects($this->exactly(1))->method('getContainer')->with(3, 4)->willReturn(array(
             array('DEWARID' => 1, 'BEAMLINENAME' => 'p45', 'CONTAINERID' => 4, 'CODE' => 'ABC-001'),
         ));
-        $this->dataLayerStub->expects($this->exactly(1))->method('unassignContainer')->with(1);
+        $this->dataLayerStub->expects($this->exactly(1))->method('unassignContainer')->with($this->isType('array'));
 
         $this->assignController->unassignContainer();
         $this->assertEquals(1, $response->getBody());

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+// 1. The Polyfill for CI/CLI environments
+if (!function_exists('getallheaders')) {
+    function getallheaders() {
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $name = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))));
+                $headers[$name] = $value;
+            }
+        }
+        return $headers;
+    }
+}
+
+// 2. Ensure your Composer autoloader is still loaded
+// Since we are in /tests, we go up one level to /api/vendor
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/api/tests/phpunit.xml
+++ b/api/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+<phpunit bootstrap="bootstrap.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
 	<coverage>
 		<include>
 			<directory suffix=".php">../src</directory>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2135](https://jira.diamond.ac.uk/browse/LIMS-2135)

**Summary**:

Various PHP libraries can be updated

**Changes**:
- Tell Composer we are using PHP 7.4.33 which is on production
- Remove the getallheaders polyfill, and then add a bootstrapped version for CI testing
- Remove the bcmath polyfill, but enforce the native library instead
- Increment the major version of php-amqplib and psalm
- Allow minor updates on htmlpurifier, sql-formatter, mpdf, slim, and zipstream-php
- Change how JWTs are decoded in php-jwt 6 with PHP 7.4.33
- Fix some tests that now fail as PHP 7.4 is tougher on TypeErrors

**Not done**:
- No change to phpcas as that may be removed soon
- No major update to slim as that would require large changes

**To test**:
- Use the production database, and retrigger a processing job, to check the php-amqplib update
- Open a shipment and click "Print Shipment Labels" to check the mpdf update
- Run `./vendor/bin/psalm` within the container, check no errors occur
