### PR TITLE
LIMS-2174: Add ability to add elements to proteins

### DIFF
--- a/api/src/Database/Type/MySQL.php
+++ b/api/src/Database/Type/MySQL.php
@@ -113,11 +113,13 @@ class MySQL extends DatabaseParent {
         'PDBEntry_has_AutoProcProgram',
 
         // Protein -> Component
+        'Component',
         'ConcentrationType',
         'ComponentType',
         'Component_has_SubType',
         'ComponentSubType',
         'BLSampleType_has_Component',
+        'Protein_has_Component',
 
         // VMXi
         'ContainerInspection',

--- a/api/src/Page/Sample.php
+++ b/api/src/Page/Sample.php
@@ -213,6 +213,9 @@ class Sample extends Page
 
         array('/concentrationtypes', 'get', '_concentration_types'),
         array('/componenttypes', 'get', '_component_types'),
+        array('/elements(/pid/:pid)', 'get', '_get_elements'),
+        array('/elements/pid/:pid/:cid', 'delete', '_remove_element'),
+        array('/elements/pid/:pid/:cid', 'put', '_add_element'),
 
         array('/groups', 'get', '_sample_groups'),
         array('/groups', 'post', '_add_new_sample_group'),
@@ -2945,11 +2948,96 @@ class Sample extends Page
         $this->_output($rows);
     }
 
-
     function _component_sub_types()
     {
         $rows = $this->db->pq("SELECT componentsubtypeid, name FROM componentsubtype");
         $this->_output($rows);
+    }
+
+    function _get_elements()
+    {
+        if (!$this->has_arg('prop'))
+            $this->_error('No proposal specified');
+
+        $where = 'ct.name=:1';
+        $args = array('Element');
+        $join = 'INNER JOIN componenttype ct ON c.componenttypeid = ct.componenttypeid';
+
+        if ($this->has_arg('pid')) {
+            $join .= ' INNER JOIN protein_has_component phc ON c.componentid = phc.componentid';
+            $join .= ' INNER JOIN protein pr ON phc.proteinid = pr.proteinid';
+            $where .= ' AND pr.proposalid=:2 AND pr.proteinid=:3';
+            array_push($args, $this->proposalid, $this->arg('pid'));
+        }
+
+        $rows = $this->db->pq("SELECT c.componentid, c.name
+            FROM component c
+            $join
+            WHERE $where",
+            $args
+            );
+        $this->_output($rows);
+    }
+
+    function _add_element()
+    {
+        if (!$this->has_arg('prop'))
+            $this->_error('No proposal specified');
+
+        if (!$this->has_arg('pid'))
+            $this->_error('No protein specified');
+
+        if (!$this->has_arg('cid'))
+            $this->_error('No element specified');
+
+        $prot = $this->db->pq("SELECT p.proteinid
+            FROM protein p
+            WHERE p.proposalid=:1 AND p.proteinid=:2",
+            array($this->proposalid, $this->arg('pid')));
+
+        if (!sizeof($prot))
+            $this->_error('No such protein');
+
+        $phc = $this->db->pq("SELECT phc.proteinhascomponentid
+            FROM protein_has_component phc
+            INNER JOIN protein p ON p.proteinid = phc.proteinid
+            WHERE p.proposalid=:1 AND phc.proteinid=:2 AND phc.componentid=:3",
+            array($this->proposalid, $this->arg('pid'), $this->arg('cid')));
+
+        if (sizeof($phc))
+            $this->_error('Element already added to this protein');
+
+        $this->db->pq("INSERT INTO protein_has_component (proteinid, componentid) VALUES (:1, :2) RETURNING proteinhascomponentid INTO :id",
+            array($this->arg('pid'), $this->arg('cid')));
+
+        $phc = $this->db->id();
+
+        $this->_output(array('PROTEINHASCOMPONENTID' => $phc));
+    }
+
+    function _remove_element()
+    {
+        if (!$this->has_arg('prop'))
+            $this->_error('No proposal specified');
+
+        if (!$this->has_arg('pid'))
+            $this->_error('No protein specified');
+
+        if (!$this->has_arg('cid'))
+            $this->_error('No element specified');
+
+        $phc = $this->db->pq("SELECT phc.proteinhascomponentid
+            FROM protein_has_component phc
+            INNER JOIN protein p ON p.proteinid = phc.proteinid
+            WHERE p.proposalid=:1 AND phc.proteinid=:2 AND phc.componentid=:3",
+            array($this->proposalid, $this->arg('pid'), $this->arg('cid')));
+
+        if (!sizeof($phc))
+            $this->_error('No such association');
+
+        $this->db->pq("DELETE FROM protein_has_component WHERE proteinhascomponentid=:1", array($phc[0]['PROTEINHASCOMPONENTID']));
+
+        $this->_output(1);
     }
 
     # Sample Groups

