### PR TITLE
LIMS-2159: Allow CSV upload of ligands

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -2098,7 +2098,7 @@ class Sample extends Page
         $libbatch = $this->has_arg('LIBRARYBATCHNUMBER') ? $this->arg('LIBRARYBATCHNUMBER') : null;
         $barcode = $this->has_arg('PLATEBARCODE') ? $this->arg('PLATEBARCODE') : null;
 
-        $json = $this->request['json'];
+        $json = $this->request['json'] ?? null;
         if ($json && is_array($json)) {
 
             foreach ($json as $row) {

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -2113,7 +2113,7 @@ class Sample extends Page
             if (!$this->has_arg('NAME'))
                 $this->_error('No ligand name');
 
-            $smiles = $this->has_arg('SMILES') ? $this->arg('SMILES') : '';
+            $smiles = $this->has_arg('SMILES') ? $this->arg('SMILES') : null;
             $well = $this->has_arg('SOURCEWELL') ? $this->arg('SOURCEWELL') : null;
 
             array_push($ligs, array($this->proposalid, $this->arg('NAME'), $smiles, $libname, $libbatch, $barcode, $well));

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1966,15 +1966,19 @@ class Sample extends Page
             array_push($args, $this->arg('lid'));
         }
 
-        $tot = $this->db->pq("SELECT count(distinct l.ligandid) as tot FROM ligand l INNER JOIN proposal p ON p.proposalid = l.proposalid WHERE $where", $args);
-        $tot = intval($tot[0]['TOT']);
-
         if ($this->has_arg('s')) {
             $st = sizeof($args) + 1;
-            $where .= " AND l.name LIKE CONCAT('%',:" . $st . ", '%')";
-            array_push($args, $this->arg('s'));
+            $where .= " AND (
+                l.name LIKE CONCAT('%',:" . $st . ", '%')
+                OR l.libraryname LIKE CONCAT('%',:" . ($st + 1) . ", '%')
+                OR l.librarybatchnumber LIKE CONCAT('%',:" . ($st + 2) . ", '%')
+                OR l.platebarcode LIKE CONCAT('%',:" . ($st + 3) . ", '%')
+            )";
+            array_push($args, $this->arg('s'), $this->arg('s'), $this->arg('s'), $this->arg('s'));
         }
 
+        $tot = $this->db->pq("SELECT count(distinct l.ligandid) as tot FROM ligand l WHERE $where", $args);
+        $tot = intval($tot[0]['TOT']);
 
         $start = 0;
         $pp = $this->has_arg('per_page') ? $this->arg('per_page') : 15;
@@ -1990,12 +1994,18 @@ class Sample extends Page
         array_push($args, $end);
 
         $order = 'l.ligandid DESC';
