### PR TITLE
LIMS-1949: Use parentAutoProcProgramId field

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -439,6 +439,9 @@
         ),
     );
 
+    # Set the first AutoProcProgram row with parentAutoProcProgramId not null
+    #$max_appid_without_parent = 123456789;
+
 
     # Add a button to upload file to CCP4 cloud
     #$ccp4_cloud_upload_url = 'https://data.cloud.ccp4.ac.uk/api/data/<%=USERNAME%>/<%=FACILITYNAME%>/<%=IMAGEPREFIX%>_<%=DATACOLLECTIONNUMBER%>/upload';

--- a/api/src/Downstream/BigEPPhasing.php
+++ b/api/src/Downstream/BigEPPhasing.php
@@ -13,14 +13,10 @@ class BigEPPhasing extends DownstreamPlugin {
         $dat = array();
 
         if (array_key_exists('program_id', $this->process['PARAMETERS'])) {
-            $integrator = $this->_lookup_autoproc(
-                $this->process['PARAMETERS']['program_id']
-            );
-            if ($integrator) {
-                $dat['PARENTAUTOPROCPROGRAM'] =
-                    $integrator['PROCESSINGPROGRAMS'];
-                $dat['PARENTAUTOPROCPROGRAMID'] =
-                    $integrator['AUTOPROCPROGRAMID'];
+            $parent = $this->_lookup_parent_autoproc();
+            if ($parent) {
+                $dat['PARENTAUTOPROCPROGRAM'] = $parent['PROCESSINGPROGRAMS'];
+                $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
             }
         }
 

--- a/api/src/Downstream/DownstreamProcessing.php
+++ b/api/src/Downstream/DownstreamProcessing.php
@@ -181,28 +181,35 @@ abstract class DownstreamPlugin implements DownstreamPluginInterface {
         return array($plts, $stats);
     }
 
-    function _lookup_autoproc($aid, $scalingid = null) {
-        if ($aid) {
-            $where = 'app.autoprocprogramid=:1';
-            $args = array($aid);
-        }
-
-        if ($scalingid) {
-            $where = 'aps.autoprocscalingid=:1';
-            $args = array($scalingid);
-        }
-
+    function _lookup_autoproc_from_scalingid() {
         $app = $this->db->pq(
             "SELECT app.autoprocprogramid, app.processingprograms
             FROM autoprocscaling aps
             INNER JOIN autoproc ap ON ap.autoprocid = aps.autoprocid
             INNER JOIN autoprocprogram app ON app.autoprocprogramid = ap.autoprocprogramid
-            WHERE $where",
-            $args
+            WHERE aps.autoprocscalingid=:1",
+            array($this->process['PARAMETERS']['scaling_id'])
         );
 
         if (sizeof($app)) {
             return $app[0];
+        }
+    }
+
+    function _lookup_parent_autoproc() {
+        global $max_appid_without_parent;
+        $parent = $this->db->pq(
+            "SELECT app2.autoprocprogramid, app2.processingprograms
+            FROM autoprocprogram app
+            INNER JOIN autoprocprogram app2 ON app.parentautoprocprogramid = app2.autoprocprogramid
+            WHERE app.autoprocprogramid=:1",
+            array($this->autoprocprogramid)
+        );
+
+        if (sizeof($parent)) {
+            return $parent[0];
+        } else if (!$max_appid_without_parent || (int)$this->autoprocprogramid < $max_appid_without_parent) {
+            return $this->_lookup_autoproc_from_scalingid();
         }
     }
 

--- a/api/src/Downstream/Type/Dimple.php
+++ b/api/src/Downstream/Type/Dimple.php
@@ -69,13 +69,10 @@ class Dimple extends DownstreamPlugin {
         $dat['PLOTS'] = array();
         $dat['PKLIST'] = array();
 
-        $integrator = $this->_lookup_autoproc(
-            null,
-            $this->process['PARAMETERS']['scaling_id']
-        );
-        if ($integrator) {
-            $dat['PARENTAUTOPROCPROGRAM'] = $integrator['PROCESSINGPROGRAMS'];
-            $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+        $parent = $this->_lookup_parent_autoproc();
+        if ($parent) {
+            $dat['PARENTAUTOPROCPROGRAM'] = $parent['PROCESSINGPROGRAMS'];
+            $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
         }
 
         if (file_exists($lf)) {

--- a/api/src/Downstream/Type/FastEp.php
+++ b/api/src/Downstream/Type/FastEp.php
@@ -10,19 +10,18 @@ class FastEp extends DownstreamPlugin {
     var $has_mapmodel = array(1, 1);
 
     function results() {
+        global $max_appid_without_parent;
         $dat = array(
             'FOM' => 'sad.lst file not found',
             'CC' => 'sad.lst file not found',
             'ATOMS' => array(array('sad_fa.pdb file not found'))
         );
 
-        $integrator = $this->_lookup_autoproc(
-            null,
-            $this->process['PARAMETERS']['scaling_id']
-        );
-        if ($integrator) {
-            $dat['PARENTAUTOPROCPROGRAM'] = $integrator['PROCESSINGPROGRAMS'];
-            $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+        $parent = $this->_lookup_parent_autoproc();
+
+        if ($parent) {
+            $dat['PARENTAUTOPROCPROGRAM'] = $parent['PROCESSINGPROGRAMS'];
+            $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
         }
 
         $ats = array();

--- a/api/src/Downstream/Type/LigandFit.php
+++ b/api/src/Downstream/Type/LigandFit.php
@@ -57,13 +57,10 @@ class LigandFit extends DownstreamPlugin {
         $dat['SOLUTIONS'] = json_decode($json_data);
         $dat['PARENTAUTOPROCPROGRAM'] = $this->process['PROCESSINGCOMMENTS'];
         
-        $integrator = $this->_lookup_autoproc(
-            null,
-            $this->process['PARAMETERS']['scaling_id']
-        );
-        if ($integrator) {
-            $dat['PARENTAUTOPROCPROGRAM'] .= ' (' . $integrator['PROCESSINGPROGRAMS'] . ')';
-            $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+        $parent = $this->_lookup_parent_autoproc();
+        if ($parent) {
+            $dat['PARENTAUTOPROCPROGRAM'] .= ' (' . $parent['PROCESSINGPROGRAMS'] . ')';
+            $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
         }
 
         $results = new DownstreamResult($this);

--- a/api/src/Downstream/Type/MetalId.php
+++ b/api/src/Downstream/Type/MetalId.php
@@ -27,13 +27,10 @@ class MetalId extends DownstreamPlugin {
         $dat['BLOBS'] = sizeof($blobs);
         $dat['PEAKS'] = $peaks;
 
-        $integrator = $this->_lookup_autoproc(
-            null,
-            $this->process['PARAMETERS']['scaling_id']
-        );
-        if ($integrator) {
-            $dat['PARENTAUTOPROCPROGRAM'] = $integrator['PROCESSINGPROGRAMS'];
-            $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+        $parent = $this->_lookup_parent_autoproc();
+        if ($parent) {
+            $dat['PARENTAUTOPROCPROGRAM'] = $parent['PROCESSINGPROGRAMS'];
+            $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
         }
 
         $results = new DownstreamResult($this);

--- a/api/src/Downstream/Type/Mrbump.php
+++ b/api/src/Downstream/Type/Mrbump.php
@@ -17,15 +17,10 @@ class Mrbump extends DownstreamPlugin {
             if (file_exists($log["FILE"])) {
                 $dat = array();
 
-                $integrator = $this->_lookup_autoproc(
-                    null,
-                    $this->process['PARAMETERS']['scaling_id']
-                );
-                if ($integrator) {
-                    $dat['PARENTAUTOPROCPROGRAM'] =
-                        $integrator['PROCESSINGPROGRAMS'];
-                    $dat['PARENTAUTOPROCPROGRAMID'] =
-                        $integrator['AUTOPROCPROGRAMID'];
+                $parent = $this->_lookup_parent_autoproc();
+                if ($parent) {
+                    $dat['PARENTAUTOPROCPROGRAM'] = $parent['PROCESSINGPROGRAMS'];
+                    $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
                 }
 
                 list($plots, $stats) = $this->_parse_ccp4_log(

--- a/api/src/Downstream/Type/Shelxt.php
+++ b/api/src/Downstream/Type/Shelxt.php
@@ -56,13 +56,10 @@ class Shelxt extends DownstreamPlugin {
 
         // scaling_id should always be present, but just in case...
         if (array_key_exists('scaling_id', $this->process['PARAMETERS'])) {
-            $integrator = $this->_lookup_autoproc(
-                null,
-                $this->process['PARAMETERS']['scaling_id']
-            );
-            if ($integrator) {
-                $dat['PARENTAUTOPROCPROGRAM'] = $integrator['PROCESSINGPROGRAMS'];
-                $dat['PARENTAUTOPROCPROGRAMID'] = $integrator['AUTOPROCPROGRAMID'];
+            $parent = $this->_lookup_parent_autoproc();
+            if ($parent) {
+                $dat['PARENTAUTOPROCPROGRAM'] = $parent['PROCESSINGPROGRAMS'];
+                $dat['PARENTAUTOPROCPROGRAMID'] = $parent['AUTOPROCPROGRAMID'];
             }
         }
         $results = new DownstreamResult($this);


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1949](https://jira.diamond.ac.uk/browse/LIMS-1949)

**Summary**:

It is useful to be able to see a downstream processing job's upstream parent, but at the moment we use the "scaling_id" parameter in the ProcessingJobParameter table, which is a bit flaky. We now have an `AutoProcProgram.parentAutoProcProgramId` field, which is being populated from about 1st April 2026.

**Changes**:
- Re-route all calls to `_lookup_autoproc` to a new `_lookup_parent_autoproc` function, which uses the parentAutoProcProgramId field
- If no parent job is found, fall back to the old method, to avoid all pre-April 2026 jobs being broken
- Use a config variable to limit falling back to before a certain job, as from now on the parentAutoProcProgramId field should be populated
- Simplify the old method a little, Big EP was using the program_id instead of the scaling_id, but this seems not to be necessary

**To test**:
- Go to a recent data collection with lots of downstream processing jobs, eg /dc/visit/nt44198-3/id/22397399
- On each downstream job, click the "View Upstream" button, check it opens the Automatic Processing bar if needed and switches to the correct tab
- Go to an older data collection eg /dc/visit/nt44198-3/id/21167691, repeat the check
- Add the config variable with a low number eg
```
$max_appid_without_parent = 123;
```
- Repeat the check on the older data collection, it should stop working as you have now disallowed falling back to the old method
- Now set it to 119440000, and repeat the check on the older data collection, it should work again.