--- a/client/src/css/partials/_assign.scss
+++ b/client/src/css/partials/_assign.scss
@@ -117,3 +117,22 @@
         }
     }
 }
+
+.proteinelements {
+    list-style: none;
+
+    li {
+        @mixin cols 10, 1%, 0.5%;
+        float: left;
+        border-radius: 5px;
+        background: $content-dark-background;
+
+        &.active {
+            background: $content-active;
+        }
+    }
+
+    li.empty-message {
+        @mixin cols 3, 1%, 0.5%;
+    }
+}

--- a/client/src/css/partials/_form.scss
+++ b/client/src/css/partials/_form.scss
@@ -19,6 +19,10 @@ div.form {
                 /* Want consistent padding for form span elements */
                 @apply tw-px-1 tw-py-2;
             }
+
+            span.novertpad {
+                @apply tw-px-1 tw-py-0;
+            }
         }
     }
     

--- a/client/src/js/collections/elements.js
+++ b/client/src/js/collections/elements.js
@@ -1,0 +1,16 @@
+define(['backbone', 'utils/kvcollection'], function(Backbone, KVCollection) {
+    
+    return Backbone.Collection.extend(_.extend({}, KVCollection, {
+        initialize: function(models, options) {
+            this.pid = options && options.pid
+        },
+        url: function() {
+            return this.pid ? '/sample/elements/pid/'+this.pid : '/sample/elements'
+        },
+        model: Backbone.Model.extend({
+            idAttribute: 'COMPONENTID',
+        }),
+        keyAttribute: 'NAME',
+        valueAttribute: 'COMPONENTID',
+    }))
+})

--- a/client/src/js/modules/samples/views/elements.js
+++ b/client/src/js/modules/samples/views/elements.js
@@ -1,0 +1,40 @@
+define(['marionette', 'backbone', 'utils'], function(Marionette, Backbone, utils) {
+
+    var UserItem = Marionette.ItemView.extend({
+        template: _.template(''),
+        tagName: 'li',
+        attributes: { 'data-testid': 'protein-element-list-item' },
+        events: {
+            'click a.delete': 'deleteElement',
+        },
+
+        render: function() {
+            UserItem.__super__.render.call(this)
+            const deleteButton = '<a class="button button-notext delete" href="#"><i class="fa fa-times"></i> <span>Delete</span></a>'
+            this.$el.append(this.model.get('NAME')+' <span class="r novertpad">'+deleteButton+'</span>')
+        },
+
+        deleteElement: function(e) {
+            e.preventDefault()
+            this.model.destroy()
+        },
+    })
+
+    var EmptyUserItem = Marionette.ItemView.extend({
+        template: _.template('No elements associated with this protein'),
+        tagName: 'li',
+        className: 'empty-message',
+        attributes: { 'data-testid': 'protein-element-no-item' },
+    })
+    
+    return Marionette.CollectionView.extend({
+        tagName: 'ul',
+        className: 'proteinelements clearfix',
+        attributes: { 'data-testid': 'protein-element-list' },
+        childView: UserItem,
+        emptyView: EmptyUserItem,
+        childViewOptions: function(model) {
+            return this.options
+        }
+    })
+})

