### PR TITLE
Display message for null FedIDs

### DIFF
--- a/api/src/Authentication/Type/OIDC.php
+++ b/api/src/Authentication/Type/OIDC.php
@@ -132,8 +132,13 @@ class OIDC extends AuthenticationParent implements AuthenticationInterface
             'samesite' => 'Strict'
         );
 
-        setcookie($cookie_key, $token, $cookieOpts);
-        return $this->getUser($token);
+        $user = $this->getUser($token);
+
+        if ($user) {
+            setcookie($cookie_key, $token, $cookieOpts);
+        }
+
+        return $user;
     }
 
     function logout()

--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -84,6 +84,8 @@ class AuthenticationController
             {
                 $this->returnResponse(200, $this->generateJwtToken($userId));
             }
+        } else if ($userId === null) {
+            $this->returnError(403, 'User not recognised');
         }
         $this->returnError(400, 'No previous session');
     }
@@ -358,7 +360,7 @@ class AuthenticationController
 
         if ($cas_sso) {
             header('Location: ' . $this->authenticateByType()->authorise());
-            $this->returnResponse(302, array('status' => "Redirecting to CAS"));
+            $this->returnResponse(302, array('status' => "Redirecting to provider"));
         } else {
             $this->returnError(501, "SSO not configured");
         }
@@ -379,7 +381,7 @@ class AuthenticationController
             }
             $this->returnResponse(200, $this->generateJwtToken($fedid));
         } else {
-            $this->returnError(401, 'Invalid Credentials');
+            $this->returnError(403, 'User not recognised');
         }
     }
 

--- a/api/tests/Controllers/AuthenticationControllerTest.php
+++ b/api/tests/Controllers/AuthenticationControllerTest.php
@@ -159,7 +159,7 @@ final class AuthenticationControllerTest extends TestCase
         });
 
         $this->assertContains('Content-Type: application/json', Output::$headers);
-        $this->assertContains('X-PHP-Response-Code: 401', Output::$headers);
+        $this->assertContains('X-PHP-Response-Code: 403', Output::$headers);
     }
 
     public function testCodeAuthenticationWhenGetValidFedIdReturnsSuccess(): void

--- a/client/src/js/app/store/modules/store.auth.js
+++ b/client/src/js/app/store/modules/store.auth.js
@@ -125,7 +125,7 @@ const auth = {
           },
           error: function(req, status, error) {
             commit('authError')
-            reject(error)
+            reject(req)
           }, 
           complete: function() {
             commit('loading', false, { root: true })

--- a/client/src/js/app/views/login.vue
+++ b/client/src/js/app/views/login.vue
@@ -199,7 +199,7 @@ export default {
             .dispatch("auth/getToken", token)
             .then(() => this.$router.push(actualRedirectUrl))
             .catch((e) => {
-              if (e === "Forbidden") {
+              if (e.status === 403) {
                 this.authError = "not-recognised";
               }
             });


### PR DESCRIPTION
**Summary**:

This displays a descriptive error message for those who logged in with an email and got a null FedID back (because they don't have FedIDs yet)

**Changes**:
- Display message for null FedIDs

**To test**:
- Log in with a test Keycloak user that has no FedID (or modify `getUser` in the authentication method you're using, so it always returns null)
- Check if a message asking you to log in with your FedID is displayed
- Repeat by logging with your FedID (if you modified `getUser`, undo your changes), check if you can log in as normal
