### PR TITLE
LIMS-2208: Show dose on UDC strategy results

### DIFF
--- a/api/src/Page/DC.php
+++ b/api/src/Page/DC.php
@@ -1171,7 +1171,7 @@ class DC extends Page
         global $strat_align;
 
         $rows = $this->db->pq("SELECT s.programversion, s.comments,
-                st.rankingresolution as rankres,
+                st.rankingresolution as rankres, sssw.dosetotal, st.screeningstrategyid,
                 ssw.wedgenumber, ssw.chi, ssw.kappa, ssw.phi, ssw.comments as sswcomments,
                 sssw.subwedgenumber, sssw.axisstart as st, sssw.exposuretime as time, sssw.transmission as tran,
                 sssw.oscillationrange as oscran, sssw.resolution as res, sssw.numberofimages as nimg, sssw.rotationaxis,
@@ -1199,6 +1199,7 @@ class DC extends Page
                 $output[$t] = array('CELL' => array(), 'STRATS' => array());
 
             $r['ATRAN'] = $r['TRAN'] / 100.0 * $r['DCTRN'];
+            $r['ROTATION'] = $r['NIMG'] * $r['OSCRAN'];
             foreach ($nf as $nff => $cols) {
                 foreach ($cols as $c) {
                     $r[$c] = number_format($r[$c], $nff);

--- a/client/src/css/partials/_content.scss
+++ b/client/src/css/partials/_content.scss
@@ -866,6 +866,11 @@ li:last-child .visit_users {
         table {
             tr {
                 cursor: pointer;
+
+                &.highlight {
+                    background-color: #f7f7f7;
+                }
+
                 &:hover {
                     background: $content-sub-hover-background;
                 }

--- a/client/src/js/templates/dc/dc_strategy.html
+++ b/client/src/js/templates/dc/dc_strategy.html
@@ -2,29 +2,29 @@
 <h2><%-TYPE%></h2>
 
 <%
-    var showUnitCell = CELL && (CELL.SG || CELL.A || CELL.B || CELL.C || CELL.AL || CELL.BE || CELL.GA)
-    var showChi = _.some(STRATS, function(r) {
+    const showUnitCell = CELL && (CELL.SG || CELL.A || CELL.B || CELL.C || CELL.AL || CELL.BE || CELL.GA)
+    const showChi = STRATS.some(function(r) {
         return r.CHI && parseFloat(r.CHI) !== 0
     })
-    var showPhi = _.some(STRATS, function(r) {
+    const showPhi = STRATS.some(function(r) {
         return r.PHI && parseFloat(r.PHI) !== 0
     })
-    var showKappa = _.some(STRATS, function(r) {
+    const showKappa = STRATS.some(function(r) {
         return r.KAPPA && parseFloat(r.KAPPA) !== 0
     })
-    var showRankingRes = _.some(STRATS, function(r) {
+    const showRankingRes = STRATS.some(function(r) {
         return r.RANKRES && parseFloat(r.RANKRES) !== 0
     })
-    var showExposure = _.some(STRATS, function(r) {
+    const showExposure = STRATS.some(function(r) {
         return r.TIME && parseFloat(r.TIME) !== 0
     })
-    var showDose = _.some(STRATS, function(r) {
+    const showDose = STRATS.some(function(r) {
         return r.DOSETOTAL && parseFloat(r.DOSETOTAL) !== 0
     })
 
-    var displayAxis = "Axis"
+    let displayAxis = "Axis"
     if (STRATS && STRATS.length > 0 && STRATS[0].ROTATIONAXIS) {
-        var raw = STRATS[0].ROTATIONAXIS
+        let raw = STRATS[0].ROTATIONAXIS
         displayAxis = raw.charAt(0).toUpperCase() + raw.slice(1)
     }
 %>
@@ -81,10 +81,10 @@
     </thead>
     
     <%
-    var highlight = true;
-    var lastId = null;
+    let highlight = true;
+    let lastId = null;
 
-    _.each(STRATS, function(r, i) {
+    STRATS.forEach((r, i) => {
         if (r.SCREENINGSTRATEGYID !== lastId) {
             highlight = !highlight;
             lastId = r.SCREENINGSTRATEGYID;

--- a/client/src/js/templates/dc/dc_strategy.html
+++ b/client/src/js/templates/dc/dc_strategy.html
@@ -15,6 +15,12 @@
     var showRankingRes = _.some(STRATS, function(r) {
         return r.RANKRES && parseFloat(r.RANKRES) !== 0
     })
+    var showExposure = _.some(STRATS, function(r) {
+        return r.TIME && parseFloat(r.TIME) !== 0
+    })
+    var showDose = _.some(STRATS, function(r) {
+        return r.DOSETOTAL && parseFloat(r.DOSETOTAL) !== 0
+    })
 
     var displayAxis = "Axis"
     if (STRATS && STRATS.length > 0 && STRATS[0].ROTATIONAXIS) {
@@ -66,15 +72,25 @@
             <% if (showKappa) { %> <th>Kappa (°)</th> <% } %>
             <th>Res (&#197;)</th>
             <% if (showRankingRes) { %> <th>Ranking Res (&#197;)</th> <% } %>
-            <th>Rel Trn (%)</th>
-            <th>Abs Trn (%)</th>
-            <th>Exposure (s)</th>
+            <th><% if (showDose) { %> Max <% } %>Transmission (%)</th>
+            <% if (showExposure) { %> <th>Exposure (s)</th> <% } %>
             <th>No. Images</th>
+            <th>Total Rotation (°)</th>
+            <% if (showDose) { %> <th>Dose (MGy)</th> <% } %>
         </tr>
     </thead>
     
-    <% _.each(STRATS, function(r, i) { %>
-    <tr class="stratrow" draggable="true" sid="<%-i%>">
+    <%
+    var highlight = true;
+    var lastId = null;
+
+    _.each(STRATS, function(r, i) {
+        if (r.SCREENINGSTRATEGYID !== lastId) {
+            highlight = !highlight;
+            lastId = r.SCREENINGSTRATEGYID;
+        }
+    %>
+    <tr class="stratrow <%= highlight ? 'highlight' : '' %>" draggable="true" sid="<%-i%>">
         <td><%-r.COM%></td>
         <td><%-r.COMMENTS%></td>
         <td><%-r.ST%></td>
@@ -84,10 +100,11 @@
         <% if (showKappa) { %> <td><%-r.KAPPA%></td> <% } %>
         <td><%-r.RES%></td>
         <% if (showRankingRes) { %> <td><%-r.RANKRES%></td> <% } %>
-        <td><%-r.TRAN%></td>
         <td><%-r.ATRAN%></td>
-        <td><%-r.TIME%></td>
+        <% if (showExposure) { %> <td><%-r.TIME%></td> <% } %>
         <td><%-r.NIMG%></td>
+        <td><%-r.ROTATION%></td>
+        <% if (showDose) { %> <td><%-r.DOSETOTAL%></td> <% } %>
     </tr>
     <% }) %>
 </table>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2208](https://jira.diamond.ac.uk/browse/LIMS-2208)

**Summary**:

Add some more details to the UDC Strategy results

**Changes**:
- Display subwedge dose if non-zero, and hide exposure time if zero
- Show the total rotation as well as per image rotation
- Hide the 'relative transmission' column, only show 'absolute transmission', rename as '(Max) transmission'.
- Add some highlighting to rows to show which wedges belong together

**To test**:
- Go to a data collection with a result from the UDC strategy, eg /dc/visit/nt44198-3/id/23192087
- Open the Strategies bar to display the UDC Strategy results
- Check total rotation, max transmission and dose are displayed
- Check relative transmission and exposure time are hidden
- Check the 'Native' wedges are coloured slightly darker to show they belong together