--- a/client/src/js/modules/samples/views/pdbs.js
+++ b/client/src/js/modules/samples/views/pdbs.js
@@ -23,6 +23,7 @@ define(['marionette', 'backbone', 'utils'], function(Marionette, Backbone, utils
         },
 
         deletePDB: function(e) {
+            e.preventDefault()
             if (this.options.isLigand) {
                 var self = this
                 Backbone.ajax({

--- a/client/src/js/modules/samples/views/proteinview.js
+++ b/client/src/js/modules/samples/views/proteinview.js
@@ -15,6 +15,8 @@ define(['marionette',
 
     'collections/componenttypes',
     'collections/concentrationtypes',
+    'collections/elements',
+    'modules/samples/views/elements',
 
     'modules/dc/views/getdcview',
     
@@ -22,7 +24,7 @@ define(['marionette',
     'backbone', 'backbone-validation'
     ], function(Marionette, Editable, DCCol, DCView, Samples, SamplesView, Containers, ContainersView, 
         PDBs, PDBView, AddPDBView, 
-        ComponentTypes, ConcentrationTypes,
+        ComponentTypes, ConcentrationTypes, Elements, ElementsView,
         GetDCView,
         template, Backbone) {
 
@@ -32,8 +34,13 @@ define(['marionette',
         template: template,
         showContainers: true,
         
+        ui: {
+            userInput: '#element-search',
+        },
+
         regions: {
             pdb: '.pdb',
+            element: '.element',
             smp: '.samples',
             dc: '.datacollections',
             cont: '.conts',
@@ -41,9 +48,55 @@ define(['marionette',
         
         events: {
             'click a.add': 'addPDB',
+            'click .btn-add': 'onAddElement',
+            'keypress #element-search': 'onKeyPress',
+        },
+
+        onKeyPress: function(e) {
+            if (e.which === 13) { this.onAddElement() }
+        },
+
+        onAddElement: function() {
+            const userInput = this.ui.userInput.val().trim();
+            if (!userInput) { return }
+
+            const matchedElement = this.elements.find(function(model) {
+                return model.get('NAME').toLowerCase() === userInput.toLowerCase();
+            });
+
+            if (matchedElement) {
+                const exactDatabaseName = matchedElement.get('NAME');
+                const componentId = matchedElement.get('COMPONENTID');
+                const isAlreadyAdded = this.associatedElements.some(function(model) {
+                    return model.get('COMPONENTID') === componentId;
+                });
+
+                if (isAlreadyAdded) {
+                    app.alert({ message: exactDatabaseName + ' has already been added to this protein!' })
+                    this.ui.userInput.val('');
+                    return;
+                }
+
+                this.associatedElements.create({
+                    NAME: exactDatabaseName,
+                    COMPONENTID: componentId,
+                }, {
+                    wait: true,
+                    success: function(model, response) {
+                        app.message({ message: 'Element successfully added' })
+                    },
+                    error: function(model, xhr, options) {
+                        app.alert({ message: 'Failed to save element to database. Please try again.' })
+                    }
+                });
+            } else {
+                app.alert({ message: 'Invalid chemical element' })
+            }
+            this.ui.userInput.val('');
         },
         
-        addPDB: function() {
+        addPDB: function(e) {
+            e.preventDefault()
             var view = new AddPDBView({ pid: this.model.get('PROTEINID') })
             this.listenTo(view, 'pdb:success', this.getPDBs)
             app.dialog.show(view)
@@ -52,10 +105,14 @@ define(['marionette',
         getPDBs: function() {
             this.pdbs.fetch()
         },
-        
+
+        getAssociatedElements: function() {
+            this.associatedElements.fetch()
+        },
+
         initialize: function(options) {
             Backbone.Validation.bind(this);
-            
+
             this.types = new ComponentTypes()
             this.tr = this.types.fetch()
 
@@ -72,6 +129,12 @@ define(['marionette',
             
             this.pdbs = new PDBs(null, { pid: this.model.get('PROTEINID') })
             this.getPDBs()
+
+            this.elements = new Elements()
+            this.elements.fetch()
+
+            this.associatedElements = new Elements(null, { pid: this.model.get('PROTEINID') })
+            this.getAssociatedElements()
 
             if (this.getOption('showContainers')) {
                 this.containers = new Containers()
@@ -103,6 +166,7 @@ define(['marionette',
             // var GetDCView = require('modules/dc/views/getdcview')
 
             this.pdb.show(new PDBView({ collection: this.pdbs }))
+            this.element.show(new ElementsView({ collection: this.associatedElements }))
             this.smp.show(GetSampleView.SampleList.get(app.type, { collection: this.samples, noPageUrl: true, noFilterUrl: true, noSearchUrl: true }))
             this.dc.show(GetDCView.DCView.get(app.type, { model: this.model, collection: this.dcs, params: { visit: null }, noPageUrl: true, noFilterUrl: true, noSearchUrl: true }))
             if (this.getOption('showContainers')) this.cont.show(new ContainersView({ collection: this.containers, params: {} }))

--- a/client/src/js/templates/samples/protein.html
+++ b/client/src/js/templates/samples/protein.html
@@ -34,12 +34,12 @@
                   This sequence will be used for the model building step of any Big EP phasing runs.
                 </span>
             </label>
-            <div  data-testid="protein-sequence" class="SEQUENCE seq text tw-inline-block tw-w-2/3"><%=SEQUENCEMD%></div>
+            <div data-testid="protein-sequence" class="SEQUENCE seq text tw-inline-block tw-w-2/3"><%=SEQUENCEMD%></div>
         </li>
         
         <li>
             <span class="label">Component Type</span>
-            <span  data-testid="protein-component-type" class="COMPONENTTYPEID"><%-COMPONENTTYPE%></span>
+            <span data-testid="protein-component-type" class="COMPONENTTYPEID"><%-COMPONENTTYPE%></span>
         </li>
 
         <li>
@@ -50,6 +50,15 @@
         <li>
             <span class="label">Global</span>
             <span data-testid="protein-global" class="GLOBAL"><%-GLOBAL==1 ? 'Yes' : 'No' %></span>
+        </li>
+
+        <li>
+            <label>
+                <span class="label">Associated Elements</span>
+                <input type="text" id="element-search" placeholder="Type e.g., C, H, N, O..." autocomplete="off" />
+                <button type="button" class="btn-add button">Add</button>
+            </label>
+            <span class="element floated"></span>
         </li>
         
         <li class="clearfix">
@@ -63,7 +72,6 @@
                 <a href="#" data-testid="protein-add-pdb-button" class="button add"><i class="fa fa-plus"></i> Add PDB File</a>
             </label>
             <span class="pdb floated">
-                <ul class="visits clearfix"></ul>
             </span>
         </li>
         


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2174](https://jira.diamond.ac.uk/browse/LIMS-2174)

**Summary**:

Now that we have a Protein_has_Component table (https://github.com/DiamondLightSource/ispyb-database/pull/318), and each element is a component, we would like a way for each protein to be associated with some elements via Synchweb. Needs to be quick to type in, not just select from a 118 element dropdown.

**Changes**:
- Add access to Component and Protein_has_Component tables
- Add endpoints for getting a list of elements (either all, or those attached to a protein), adding an element to a protein, and removing an element from a protein
- Add a new Backbone collection for elements, and modified CSS to display it
- Add a textbox to add new elements to a protein, with an add button (or use the enter key)
- Stop the (similar) add PDB box from scrolling to the top of the page

**To test**:
- Go to any proposal, then go to proteins, then go to any protein, eg /proteins/pid/635322
- Add and delete elements from the protein (using 1 or 2 letter codes eg H, C, Se), check they appear correctly and persevere after a refresh
- Check a sensible message appears when there are no associated elements
