### PR TITLE
LIMS-2152: Remove notifications on load of beamline status page

### DIFF
--- a/client/src/js/app/store/store.js
+++ b/client/src/js/app/store/store.js
@@ -285,8 +285,6 @@ const store = new Vuex.Store({
         url: app.apiurl + url,
         type: 'POST',
         data,
-        ...others,
-
         success: function(response) {
           commit('notifications/addNotification', {
             title: 'Action Successful',
@@ -306,6 +304,7 @@ const store = new Vuex.Store({
             root: true
           })
         },
+        ...others,
       })
     },
     // update data to the backend that is not attached to any model
@@ -315,8 +314,6 @@ const store = new Vuex.Store({
         url: app.apiurl + url,
         type,
         data,
-        ...others,
-
         success: function(response) {
           commit('notifications/addNotification', {
             title: 'Update Successful',
@@ -336,6 +333,7 @@ const store = new Vuex.Store({
             root: true
           })
         },
+        ...others,
       })
     },
     // delete data from the backend that is not attached to any model

--- a/client/src/js/modules/status/views/beamline-status-view.vue
+++ b/client/src/js/modules/status/views/beamline-status-view.vue
@@ -222,6 +222,7 @@ export default {
     fetchCamToken(data) {
       return this.$store.dispatch('saveDataToApi', {
         url: `/download/sign`,
+        success: (response) => response,
         data
       })
     },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2152](https://jira.diamond.ac.uk/browse/LIMS-2152)

**Summary**:

If you go to a visit and click "Beamline Status" to take you to eg /status/bl/i04, 2 or 3 notifications appear to say "Action Successful". We should silence these.

**Changes**:
- Change order of arguments to the store.js functions, so the success function can be overwritten
- Pass in a dummy function with no notification instead

**To test**:
- Go to any visit, click "Beamline Status", check no notifications appear.
