### PR TITLE
LIMS-2165: Fix Map/Model Viewer from data collection groups

### DIFF
--- a/api/src/Downstream/DownstreamProcessing.php
+++ b/api/src/Downstream/DownstreamProcessing.php
@@ -281,6 +281,7 @@ class DownstreamResult {
         $resp['TYPE'] = $this->friendlyname;
         $resp['PROCESS'] = $this->process;
         $resp['MESSAGES'] = $this->process['MESSAGES'];
+        $resp['DCID'] = $this->process['DCID'];
         $resp['FEATURES'] = array(
             'MAPMODEL' => $this->has_mapmodel,
             'IMAGES' => $this->has_images,

--- a/api/src/Page/Processing.php
+++ b/api/src/Page/Processing.php
@@ -799,7 +799,7 @@ class Processing extends Page {
         }
 
         $downstreams = $this->db->pq(
-            "SELECT app.autoprocprogramid, app.processingprograms, pj.automatic, 
+            "SELECT app.autoprocprogramid, app.processingprograms, pj.automatic, pj.datacollectionid as dcid,
                     app.processingstatus, app.processingmessage,
                     app.processingstarttime, app.processingendtime, pj.recipe, pj.comments as processingcomments,
                     dc.imageprefix as dcimageprefix, dc.imagedirectory as dcimagedirectory, 

--- a/client/src/js/modules/dc/views/downstreamwrapper.js
+++ b/client/src/js/modules/dc/views/downstreamwrapper.js
@@ -97,7 +97,7 @@ define(['backbone', 'marionette',
             var mapButton = null
             if (this.getOption('links')) {
                 var links = [
-                    '<a class="view button" href="/dc/map/id/'+this.getOption('DCID')+'/aid/'+this.model.get('AID')+'"><i class="fa fa-search"></i> Map / Model Viewer</a>',
+                    '<a class="view button" href="/dc/map/id/'+this.model.get('DCID')+'/aid/'+this.model.get('AID')+'"><i class="fa fa-search"></i> Map / Model Viewer</a>',
                     '<a class="pattach button" href="#"><i class="fa fa-files-o"></i> Logs &amp; Files</a>',
                     '<a class="dll button" href="'+app.apiurl+'/download/ap/archive/'+this.model.get('AID')+'"><i class="fa fa-cloud-download"></i> Download Zip</a>',
                 ]


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2165](https://jira.diamond.ac.uk/browse/LIMS-2165)

**Summary**:

Clicking on the "Map / Model Viewer" button from a data collection group sometimes throws an error. This was introduced by https://github.com/DiamondLightSource/SynchWeb/pull/1024

**Changes**:
- Get the data collection id for each downstream processing job and return it from the backend
- Use it to build the link to the Map / Model Viewer

**To test**:
- Go to a visit with lots of groups with successful downstream processing jobs, eg /dc/visit/mx41060-23/ty/ph
- Click the downstream processing bar on one of the blue data collection groups
- Hover over each of the Map / Model Viewer buttons for a particular pipeline, and check each link has different data collection id's as well as autoproc ids, eg /dc/map/id/22567397/aid/119664992 and /dc/map/id/22567439/aid/119665103
- Click each one's button, check the model loads without any errors in the dev console
