### PR TITLE
LIMS-2162: Dont change dewar status if already dispatch-booked

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -538,10 +538,11 @@ class Shipment extends Page
                 $email_location = $dewar_complete_email_locations[$last_location];
                 $send_return_email = preg_match($email_location, strtolower($this->arg('LOCATION')));
             }
-            // If dewar status is dispatch-requested - don't change it.
+            // If dewar status is dispatch-requested or dispatch-booked - don't change it.
             // This way the dewar can be moved between storage locations and keep the record that a user requested the dispatch
             // Default status is 'at-facility'
-            $dewarstatus = strtolower($dew['DEWARSTATUS']) == 'dispatch-requested' ? 'dispatch-requested' : 'at facility';
+            $status = strtolower($dew['DEWARSTATUS']);
+            $dewarstatus = ($status == 'dispatch-requested' || $status == 'dispatch-booked') ? $status : 'at facility';
             $dewarlocation = $this->arg('LOCATION');
 
         } else {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2162](https://jira.diamond.ac.uk/browse/LIMS-2162)

**Summary**:

When a dewar location changes to eg the Randex, we update the location and also the status to `at facility`. Since https://github.com/DiamondLightSource/SynchWeb/pull/856, we have not updated the status if it was already `dispatch-requested`, so the dispatch request remains visible. https://github.com/DiamondLightSource/SynchWeb/pull/1049 introduced the new status of `dispatch-booked`, this PR is to treat `dispatch-booked` in the same way as `dispatch-requested`.

**Changes**:
- Check for both `dispatch-booked` and `dispatch-requested` before changing status to `at facility`.

**To test**:
- Using ispyb-test, go to (or create) a UK shipment (mx23694 usually has a couple of Selenium test ones), then do a dispatch request via the shipping service. The shipment should have a status of `dispatch-booked`
- Add your local IP to the `$bcr` config variable, then send a POST request to `/api/shipment/dewars/history`, with the body of `{"BARCODE": <your dewar barcode>, "LOCATION": "TRAY-17P"}`
- Check (in ispyb-test) the dewar now has a location of "tray-17p", but the status is still `dispatch-booked`. Check the dewar history agrees.
- Take your IP out of $bcr as it messes up other things (eg dewar history)
