### PR TITLE
LIMS-2146: Always display all detectors

### DIFF
--- a/api/src/Page/Exp.php
+++ b/api/src/Page/Exp.php
@@ -141,7 +141,7 @@ class Exp extends Page
             array('/plans/detectors/:DATACOLLECTIONPLANHASDETECTORID', 'patch', '_dp_update_detector'),
             array('/plans/detectors/:DATACOLLECTIONPLANHASDETECTORID', 'delete', '_dp_remove_detector'),
 
-            array('/setup', 'get', '_get_beamline_setups'),
+            array('/setup(/:BEAMLINESETUPID)', 'get', '_get_beamline_setups'),
             array('/setup', 'post', '_add_beamline_setup'),
             array('/setup/:BEAMLINESETUPID', 'patch', '_update_beamline_setup'),
 
@@ -164,7 +164,7 @@ class Exp extends Page
             array_push($args, $this->arg('BEAMLINENAME'));
         }
 
-        $tot = $this->db->pq("SELECT count(d.detectorid) as tot
+        $tot = $this->db->pq("SELECT count(distinct d.detectorid) as tot
             FROM detector d
             LEFT OUTER JOIN beamlinesetup bls ON bls.detectorid = d.detectorid
             WHERE $where", $args);
@@ -177,10 +177,24 @@ class Exp extends Page
             'd.detectorid ASC'
         );
 
-        $rows = $this->db->paginate("SELECT d.detectorid, d.detectortype, d.detectormanufacturer, d.detectorserialnumber, d.sensorthickness, d.detectormodel, d.detectorpixelsizehorizontal, d.detectorpixelsizevertical, d.detectordistancemin, d.detectordistancemax, d.density, d.composition, concat(d.detectormanufacturer,' ',d.detectormodel, ' (',d.detectortype,')') as description, d.detectormaxresolution, d.detectorminresolution, count(distinct dc.datacollectionid) as dcs, count(distinct bls.beamlinesetupid) as blsetups, (SELECT count(distinct dphd.detectorid) FROM DataCollectionPlan_has_Detector dphd WHERE dphd.detectorid = d.detectorid) as dps, GROUP_CONCAT(distinct bls.beamlinename) as beamlines, d.numberofpixelsx, d.numberofpixelsy, d.detectorrollmin, d.detectorrollmax
+        $rows = $this->db->paginate("SELECT d.detectorid, d.detectortype, d.detectormanufacturer, d.detectorserialnumber, d.sensorthickness, d.detectormodel, d.detectorpixelsizehorizontal, d.detectorpixelsizevertical, d.detectordistancemin, d.detectordistancemax, d.density, d.composition, d.detectormaxresolution, d.detectorminresolution, d.numberofpixelsx, d.numberofpixelsy, d.detectorrollmin, d.detectorrollmax,
+            concat(d.detectormanufacturer,' ',d.detectormodel, ' (', ifnull(d.detectortype, ''), ')') as description,
+            count(distinct bls.beamlinesetupid) as blsetups,
+            GROUP_CONCAT(distinct bls.beamlinename) as beamlines,
+            COALESCE(datacollections.dcs, 0) as dcs,
+            COALESCE(datacollectionplans.dps, 0) as dps
             FROM detector d
-            LEFT OUTER JOIN datacollection dc ON dc.detectorid = d.detectorid
             LEFT OUTER JOIN beamlinesetup bls ON bls.detectorid = d.detectorid
+            LEFT JOIN (
+                SELECT detectorid, COUNT(datacollectionid) as dcs
+                FROM datacollection
+                GROUP BY detectorid
+            ) datacollections ON datacollections.detectorid = d.detectorid
+            LEFT JOIN (
+                SELECT detectorid, COUNT(DISTINCT detectorid) as dps
+                FROM DataCollectionPlan_has_Detector
+                GROUP BY detectorid
+            ) datacollectionplans ON datacollectionplans.detectorid = d.detectorid
             WHERE $where
             GROUP BY d.detectorid
             ORDER BY $order", $args);

--- a/client/src/js/collections/detectors.js
+++ b/client/src/js/collections/detectors.js
@@ -9,7 +9,7 @@ define(['backbone.paginator', 'models/detector', 'utils/kvcollection'], function
         valueAttribute: 'DETECTORID',
 
         state: {
-            pageSize: 5,
+            pageSize: 9999,
         },
 
         parseState: function(r, q, state, options) {

--- a/client/src/js/modules/imaging/views/admin/params.js
+++ b/client/src/js/modules/imaging/views/admin/params.js
@@ -180,6 +180,11 @@ define(['marionette',
 
 
     var DetectorsLimitsCellStatic = Backgrid.Cell.extend({
+        initialize: function(options) {
+            Backgrid.Cell.prototype.initialize.apply(this, arguments)
+            this.listenTo(this.model, 'sync change', this.render)
+        },
+
         render: function() {
             this.$el.empty()
             if (!this.model.isNew()) {
@@ -238,9 +243,17 @@ define(['marionette',
             console.log('model changed', arguments)
             // Changed Attributes are not being detected correctly.
             // Therefore we can crudely set all parameters to enforce a PATCH request
-            if (!m.isNew()) m.save(_.clone(m.attributes), { patch: true })
-        },
 
+            if (!m.isNew()) {
+                m.save(_.clone(m.attributes), {
+                    patch: true,
+                    wait: true,
+                    success: function() {
+                        m.fetch()
+                    }
+                });
+            }
+        },
 
 
         onRender: function() {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2146](https://jira.diamond.ac.uk/browse/LIMS-2146)

**Summary**:

The beamline setups page only displays 5 detectors by default, and this means you can only select form those 5 when editing a beamline setup.

**Changes**:
- Set the page size to 9999 to get all detectors by default (the only other place to get detectors is XPDF 'plans', where they specify a beamline name so will not have many detectors returned)
- Change the detectors query to use subqueries where possible, so it doesn't get too slow
- Add a listener to the detector 'limits' column, so if the detector is changed, they all change to match

**To test**:
- Open the Beamline Parameters page /admin/imaging/param
- Find a row in the first table that has a Beamline named in the first column
- Edit the detector, checking there are about 32 possible detectors, and each has a manufacturer and model (some have type in brackets)
- Check when you change the detector, the 'Limits' column to the right updates automatically
- Check the change persists after a page refresh
- Open a XPDF 'Plans' page eg /containers/plan/247898
- Check the query to list detectors still works ok
