### PR TITLE
LIMS-2126: Add new strategy pipeline and tidy code

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1286,7 +1286,7 @@ class DC extends Page
                 dc.imageprefix as imp, dc.comments as dcc, dc.blsampleid as sid,
                 sl.spacegroup as sg, sl.unitcell_a as a, sl.unitcell_b as b, sl.unitcell_c as c, sl.unitcell_alpha as al, sl.unitcell_beta as be, sl.unitcell_gamma as ga,
                 det.numberofpixelsx, det.detectorpixelsizehorizontal,
-                CONCAT(IF(sssw.comments, sssw.comments, IF(ssw.comments, ssw.comments, s.shortcomments)), ' Wedge', IFNULL(ssw.wedgenumber, '')) as com
+                CONCAT(IF(sssw.comments is not null, sssw.comments, IF(ssw.comments is not null, ssw.comments, s.shortcomments)), ' Wedge ', IFNULL(ssw.wedgenumber, '')) as com
                 FROM screeningstrategy st 
                 INNER JOIN screeningoutput so on st.screeningoutputid = so.screeningoutputid 
                 INNER JOIN screening s on so.screeningid = s.screeningid 
@@ -1296,142 +1296,42 @@ class DC extends Page
                 INNER JOIN datacollection dc on s.datacollectionid = dc.datacollectionid
                 LEFT OUTER JOIN detector det ON dc.detectorid = det.detectorid
                 WHERE s.datacollectionid = :1 
-                ORDER BY s.shortcomments, ssw.wedgenumber", array($id));
+                ORDER BY s.screeningid, com, ssw.wedgenumber", array($id));
 
-
+        $nf = array(1 => array('TRAN', 'ATRAN'), 2 => array('A', 'B', 'C', 'AL', 'BE', 'GA', 'OSCRAN', 'RES', 'RANKRES'), 4 => array('TIME'));
         $output = array();
