### PR TITLE
LIMS-2181: Improve speed of queueing and editing 1000s of samples

### DIFF
--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -177,6 +177,7 @@ class Sample extends Page
         array('/sub/:ssid', 'get', '_get_sub_sample'),
         array('/sub/:ssid', 'patch', '_update_sub_sample'),
         array('/sub/:ssid', 'put', '_update_sub_sample_full'),
+        array('/sub/cid/:cid', 'post', '_update_container_sub_samples'),
         array('/sub', 'post', '_add_sub_sample'),
         array('/sub/:ssid', 'delete', '_delete_sub_sample'),
         array('/sub/queue/cid/:cid', 'post', '_queue_all_sub_samples'),
@@ -638,13 +639,39 @@ class Sample extends Page
 
         $this->db->wait_rep_sync(false);
 
-        $ret = array();
-        foreach ($subs as $sub) {
-            array_push($ret, array(
-                'BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID'], 
-                'CONTAINERQUEUESAMPLEID' => $this->_do_pre_q_sample(array('BLSUBSAMPLEID' => $sub['BLSUBSAMPLEID']))));
+        if (!sizeof($subs))
+            $this->_error('No subsamples found');
+
+        $sub_ids = array_column($subs, 'BLSUBSAMPLEID');
+        $placeholders = implode(',', array_fill(0, count($sub_ids), '?'));
+        if ($this->has_arg('UNQUEUE')) {
+            $this->db->pq("DELETE FROM containerqueuesample
+                            WHERE containerqueueid IS NULL
+                            AND blsubsampleid IN ($placeholders)", $sub_ids);
+
+            $ret = array_map(function($id) {
+                return array('BLSUBSAMPLEID' => $id, 'CONTAINERQUEUESAMPLEID' => null);
+            }, $sub_ids);
+
+        } else {
+            $this->db->pq("INSERT INTO containerqueuesample (blsubsampleid)
+                SELECT ss.blsubsampleid
+                FROM blsubsample ss
+                INNER JOIN blsample s ON s.blsampleid = ss.blsampleid
+                INNER JOIN container c ON c.containerid = s.containerid
+                INNER JOIN dewar d ON d.dewarid = c.dewarid
+                INNER JOIN shipping sh ON sh.shippingid = d.shippingid
+                WHERE sh.proposalid = ?
+                AND ss.blsubsampleid IN ($placeholders)",
+                array_merge(array($this->proposalid), $sub_ids));
+
+            $ret = $this->db->pq("SELECT blsubsampleid, containerqueuesampleid
+                FROM containerqueuesample
+                WHERE blsubsampleid IN ($placeholders)
+                AND containerqueueid IS NULL", $sub_ids);
         }
         $this->_output($ret);
+
     }
 
     function _sub_samples()
@@ -959,6 +986,59 @@ class Sample extends Page
         }
     }
 
