### PR TITLE
LIMS-2136: Fix editing priority processing pipeline

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -133,15 +133,17 @@
                 />
               </validation-provider>
             </li>
-            <li v-if="container.PIPELINE">
+            <li>
               <span class="label">Priority Processing</span>
               <base-input-select
-                v-model="container.PIPELINE"
-                name="PIPELINE"
+                v-model="container.PROCESSINGPIPELINEID"
+                :initial-text="container.PIPELINE ? container.PIPELINE : 'Click to edit'"
+                name="PROCESSINGPIPELINEID"
                 :options="processingPipelines"
-                option-value-key="PROCESSINGPIPELINEID"
                 :inline="true"
+                option-value-key="PROCESSINGPIPELINEID"
                 option-text-key="NAME"
+                @save="save('PROCESSINGPIPELINEID')"
               />
             </li>
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2136](https://jira.diamond.ac.uk/browse/LIMS-2136)

**Summary**:

At the moment you cannot edit the priority processing pipeline.

**Changes**:
- Display the priority pipeline even if not yet selected
- Use the pipeline id as the model for the dropdown, not the pipeline name

**To test**:
- Go to a puck with no priority pipeline set, eg /containers/cid/359802
- Check there is a field to set the priority pipeline, and it says "Click to Edit" initially
- Choose a pipeline, check a notification appears to say it has been successfully updated
- Refresh the page, check the chosen pipeline appears
- Edit again and check it remains after another refresh