-
         $group = 'l.ligandid';
 
         if ($this->has_arg('sort_by')) {
             $cols = array(
                 'NAME' => 'l.name',
+                'SMILES' => 'l.smiles',
+                'LIBRARYNAME' => 'l.libraryname',
+                'LIBRARYBATCHNUMBER' => 'l.librarybatchnumber',
+                'PLATEBARCODE' => 'l.platebarcode',
+                'SOURCEWELL' => 'l.sourcewell',
+                'SCOUNT' => 'scount',
+                'DCOUNT' => 'dcount',
             );
             $dir = $this->has_arg('order') ? ($this->arg('order') == 'asc' ? 'ASC' : 'DESC') : 'ASC';
             if (array_key_exists($this->arg('sort_by'), $cols))
@@ -2006,7 +2016,6 @@ class Sample extends Page
                                 COUNT(DISTINCT dc.datacollectionid) AS dcount,
                                 COUNT(DISTINCT b.blsampleid) AS scount
                                 FROM ligand l
-                                INNER JOIN proposal p ON p.proposalid = l.proposalid
                                 LEFT OUTER JOIN ligand_has_pdb lhp ON lhp.ligandid = l.ligandid
                                 LEFT OUTER JOIN blsample_has_ligand bhl ON bhl.ligandid = l.ligandid
                                 LEFT OUTER JOIN blsample b ON b.blsampleid = bhl.blsampleid
@@ -2081,29 +2090,51 @@ class Sample extends Page
     {
         if (!$this->has_arg('prop'))
             $this->_error('No proposal specified');
-        if (!$this->has_arg('NAME'))
-            $this->_error('No ligand name');
 
-        $smiles = $this->has_arg('SMILES') ? $this->arg('SMILES') : '';
+        $ligs = array();
+        $lids = array();
+
         $libname = $this->has_arg('LIBRARYNAME') ? $this->arg('LIBRARYNAME') : null;
         $libbatch = $this->has_arg('LIBRARYBATCHNUMBER') ? $this->arg('LIBRARYBATCHNUMBER') : null;
         $barcode = $this->has_arg('PLATEBARCODE') ? $this->arg('PLATEBARCODE') : null;
-        $well = $this->has_arg('SOURCEWELL') ? $this->arg('SOURCEWELL') : null;
 
-        $chk = $this->db->pq("SELECT name FROM ligand
-              WHERE proposalid=:1 AND name=:2", array($this->proposalid, $this->arg('NAME')));
-        if (sizeof($chk))
-            $this->_error('That ligand name already exists in this proposal');
+        $json = $this->request['json'];
+        if ($json && is_array($json)) {
 
-        $this->db->pq(
-            'INSERT INTO ligand (proposalid,name,smiles,libraryname,librarybatchnumber,platebarcode,sourcewell)
-              VALUES (:1,:2,:3,:4,:5,:6,:7) RETURNING ligandid INTO :id',
-            array($this->proposalid, $this->arg('NAME'), $smiles, $libname, $libbatch, $barcode, $well)
-        );
+            foreach ($json as $row) {
+                if (isset($row->NAME)) {
+                    $name = $row->NAME;
+                    $smiles = isset($row->SMILES) ? $row->SMILES : null;
+                    $well = isset($row->SOURCEWELL) ? $row->SOURCEWELL : null;
+                    array_push($ligs, array($this->proposalid, $name, $smiles, $libname, $libbatch, $barcode, $well));
+                }
+            }
+        } else {
+            if (!$this->has_arg('NAME'))
+                $this->_error('No ligand name');
 
-        $lid = $this->db->id();
+            $smiles = $this->has_arg('SMILES') ? $this->arg('SMILES') : '';
+            $well = $this->has_arg('SOURCEWELL') ? $this->arg('SOURCEWELL') : null;
 
-        $this->_output(array('LIGANDID' => $lid));
+            array_push($ligs, array($this->proposalid, $this->arg('NAME'), $smiles, $libname, $libbatch, $barcode, $well));
+
+            $chk = $this->db->pq("SELECT name FROM ligand
+                  WHERE proposalid=:1 AND name=:2", array($this->proposalid, $this->arg('NAME')));
+            if (sizeof($chk))
+                $this->_error('That ligand name already exists in this proposal');
+        }
+
+        foreach ($ligs as $lig) {
+            $this->db->pq(
+                'INSERT INTO ligand (proposalid,name,smiles,libraryname,librarybatchnumber,platebarcode,sourcewell)
+                VALUES (:1,:2,:3,:4,:5,:6,:7) RETURNING ligandid INTO :id',
+                $lig
+            );
+
+            array_push($lids, $this->db->id());
+        }
+
+        $this->_output(array('LIGANDIDS' => $lids));
     }
 
     # ------------------------------------------------------------------------

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,6 +34,7 @@
         "jquery.flot.tooltip": "^0.9.0",
         "lodash-es": "^4.17.21",
         "markdown": "^0.5.0",
+        "papaparse": "^5.4.1",
         "plotly.js": "^1.52.2",
         "portal-vue": "2.1.7",
         "promise": "^8.0.3",
@@ -12573,7 +12574,8 @@
     "node_modules/papaparse": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "license": "MIT"
     },
     "node_modules/param-case": {
       "version": "2.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -82,6 +82,7 @@
     "jquery.flot.tooltip": "^0.9.0",
     "lodash-es": "^4.17.21",
     "markdown": "^0.5.0",
+    "papaparse": "^5.4.1",
     "plotly.js": "^1.52.2",
     "portal-vue": "2.1.7",
     "promise": "^8.0.3",

--- a/client/src/js/modules/samples/routes.js
+++ b/client/src/js/modules/samples/routes.js
@@ -58,6 +58,10 @@ app.addInitializer(function() {
     app.navigate('/ligands/lid/'+lid)
   })
 
+  app.on('ligands:viewall', function(lid) {
+    app.navigate('/ligands')
+  })
+
   app.on('phases:view', function(pid) {
     app.navigate('/phases/pid/'+pid)
   })

--- a/client/src/js/modules/samples/routes.js
+++ b/client/src/js/modules/samples/routes.js
@@ -58,7 +58,7 @@ app.addInitializer(function() {
     app.navigate('/ligands/lid/'+lid)
   })
 
-  app.on('ligands:viewall', function(lid) {
+  app.on('ligands:viewall', function() {
     app.navigate('/ligands')
   })
 

--- a/client/src/js/modules/samples/views/ligandadd.js
+++ b/client/src/js/modules/samples/views/ligandadd.js
@@ -1,11 +1,125 @@
-define(['marionette', 'views/form', 
+define(['marionette',
+    'papaparse',
+    'views/form',
     'models/ligand',
     'templates/samples/ligandadd.html'], 
-    function(Marionette, TableView, Ligand, template) {
-    
-    
+    function(Marionette, Papa, TableView, Ligand, template) {
+
     return FormView.extend({
         template: template,
+
+        ui: {
+            fileRadio: 'input[name="fileupload"]',
+            single: '.single',
+            csv: '.csv',
+        },
+
+        events: {
+            'change @ui.fileRadio': 'toggleInputMode',
+            'change input[type="file"]': 'validateCSV'
+        },
+
+        onRender: function() {
+            this.toggleInputMode()
+        },
+
+        toggleInputMode: function() {
+            let isFileUpload = this.ui.fileRadio.filter(':checked').val() === 'true'
+
+            if (isFileUpload) {
+                this.ui.single.hide()
+                this.ui.csv.show()
+                this.model.validation.NAME.required = false
+                this.model.validation.LIBRARYNAME.required = true
+                this.model.validation.LIBRARYBATCHNUMBER.required = true
+                this.model.validation.PLATEBARCODE.required = true
+            } else {
+                this.ui.single.show()
+                this.ui.csv.hide()
+                this.model.validation.NAME.required = true
+                this.model.validation.LIBRARYNAME.required = false
+                this.model.validation.LIBRARYBATCHNUMBER.required = false
+                this.model.validation.PLATEBARCODE.required = false
+            }
+        },
+
+        validateCSV: function(e) {
+            const file = e.target.files[0]
+            if (!file) return
+            let seen = new Set()
+
+            Papa.parse(file, {
+                header: true,
+                skipEmptyLines: true,
+                transformHeader: function(h, i) {
+                    if (i === 0) {
+                        seen = new Set()
+                    }
+                    const header = h.trim().toUpperCase()
+                    console.log(i, header, seen)
+                    // Exact matches
+                    if (header === 'NAME') {
+                        seen.add('NAME')
+                        return 'NAME'
+                    }
+                    if (header === 'SMILES') {
+                        seen.add('SMILES')
+                        return 'SMILES'
+                    }
+                    if (header === 'SOURCEWELL' || header === 'SOURCE WELL' || header === 'WELL') {
+                        seen.add('SOURCEWELL')
+                        return 'SOURCEWELL'
+                    }
+                    // Partial matches only return the target if that slot hasn't been taken.
+                    if (header.includes('NAME') && !header.includes('SALT') && !seen.has('NAME')) {
+                        seen.add('NAME')
+                        return 'NAME'
+                    }
+                    if (header.startsWith('SMILE') && !seen.has('SMILES')) {
+                        seen.add('SMILES')
+                        return 'SMILES'
+                    }
+                    if (header.startsWith('WELL') && !header.includes('VOLUME') && !seen.has('SOURCEWELL')) {
+                        seen.add('SOURCEWELL')
+                        return 'SOURCEWELL'
+                    }
+                    return header
+                },
+                complete: (results) => {
+                    let valid = true
+                    if (results.data.length === 0) {
+                        app.alert({ message: 'Invalid CSV: No data found' })
+                        valid = false
+                    } else if (results.errors.length > 0) {
+                        app.alert({ message: 'Invalid CSV: '+results.errors[0].message })
+                        valid = false
+                    }
+                    for (let i = 0; i < results.data.length; i++) {
+                        let rowdata = results.data[i]
+                        let rownum = i+2
+                        console.log(rowdata)
+                        if (!rowdata.NAME) {
+                            app.alert({ message: 'Invalid CSV: row '+rownum+' has no NAME value' })
+                            valid = false
+                        }
+                        if (!rowdata.SMILES) {
+                            app.alert({ message: 'Invalid CSV: row '+rownum+' has no SMILES value' })
+                            valid = false
+                        }
+                        if (!rowdata.SOURCEWELL) {
+                            app.alert({ message: 'Invalid CSV: row '+rownum+' has no WELL value' })
+                            valid = false
+                        }
+                        if (!valid) break
+                    }
+                    if (valid) {
+                        this.model.set('json', results.data)
+                    } else {
+                        e.target.value = ''
+                    }
+                }
+            })
+        },
 
         createModel: function() {
             this.model = new Ligand()
@@ -13,12 +127,18 @@ define(['marionette', 'views/form',
         
         success: function(model, response, options) {
             console.log('success from ligand add', this.model)
-            app.trigger('ligands:view', model.get('LIGANDID'))
+            let ligandid = model.get('LIGANDIDS')
+            if (ligandid.length === 1) {
+                app.trigger('ligands:view', ligandid[0])
+            } else {
+                app.message({ title: 'Ligands added successfully', message: ligandid.length+' ligands added successfully' })
+                app.trigger('ligands:viewall')
+            }
         },
 
         failure: function(model, xhr, options) {
             console.log(arguments)
-            json = null
+            let json = null
             if (xhr.responseText) {
                 try { 
                     json = $.parseJSON(xhr.responseText)

--- a/client/src/js/modules/samples/views/ligandadd.js
+++ b/client/src/js/modules/samples/views/ligandadd.js
@@ -56,7 +56,6 @@ define(['marionette',
                         seen = new Set()
                     }
                     const header = h.trim().toUpperCase()
-                    console.log(i, header, seen)
                     // Exact matches
                     if (header === 'NAME') {
                         seen.add('NAME')
@@ -97,7 +96,6 @@ define(['marionette',
                     for (let i = 0; i < results.data.length; i++) {
                         let rowdata = results.data[i]
                         let rownum = i+2
-                        console.log(rowdata)
                         if (!rowdata.NAME) {
                             app.alert({ message: 'Invalid CSV: row '+rownum+' has no NAME value' })
                             valid = false

--- a/client/src/js/templates/samples/ligandadd.html
+++ b/client/src/js/templates/samples/ligandadd.html
@@ -4,8 +4,21 @@
     
     <div class="form">
         <ul>
+        <input id="file" type="radio" name="fileupload" value="true" checked="checked">
+        <label for="file">CSV Upload for Multiple Ligands</label>
+        <br />
+        <input id="form" type="radio" name="fileupload" value="false">
+        <label for="form">Add a Single Ligand</label>
+        <br />
             
-            <li>
+            <li class="csv">
+                <span class="file">
+                    <input type="file" name="csv_file" accept=".csv">
+                </span>
+                <p>CSV files must contain 3 comma separated columns with the following mandatory headers on the first row: Name,SMILES,Well. <button type="button" onclick="window.open('/assets/files/ligand_template.csv');return false">Download CSV Template</button></p>
+            </li>
+
+            <li class="single">
                 <label>Name
                 </label>
                 <span class="name">
@@ -13,7 +26,7 @@
                 </span>
             </li>
             
-            <li>
+            <li class="single">
                 <label>SMILES Code
                 </label>
                 <span class="SMILES"><input data-testid="new-ligand-smiles" type="text" name="SMILES" /></span>
@@ -38,13 +51,13 @@
                 <span class="PLATEBARCODE"><input data-testid="new-ligand-plate-barcode" type="text" name="PLATEBARCODE" /></span>
             </li>
 
-            <li>
+            <li class="single">
                 <label>Source Well
                 </label>
                 <span class="SOURCEWELL"><input data-testid="new-ligand-source-well" type="text" name="SOURCEWELL" /></span>
             </li>
 
-            <li>
+            <li class="single">
                 <label>
                     PDB File
                     <span class="small">
@@ -56,7 +69,7 @@
             </li>
         </ul>
         
-        <button name="submit" value="1" type="submit" class="button submit" data-testid="add-ligand">Add Ligand</button>
+        <button name="submit" value="1" type="submit" class="button submit" data-testid="add-ligand">Add Ligand(s)</button>
     </div>
     
 </form>

--- a/client/src/js/templates/samples/ligandlist.html
+++ b/client/src/js/templates/samples/ligandlist.html
@@ -2,7 +2,7 @@
 <p class="help">This page lists all <%-title.toLowerCase()%>s associated with the currently selected proposal.</p>
 
 <div class="ra">
-    <a class="button" href="/<%-url%>s/add"><i class="fa fa-plus"></i> Add <%-title%></a>
+    <a class="button" href="/<%-url%>s/add"><i class="fa fa-plus"></i> Add <%-title%>(s)</a>
 </div>
 
 <div class="wrapper"></div>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2159](https://jira.diamond.ac.uk/browse/LIMS-2159)

**Summary**:

Add a CSV uploader for ligands. As ligand info often comes in a fairly rich spreadsheet, we should be quite flexible with column names.

**Changes**:
- Fix page count and sorting of ligands on ligand view page, allow searching by fields other than 'name'
- Allow adding of multiple ligands in a loop in the backend
- Enforce install of papaparse library to inspect CSV files (previously installed as a dependency of csv-file-validator anyway)
- Add a radio box to switch between CSV upload and single mode on the ligand add page
- Make different fields compulsory in each mode
- Parse the header lines in the CSV to try to get "Name", "Source Well" and "SMILES" columns, or similarly named ones
- Display errors if found, add notification on upload success, and redirect to the View Ligands page

**To test**:
- Go to any proposal (eg mx23694), go to Ligands in the main menu, then click Add Ligand(s) to go to /ligands/add
- Choose "Add a Single Ligand" and fill in the name field and any others you fancy, click Add Ligand(s) and check you are redirected to a view of your ligand
- Go back to /ligands/add, and choose CSV Upload. Check only 3 text boxes remain visible (and are compulsory), as well as the file selection box
- Go to [LIMS-1052](https://jira.diamond.ac.uk/browse/LIMS-1052) and download any of the spreadsheet files (except Euopen_screen_with_smiles.xlsx), then export it to CSV
- Select the CSV on the /ligands/add page, check no errors occur. Click Add Ligand(s) and check it uploads ok, and you are taken to the View all Ligands page
- Check searching for Ligands and ordering by clicking on the headers works ok
- Delete the Name or SMILES code from one line of your CSV, and then try to re-select it on the Add Ligands page, check your are shown an error explaining which line number has a problem