### PR TITLE
LIMS-2206: Assume DHL when no courier specified

### DIFF
--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1703,7 +1703,7 @@ class Shipment extends Page
         }
 
         $dewar = $this->db->pq(
-            "SELECT d.trackingnumbertosynchrotron,d.trackingnumberfromsynchrotron, LOWER(s.deliveryagent_agentname) as deliveryagent_agentname
+            "SELECT d.trackingnumbertosynchrotron,d.trackingnumberfromsynchrotron, LOWER(IFNULL(s.deliveryagent_agentname, '')) as deliveryagent_agentname
             FROM dewar d 
             INNER JOIN shipping s ON s.shippingid = d.shippingid 
             INNER JOIN proposal p ON p.proposalid = s.proposalid
@@ -1725,7 +1725,7 @@ class Shipment extends Page
 
         $delivery_agent = $dewar['DELIVERYAGENT_AGENTNAME'];
 
-        if ($delivery_agent == 'dhl') {
+        if ($delivery_agent == 'dhl' || $delivery_agent == '') {
             $tracking_history = $this->_dhl_dewar_tracking($tracking_number);
             $this->_output($tracking_history);
         } else {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2206](https://jira.diamond.ac.uk/browse/LIMS-2206)

**Summary**:

When the shipping service is used, it doesn't specify a courier when sending data back to ispyb. If Synchweb is trying to track a shipment, and the courier is blank, we should assume DHL. There is a check for the correct number of digits anyway.

**Changes**:
- Assume DHL if courier is blank or null

**To test**:
- This has been deployed to ispyb-dev-3, complete with DHL credentials
- Go to a recently shipped DHL dewar eg /shipments/sid/80525
- Check tracking is working, eg
<img width="899" height="353" alt="image" src="https://github.com/user-attachments/assets/fcb34617-1fd3-4d9a-a24e-ab8ffdddf40c" />

- Set the courier blank and repeat the check, ie 

`update Shipping set deliveryAgent_agentName="" where shippingId=80525;`
 
- Set the courier to NULL and repeat the check, ie

`update Shipping set deliveryAgent_agentName=NULL where shippingId=80525;`