+
+    function _update_container_sub_samples()
+    {
+        if (!$this->arg('cid'))
+            $this->_error('No container specified');
+
+        if (!$this->arg('EXPERIMENTKIND'))
+            $this->_error('No experiment kind provided');
+
+        $rows = $this->db->pq("SELECT DISTINCT ss.diffractionplanid
+            FROM blsubsample ss
+            INNER JOIN blsample s ON s.blsampleid = ss.blsampleid
+            INNER JOIN diffractionplan dp ON dp.diffractionplanid = ss.diffractionplanid
+            INNER JOIN containerqueuesample cqs ON cqs.blsubsampleid = ss.blsubsampleid
+            WHERE s.containerid=:1
+            AND dp.experimentkind=:2
+            AND ss.diffractionplanid IS NOT NULL
+            AND cqs.containerqueuesampleid IS NOT NULL
+            AND cqs.containerqueueid IS NULL",
+            array($this->arg('cid'), $this->arg('EXPERIMENTKIND')));
+
+        if (!sizeof($rows)) {
+            $this->_output(array('TOTAL_UPDATED' => 0));
+            return;
+        }
+
+        $all_ids = array_column($rows, 'DIFFRACTIONPLANID');
+        $set_args = array();
+        foreach (array(
+            'REQUIREDRESOLUTION', 'EXPERIMENTKIND', 'PREFERREDBEAMSIZEX', 'PREFERREDBEAMSIZEY',
+            'EXPOSURETIME', 'BOXSIZEX', 'BOXSIZEY', 'AXISSTART', 'AXISRANGE', 'NUMBEROFIMAGES',
+            'TRANSMISSION', 'ENERGY', 'MONOCHROMATOR'
+        ) as $f) {
+            array_push($set_args, $this->has_arg($f) ? $this->arg($f) : null);
+        }
+
+        $chunks = array_chunk($all_ids, 100);
+        $total_updated = 0;
+
+        foreach ($chunks as $chunk) {
+            $id_list = implode(',', $chunk);
+
+            $this->db->pq("UPDATE diffractionplan
+                SET requiredresolution=:1, experimentkind=:2, preferredbeamsizex=:3, preferredbeamsizey=:4,
+                    exposuretime=:5, boxsizex=:6, boxsizey=:7, axisstart=:8, axisrange=:9,
+                    numberofimages=:10, transmission=:11, energy=:12, monochromator=:13
+                WHERE diffractionplanid IN ($id_list)", $set_args);
+
+            $total_updated += sizeof($chunk);
+        }
+
+        $this->_output(array('TOTAL_UPDATED' => $total_updated));
+    }
 
 
     function _add_sub_sample()

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -1036,13 +1036,22 @@ class Sample extends Page
         $total_updated = 0;
 
         foreach ($chunks as $chunk) {
-            $id_list = implode(',', $chunk);
+            $start_index = sizeof($set_args) + 1;
+            $placeholders = array();
+
+            foreach ($chunk as $index => $id) {
+                array_push($placeholders, ':' . ($start_index + $index));
+            }
+
+            $id_placeholders_list = implode(',', $placeholders);
+
+            $combined_args = array_merge($set_args, $chunk);
 
             $this->db->pq("UPDATE diffractionplan
                 SET requiredresolution=:1, experimentkind=:2, preferredbeamsizex=:3, preferredbeamsizey=:4,
                     exposuretime=:5, boxsizex=:6, boxsizey=:7, axisstart=:8, axisrange=:9,
                     numberofimages=:10, transmission=:11, energy=:12, monochromator=:13
-                WHERE diffractionplanid IN ($id_list)", $set_args);
+                WHERE diffractionplanid IN ($id_placeholders_list)", $combined_args);
 
             $total_updated += sizeof($chunk);
         }

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -643,32 +643,42 @@ class Sample extends Page
             $this->_error('No subsamples found');
 
         $sub_ids = array_column($subs, 'BLSUBSAMPLEID');
-        $placeholders = implode(',', array_fill(0, count($sub_ids), '?'));
+        $chunks = array_chunk($sub_ids, 500);
+        $ret = array();
+
         if ($this->has_arg('UNQUEUE')) {
-            $this->db->pq("DELETE FROM containerqueuesample
-                            WHERE containerqueueid IS NULL
-                            AND blsubsampleid IN ($placeholders)", $sub_ids);
+            foreach ($chunks as $chunk) {
+                $placeholders = implode(',', array_fill(0, count($chunk), '?'));
+                $this->db->pq("DELETE FROM containerqueuesample
+                    WHERE containerqueueid IS NULL
+                    AND blsubsampleid IN ($placeholders)", $chunk);
+            }
 
             $ret = array_map(function($id) {
                 return array('BLSUBSAMPLEID' => $id, 'CONTAINERQUEUESAMPLEID' => null);
             }, $sub_ids);
 
         } else {
-            $this->db->pq("INSERT INTO containerqueuesample (blsubsampleid)
-                SELECT ss.blsubsampleid
-                FROM blsubsample ss
-                INNER JOIN blsample s ON s.blsampleid = ss.blsampleid
-                INNER JOIN container c ON c.containerid = s.containerid
-                INNER JOIN dewar d ON d.dewarid = c.dewarid
-                INNER JOIN shipping sh ON sh.shippingid = d.shippingid
-                WHERE sh.proposalid = ?
-                AND ss.blsubsampleid IN ($placeholders)",
-                array_merge(array($this->proposalid), $sub_ids));
+            foreach ($chunks as $chunk) {
+                $placeholders = implode(',', array_fill(0, count($chunk), '?'));
+                $this->db->pq("INSERT INTO containerqueuesample (blsubsampleid)
+                    SELECT ss.blsubsampleid
+                    FROM blsubsample ss
+                    INNER JOIN blsample s ON s.blsampleid = ss.blsampleid
+                    INNER JOIN container c ON c.containerid = s.containerid
+                    INNER JOIN dewar d ON d.dewarid = c.dewarid
+                    INNER JOIN shipping sh ON sh.shippingid = d.shippingid
+                    WHERE sh.proposalid = ?
+                    AND ss.blsubsampleid IN ($placeholders)",
+                    array_merge(array($this->proposalid), $chunk));
 
-            $ret = $this->db->pq("SELECT blsubsampleid, containerqueuesampleid
-                FROM containerqueuesample
-                WHERE blsubsampleid IN ($placeholders)
-                AND containerqueueid IS NULL", $sub_ids);
+                $chunk_ret = $this->db->pq("SELECT blsubsampleid, containerqueuesampleid
+                    FROM containerqueuesample
+                    WHERE blsubsampleid IN ($placeholders)
+                    AND containerqueueid IS NULL", $chunk);
+
+                $ret = array_merge($ret, $chunk_ret);
+            }
         }
         $this->_output($ret);
 
@@ -1022,7 +1032,7 @@ class Sample extends Page
             array_push($set_args, $this->has_arg($f) ? $this->arg($f) : null);
         }
 
-        $chunks = array_chunk($all_ids, 100);
+        $chunks = array_chunk($all_ids, 500);
         $total_updated = 0;
 
         foreach ($chunks as $chunk) {

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -704,23 +704,36 @@ define(['marionette',
 
             var p = this.plans.findWhere({ DIFFRACTIONPLANID: this.ui.preset.val() })
             if (p) {
-                self.ui.applyall.html('Applying...').prop('disabled', true)
-                var promises = await this.applyModel(p, false)
 
-                const updateButtonAfterProcessing = () => {
-                    self.ui.applyall.html('<i class="fa fa-file-text-o"></i> Apply to All').prop('disabled', false)
+                var updateParams = {
+                    EXPERIMENTKIND: p.get('EXPERIMENTKIND')
                 }
 
-                if (promises && promises.length > 0) {
-                    Promise.allSettled(promises)
-                    .then(updateButtonAfterProcessing)
-                    .catch(error => {
-                        console.error("Error after promises settled: ", error);
-                        updateButtonAfterProcessing()
-                    })
-                } else {
-                     updateButtonAfterProcessing()
-                }
+                var fields = [
+                    'REQUIREDRESOLUTION', 'PREFERREDBEAMSIZEX', 'PREFERREDBEAMSIZEY',
+                    'EXPOSURETIME', 'BOXSIZEX', 'BOXSIZEY', 'AXISSTART', 'AXISRANGE',
+                    'NUMBEROFIMAGES', 'TRANSMISSION', 'ENERGY', 'MONOCHROMATOR'
+                ]
+
+                fields.forEach(function(k) {
+                    if (p.get(k) !== null && p.get(k) !== undefined) {
+                        updateParams[k] = p.get(k)
+                    }
+                })
+
+                Backbone.ajax({
+                    url: app.apiurl+'/sample/sub/cid/'+this.model.get('CONTAINERID'),
+                    method: 'POST',
+                    data: updateParams,
+                    success: function(json) {
+                        self.refreshSubSamples()
+                        app.message({ message: 'Applied preset to ' + json.TOTAL_UPDATED + ' samples' })
+                    },
+                    error: function() {
+                        app.alert({ message: 'Something went wrong applying to all' })
+                    }
+                })
+
             }
         },
 

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -709,7 +709,7 @@ define(['marionette',
                     EXPERIMENTKIND: p.get('EXPERIMENTKIND')
                 }
 
-                var fields = [
+                const fields = [
                     'REQUIREDRESOLUTION', 'PREFERREDBEAMSIZEX', 'PREFERREDBEAMSIZEY',
                     'EXPOSURETIME', 'BOXSIZEX', 'BOXSIZEY', 'AXISSTART', 'AXISRANGE',
                     'NUMBEROFIMAGES', 'TRANSMISSION', 'ENERGY', 'MONOCHROMATOR'

--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -683,7 +683,7 @@ define(['marionette',
                     app.message({ message: 'Container Successfully Unqueued' })
                     self.ui.unqueuebutton.hide()
                     self.ui.queuebutton.show()
-                    self.model.set('CONTAINERQUEUEID', null)
+                    self.model.set('CONTAINERQUEUEID', null, { silent: true })
                 },
                 error: function() {
                     app.alert({ message: 'Something went wrong unqueuing this container' })
@@ -790,17 +790,7 @@ define(['marionette',
                 return
             }
 
-            // need to validate all models here again in case they haven't been rendered
-            this.qsubsamples.fullCollection.each(function(qs) {
-                if (qs.get('_valid') !== undefined) return
-
-                const expcell = new ExperimentCell({model: qs, column: {beamlinesetups: this.beamlinesetups}});
-                const val = expcell.checkIsValid();
-                console.log({ experimentCell: val })
-            }, this)
-
             var invalid = this.typeselector.shadowCollection.where({ '_valid': false })
-            console.log('queue', invalid, invalid.length > 0)
             if (invalid.length > 0) {
                 app.alert({ message: 'There are '+invalid.length+' sub samples with invalid experimental plans, please either correct or remove these from the queue' })
                 var inv = this.typeselector.collection.findWhere({ id: 'invalid' })
@@ -817,7 +807,7 @@ define(['marionette',
                         app.message({ message: 'Container Successfully Queued' })
                         self.ui.unqueuebutton.show()
                         self.ui.queuebutton.hide()
-                        self.model.set('CONTAINERQUEUEID', json.CONTAINERQUEUEID)
+                        self.model.set('CONTAINERQUEUEID', json.CONTAINERQUEUEID, { silent: true })
                     },
                     error: function() {
                         app.alert({ message: 'Something went wrong queuing this container' })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2181](https://jira.diamond.ac.uk/browse/LIMS-2181)

**Summary**:

As we now automatically detect crystals in plates, there can be 1000s of them, that all need queueing, and also parameters adding to. This is currently very slow as it loops through each subsample individually. This change is to make the "Add All to Queue" and "Apply to All" buttons use far fewer database calls.

**Changes**:
- Make the "Add all to Queue" and "Unqueue All" buttons insert or delete 500 rows at a time, using "?" as a placeholder instead of ":1", ":2" etc (seems to work)
- Make the "Apply to All" button call a new endpoint, which first retrieves a list of queued subsamples in the container, then applies the preset to them all in chunks of 500.
- Remove manual validation of all queued samples when queueing the container, as this is very slow (about 200 samples / sec)
- Make queueing and unqueueing the container silent operations, as there is no need to re-render the samples.

**To test**:
- Find a container with 1000s of subsamples (that has not yet been disposed) eg /containers/cid/377216
- Click "Prepare For Data Collection" at the bottom to go to eg /containers/queue/377216
- Assuming none are currently queued (ie the queued samples list is empty), click "Add All to Queue". Check all 7626 (or however many) samples are queued (in about 10s)
- Choose one of the presets that starts with "Omega Scan" from the dropdown, then click "Apply to All". Check this returns in about 3s and each of the parameters updates correctly. (If there are any "regions" in the list they won't be edited as this is a point preset)
- Manually edit the parameters of a queued sample so they are invalid, and then click "Queue Container" at the bottom. Check you are told one is invalid and are taken to the invalid tab to correct it
- Fix the parameters, queue the container, check it works promptly. Check an Unqueue button appears at the top.
- Check the Unqueue button works promptly, and the Unqueue button disappears.
- Click "Unqueue All" and check all the samples are removed from the queue.