-        foreach ($rows as $r) {
-            if (!array_key_exists($r['PROGRAMVERSION'], $output))
-                $output[$r['PROGRAMVERSION']] = array('CELL' => array(), 'STRATS' => array());
-        }
-
-        $nf = array('A', 'B', 'C', 'AL', 'BE', 'GA');
         foreach ($rows as &$r) {
+            $t = $r['PROGRAMVERSION'];
+            if (!array_key_exists($t, $output))
+                $output[$t] = array('CELL' => array(), 'STRATS' => array());
+
+            $r['ATRAN'] = $r['TRAN'] / 100.0 * $r['DCTRN'];
+            foreach ($nf as $nff => $cols) {
+                foreach ($cols as $c) {
+                    $r[$c] = number_format($r[$c], $nff);
+                }
+            }
+
             $is_align = false;
             foreach ($strat_align as $sa) {
                 if (!$is_align)
-                    $is_align = strpos($r['PROGRAMVERSION'], $sa) !== false;
+                    $is_align = strpos($t, $sa) !== false;
             }
 
-            if ($is_align) {
+            if (!$is_align) {
                 foreach ($r as $k => &$v) {
-                    if (in_array($k, $nf)) {
-                        $v = number_format(floatval($v), 2);
-                    }
-                }
-                array_push($output[$r['PROGRAMVERSION']]['STRATS'], $r);
-            } else {
-
-                $t = $r['PROGRAMVERSION'];
-
-                foreach ($r as $k => &$v) {
-                    if (in_array($k, $nf)) {
-                        $v = number_format(floatval($v), 2);
+                    if (in_array($k, array('SG', 'A', 'B', 'C', 'AL', 'BE', 'GA'))) {
                         $output[$t]['CELL'][$k] = $v;
                         unset($r[$k]);
                     }
-
-                    if ($k == 'TRAN')
-                        $v = number_format($v, 1);
-                    if ($k == 'TIME')
-                        $v = number_format($v, 3);
-                    if ($k == 'OSCRAN')
-                        $v = number_format($v, 2);
-                    if ($k == 'RES')
-                        $v = number_format($v, 2);
-                    if ($k == 'RANKRES')
-                        $v = number_format($v, 2);
                 }
-
-                $output[$t]['CELL']['SG'] = $r['SG'];
-                unset($r['SG']);
-
-                $r['COM'] = str_replace('EDNA', '', $r['COM']);
-                $r['COM'] = str_replace('Mosflm ', '', $r['COM']);
-
-                $r['VPATH'] = join('/', array_slice(explode('/', $r['IMD']), 0, 6));
-                list(,, $r['BL']) = explode('/', $r['IMD']);
-
-                # we dont actually use this in the display view maybe Deprecate?
-                # detector diameter in mm
-                if ($r['DETECTORPIXELSIZEHORIZONTAL'] && $r['NUMBEROFPIXELSX']) {
-                    $diam = $r['DETECTORPIXELSIZEHORIZONTAL'] * $r['NUMBEROFPIXELSX'] * 1000;
-                } else {
-                    // drop back to pilatus 6m diameter
-                    $diam = 415;
-                }
-
-                $r['DIST'] = $this->_r_to_dist($diam, $r['LAM'], $r['RES']);
-                $r['ATRAN'] = round($r['TRAN'] / 100.0 * $r['DCTRN'], 1);
-                list($r['NTRAN'], $r['NEXP']) = $this->_norm_et($r['ATRAN'], $r['TIME']);
-                $r['AP'] = $this->_get_ap($r['DCC']);
-
-                array_push($output[$t]['STRATS'], $r);
             }
+
+            array_push($output[$t]['STRATS'], $r);
         }
 
         $this->_output(array(sizeof($rows), $output));
     }
-
-    # ------------------------------------------------------------------------        
-    # Normalise transmission fo 25hz data collection
-    function _norm_et($t, $e)
-    {
-        if ($t < 100 && $e > 0.04) {
-            $f = $e / 0.04;
-            $maxe = 0.04;
-            $maxt = ($e / 0.04) * $t;
-
-            if ($maxt > 100) {
-                $maxe *= $maxt / 100;
-                $maxt = 100;
-            }
-            return array(number_format($maxt, 1), number_format($maxe, 3));
-        } else {
-            return array($t, $e);
-        }
-    }
-
-    # ------------------------------------------------------------------------        
-    # Convert resolution to detector distance
-    function _r_to_dist($diam, $lambda, $r)
-    {
-        $result = 0;
-        try {
-            $b = $lambda / (2 * $r);
-            $d = 2 * asin($b);
-            $f = 2 * tan($d);
-            $result = number_format($diam / $f, 2);
-        } catch (\Exception $e) {
-            error_log('Error converting resolution to distance, lambda=' . $lambda . ' r=' . $r . ' Exception: ' . $e->getMessage());
-        }
-        return $result;
-    }
-
-    # ------------------------------------------------------------------------        
-    # Work out which aperture is selected
-    function _get_ap($com)
-    {
-        $aps = array(
-            'Aperture: Large' => 'LARGE_APERTURE',
-            'Aperture: Medium' => 'MEDIUM_APERTURE',
-            'Aperture: Small' => 'SMALL_APERTURE',
-            'Aperture: 10' => 'In_10',
-            'Aperture: 20' => 'In_20',
-            'Aperture: 30' => 'In_30',
-            'Aperture: 50' => 'In_50',
-            'Aperture: 70' => 'In_70'
-        );
-
-        $app = '';
-        foreach ($aps as $k => $v) {
-            if (strpos($com, $k) !== False)
-                $app = $v;
-        }
-
-        return $app;
-    }
-
 
     # ------------------------------------------------------------------------
     # Image quality indicators from distl

--- a/client/src/js/templates/dc/dc_strategy.html
+++ b/client/src/js/templates/dc/dc_strategy.html
@@ -1,5 +1,29 @@
 
 <h2><%-TYPE%></h2>
+
+<%
+    var showUnitCell = CELL && (CELL.SG || CELL.A || CELL.B || CELL.C || CELL.AL || CELL.BE || CELL.GA)
+    var showChi = _.some(STRATS, function(r) {
+        return r.CHI && parseFloat(r.CHI) !== 0
+    })
+    var showPhi = _.some(STRATS, function(r) {
+        return r.PHI && parseFloat(r.PHI) !== 0
+    })
+    var showKappa = _.some(STRATS, function(r) {
+        return r.KAPPA && parseFloat(r.KAPPA) !== 0
+    })
+    var showRankingRes = _.some(STRATS, function(r) {
+        return r.RANKRES && parseFloat(r.RANKRES) !== 0
+    })
+
+    var displayAxis = "Axis"
+    if (STRATS && STRATS.length > 0 && STRATS[0].ROTATIONAXIS) {
+        var raw = STRATS[0].ROTATIONAXIS
+        displayAxis = raw.charAt(0).toUpperCase() + raw.slice(1)
+    }
+%>
+
+<% if (showUnitCell) { %>
 <p class="r">
     <a class="view button" title="Lookup Unit Cell" href="/cell/a/<%-CELL.A%>/b/<%-CELL.B%>/c/<%-CELL.C%>/al/<%-CELL.AL%>/be/<%-CELL.BE%>/ga/<%-CELL.GA%>"><i class="fa fa-search"></i> Lookup Cell</a>
 </p>
@@ -28,18 +52,20 @@
         </tr>
     </tbody>
 </table>
-
+<% } %>
 
 <table class="reflow strat">
     <thead>
         <tr class="stratrow">
             <th>Strategy</th>
             <th>Description</th>
-            <th>Axis</th>
-            <th>Axis Start</th>
-            <th>Axis Osc</th>
+            <th><%- displayAxis %> Start (°)</th>
+            <th><%- displayAxis %> Osc (°)</th>
+            <% if (showChi) { %> <th>Chi (°)</th> <% } %>
+            <% if (showPhi) { %> <th>Phi (°)</th> <% } %>
+            <% if (showKappa) { %> <th>Kappa (°)</th> <% } %>
             <th>Res (&#197;)</th>
-            <th>Ranking Res (&#197;)</th>
+            <% if (showRankingRes) { %> <th>Ranking Res (&#197;)</th> <% } %>
             <th>Rel Trn (%)</th>
             <th>Abs Trn (%)</th>
             <th>Exposure (s)</th>
@@ -51,11 +77,13 @@
     <tr class="stratrow" draggable="true" sid="<%-i%>">
         <td><%-r.COM%></td>
         <td><%-r.COMMENTS%></td>
-        <td><%-r.ROTATIONAXIS%></td>
         <td><%-r.ST%></td>
         <td><%-r.OSCRAN%></td>
+        <% if (showChi) { %> <td><%-r.CHI%></td> <% } %>
+        <% if (showPhi) { %> <td><%-r.PHI%></td> <% } %>
+        <% if (showKappa) { %> <td><%-r.KAPPA%></td> <% } %>
         <td><%-r.RES%></td>
-        <td><%-r.RANKRES%></td>
+        <% if (showRankingRes) { %> <td><%-r.RANKRES%></td> <% } %>
         <td><%-r.TRAN%></td>
         <td><%-r.ATRAN%></td>
         <td><%-r.TIME%></td>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2126](https://jira.diamond.ac.uk/browse/LIMS-2126)

**Summary**:

Phil is adding a new strategy pipeline ("UDC Strategy"), we should display the results appropriately. Also the strategy fetching code can be optimised as lots is not used.

**Changes**:
- Fix the getting of the pipeline description, as in MariaDB `if("string")` returns false
- Order screening results by the order they are put into the db
- Use consistent notation to control the number format of the fields
- Remove various fields that were set but never used, and the functions used to set them
- On the front end, only display the unit cell if some of it is set
- Only show chi/phi/kappa/ranking res columns if the are set

**To test**:
- Set in the config
```
$strat_align = array('XOalign', 'dials.align_crystal', 'xia2-dials+dials.align_crystal', 'UDC strategy');
```
- Go to /dc/visit/mx23694-154/id/21392025, check a UDC strategy appears in the strategies bar, and the omega and chi angles are shown. (The relative transmission is set wrong in the db so the absolute transmission is displayed as 0)
- Check the alignment strategies show the chi and phi angles and the unit cell (but no omega or transmission etc)
- Go to a data collection with mosflm strategy results (eg /dc/visit/cm44138-1/id/21135234), check Mosflm shows both the unit cell and the data collection parameters
- Find an old data collection with EDNA strategy results (eg /dc/visit/cm19645-4/id/2983769), check EDNA shows both the unit cell and the data collection parameters)
