### PR TITLE
LIMS-2205: Allow incoming EU shipments to be booked via the shipping service

### DIFF
--- a/api/config_sample.php
+++ b/api/config_sample.php
@@ -266,6 +266,7 @@
     $use_shipping_service = null;
     $use_shipping_service_nde = False;
     $use_shipping_service_incoming_shipments = null;
+    $use_shipping_service_incoming_shipments_nde = False;
     $use_shipping_service_redirect = null;
     $use_shipping_service_redirect_incoming_shipments = null;
     $shipping_service_api_user = null;

--- a/api/index.php
+++ b/api/index.php
@@ -72,7 +72,7 @@ function setupApplication($mode): Slim
             $visit_persist_storage_dir_segment, $dhl_enable, $scale_grid, $scale_grid_end_date, $preset_proposal, $timezone,
             $valid_components, $enabled_container_types, $synchweb_version, $redirects,
             $shipping_service_app_url, $use_shipping_service_redirect, $use_shipping_service_redirect_incoming_shipments,
-            $use_shipping_service_nde,
+            $use_shipping_service_nde, $use_shipping_service_incoming_shipments_nde,
             $dials_rest_url_rings, $closed_proposal_link, $ccp4_cloud_upload_url,
             $only_staff_can_assign, $industrial_prop_codes, $upstream_reprocessing_pipelines, $downstream_reprocessing_pipelines,
             $prop_codes_data_deleted, $container_types_with_parents, $bl_capacity;
@@ -103,6 +103,7 @@ function setupApplication($mode): Slim
             'shipping_service_app_url' => $use_shipping_service_redirect ? $shipping_service_app_url : null,
             'shipping_service_app_url_incoming' => $use_shipping_service_redirect_incoming_shipments ? $shipping_service_app_url : null,
             'use_shipping_service_nde' => $use_shipping_service_nde,
+            'use_shipping_service_incoming_shipments_nde' => $use_shipping_service_incoming_shipments_nde,
             'dials_rest_url_rings' => $dials_rest_url_rings,
             'closed_proposal_link' => $closed_proposal_link,
             'ccp4_cloud_upload_url' => $ccp4_cloud_upload_url,

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -1098,19 +1098,23 @@ class Shipment extends Page
             return $dewar['EXTERNALSHIPPINGIDFROMSYNCHROTRON'];
         }
 
-        $dewars = [$dewar];
-        $proposal = $dewar['PROPOSAL'];
-        $session_number = $dewar['VIS'];
-        $external_id = (int) $dewar['DEWARID'];
-        $shipping_id = (int) $dewar['SHIPPINGID'];
-        $token = Utils::generateRandomMd5();
-        $this->db->pq(
-            "UPDATE dewar SET extra = JSON_SET(IFNULL(extra, '{}'), '$.token', :1 ) WHERE dewarid=:2",
-            array($token, $external_id)
-        );
+        if (!is_null($dewar['EXTERNALSHIPPINGIDTOSYNCHROTRON']) && !is_null($dewar['TOKEN']) && $dewar['DCOUNT'] == 1) {
+            $external_shipping_id = $dewar['EXTERNALSHIPPINGIDTOSYNCHROTRON'];
+        } else {
+            $dewars = [$dewar];
+            $proposal = $dewar['PROPOSAL'];
+            $session_number = $dewar['VIS'];
+            $external_id = (int) $dewar['DEWARID'];
+            $shipping_id = (int) $dewar['SHIPPINGID'];
+            $token = Utils::generateRandomMd5();
+            $this->db->pq(
+                "UPDATE dewar SET extra = JSON_SET(IFNULL(extra, '{}'), '$.token', :1 ) WHERE dewarid=:2",
+                array($token, $external_id)
+            );
 
-        $callback_url = "/api/shipment/dewars/confirmdispatch/did/{$external_id}/token/{$token}";
-        $external_shipping_id = $this->_create_dewars_shipment_request($dewars, $proposal, $session_number, $external_id, $shipping_id, $callback_url);
+            $callback_url = "/api/shipment/dewars/confirmdispatch/did/{$external_id}/token/{$token}";
+            $external_shipping_id = $this->_create_dewars_shipment_request($dewars, $proposal, $session_number, $external_id, $shipping_id, $callback_url);
+        }
 
         $this->db->pq(
             "UPDATE dewar SET externalShippingIdFromSynchrotron=:1 WHERE dewarid=:2",
@@ -1214,7 +1218,9 @@ class Shipment extends Page
 
         $dew = $this->db->pq(
             "SELECT d.dewarid, d.barcode, d.storagelocation, d.dewarstatus, d.externalShippingIdFromSynchrotron,
+            s.externalshippingidtosynchrotron, json_unquote(json_extract(d.extra, '$.token')) as token,
             s.shippingid, p.proposalcode, CONCAT(p.proposalcode, p.proposalnumber) as proposal,
+            (SELECT COUNT(*) FROM dewar d2 WHERE d2.shippingid = s.shippingid) as dcount,
             count(distinct c.containerId) as num_pucks, count(b.blsampleId) as num_samples,
             ifnull(bls.visit_number, 0) as vis, IF(d.facilitycode, d.facilitycode, d.code) as name,
             dr.manufacturerserialnumber
@@ -3544,7 +3550,7 @@ class Shipment extends Page
     {
         global $dhl_service, $dhl_service_eu, $dhl_acc, $dhl_acc_import, $facility_courier_countries,
             $facility_courier_countries_nde, $use_shipping_service_incoming_shipments,
-            $use_shipping_service_redirect_incoming_shipments;
+            $use_shipping_service_incoming_shipments_nde, $use_shipping_service_redirect_incoming_shipments;
         if (!$this->has_arg('prop'))
             $this->_error('No proposal specified');
         if (!$this->has_arg('sid'))
@@ -3591,8 +3597,10 @@ class Shipment extends Page
         }
 
         if (
-            Utils::getValueOrDefault($use_shipping_service_incoming_shipments)
-            && in_array($this->arg('COUNTRY'), $facility_courier_countries)
+            ((Utils::getValueOrDefault($use_shipping_service_incoming_shipments)
+              && in_array($this->arg('COUNTRY'), $facility_courier_countries))
+            || (Utils::getValueOrDefault($use_shipping_service_incoming_shipments_nde)
+              && in_array($this->arg('COUNTRY'), $facility_courier_countries_nde)))
             && Utils::getValueOrDefault($use_shipping_service_redirect_incoming_shipments)
         ) {
             if ($ship['EXTERNALSHIPPINGIDTOSYNCHROTRON']) {

--- a/client/src/js/modules/shipment/views/createawb.js
+++ b/client/src/js/modules/shipment/views/createawb.js
@@ -520,7 +520,8 @@ define(['backbone',
                     if (
                         ss_url
                         && (Number(self.terms.get('ACCEPTED')) === 1) // terms.ACCEPTED could be undefined, 1, or "1"
-                        && app.options.get("facility_courier_countries").includes(country)
+                        && (app.options.get("facility_courier_countries").includes(country) ||
+                            app.options.get("facility_courier_countries_nde").includes(country))
                     ) {
                         self.shipment.fetch().done((shipment) => {
                             const external_id = shipment.EXTERNALSHIPPINGIDTOSYNCHROTRON;

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -246,6 +246,7 @@ define(['marionette',
             const safetylevel = this.model.get('SAFETYLEVEL')
             const externalid = this.model.get('EXTERNALSHIPPINGIDTOSYNCHROTRON')
             const shippingid = this.model.get('SHIPPINGID')
+            const dcount = this.model.get('DCOUNT')
             if (!courier || (app.options.get('dhl_enable') && courier.toLowerCase().trim() == 'dhl')) {
                 if (label == '1') {
                     this.ui.booking.html('<a class="button pdf" href="'+app.apiurl+'/pdf/awb/sid/'+shippingid+'"><i class="fa fa-print"></i> Print Air Waybill</a>')
@@ -253,11 +254,17 @@ define(['marionette',
                     if (!pickup) {
                         this.ui.booking.append('<a class="button awb" href="/shipments/pickup/sid/'+shippingid+'"><i class="fa fa-truck"></i> Rebook Pickup</a>')
                     }
-                } else if ((country && !fac_country.includes(country)) || safetylevel == "Red") {
-                    this.ui.booking.html('<a class="button" href="#"><i class="fa fa-credit-card"></i> Create Air Waybill - Disabled</a>')
                 } else if (externalid && ss_url) {
                     const link = ss_url+'/shipment-requests/'+externalid+'/incoming'
                     this.ui.booking.html('<a class="button shipping-service" href="'+link+'"><i class="fa fa-print"></i> Manage Shipment Booking</a>')
+                } else if (safetylevel && safetylevel == "Red") {
+                    this.ui.booking.html('<a class="button" href="#"><i class="fa fa-credit-card"></i> Create Air Waybill - Disabled</a>')
+                } else if (this.nde && (this.industrial_visit || dcount > 1 || !this.ss_nde_incoming)) {
+                    this.ui.booking.html('<a class="button" href="#"><i class="fa fa-credit-card"></i> Create Air Waybill - Disabled</a>')
+                } else if (this.nde) {
+                    this.ui.booking.html('<a class="button awb" href="/shipments/awb/sid/'+shippingid+'"><i class="fa fa-credit-card"></i> Request DHL Air Waybill</a>')
+                } else if (country && !fac_country.includes(country)) {
+                    this.ui.booking.html('<a class="button" href="#"><i class="fa fa-credit-card"></i> Create Air Waybill - Disabled</a>')
                 } else {
                     this.ui.booking.html('<a class="button awb" href="/shipments/awb/sid/'+shippingid+'"><i class="fa fa-credit-card"></i> Create DHL Air Waybill</a>')
                 }
@@ -272,23 +279,26 @@ define(['marionette',
                 const safetylevel = this.model.get('SAFETYLEVEL')
                 const country = this.model.get('COUNTRY')
                 const courier = this.model.get('DELIVERYAGENT_AGENTNAME')
-                const fac_country_nde = app.options.get('facility_courier_countries_nde')
-                const fac_country_link = app.options.get('facility_courier_countries_link')
                 const fac_country = app.options.get('facility_courier_countries')
                 const ss_url = app.options.get("shipping_service_app_url_incoming")
                 const externalid = this.model.get('EXTERNALSHIPPINGIDTOSYNCHROTRON')
+                const dcount = this.model.get('DCOUNT')
                 if (label == '1') {
                     this.ui.dhlmessage.html('<p class="message notify">You can print your Air Waybill by clicking &quot;Print Air Waybill&quot; below.</p>')
+                } else if (externalid && ss_url) {
+                    this.ui.dhlmessage.html('<p class="message notify">You can now manage your shipment with DHL using &quot;Manage Shipment Booking&quot; below.</p>')
                 } else if (safetylevel && safetylevel == "Red") {
                     this.ui.dhlmessage.html('<p class="message alert">Shipping of red samples is not available through this application.</p>')
-                } else if (country && fac_country_nde.includes(country) ) {
-                    this.ui.dhlmessage.html('<p class="message alert">International shipping is not available through this application. If you&apos;re arranging your own shipping (e.g. industrial users), enter your tracking numbers below after booking and include printed return labels in the dewar case. European academic users, please see <a href="'+fac_country_link+'">here</a>.</p>')
+                } else if (this.nde && (this.industrial_visit || !this.ss_nde_incoming)) {
+                    this.ui.dhlmessage.html('<p class="message alert">International shipping is not available through this application. If you&apos;re arranging your own shipping, enter your tracking numbers below after booking and include printed return labels in the dewar case.</p>')
+                } else if (this.nde && dcount > 1) {
+                    this.ui.dhlmessage.html('<p class="message alert">International shipping is not available where there is more than one dewar in the shipment</p>')
+                } else if (this.nde) {
+                    this.ui.dhlmessage.html('<p class="message notify">You can now request your shipment with DHL using &quot;Request Air Waybill&quot; below.</p>')
                 } else if (country && !fac_country.includes(country) ) {
                     this.ui.dhlmessage.html('<p class="message alert">International shipping is not available through this application. If you&apos;re arranging your own shipping, enter your tracking numbers below after booking and include printed return labels in the dewar case.</p>')
                 } else if (courier && courier.toLowerCase().trim() != 'dhl') {
                     this.ui.dhlmessage.html('<p class="message alert">Shipping through this application is only available using DHL.</p>')
-                } else if (externalid && ss_url) {
-                    this.ui.dhlmessage.html('<p class="message notify">You can now manage your shipment with DHL using &quot;Manage Shipment Booking&quot; below.</p>')
                 } else {
                     this.ui.dhlmessage.html('<p class="message notify">You can now book your shipment with DHL using &quot;Create Air Waybill&quot; below.</p>')
                 }
@@ -324,7 +334,12 @@ define(['marionette',
                     this.$el.find(".remoteform").show()
                 }
             }
-            if (dynamic === 'Ready' || (app.proposal && app.proposal.get('ACTIVE') != '1')) {
+
+            if (
+                dynamic === 'Ready' ||
+                (app.proposal && app.proposal.get('ACTIVE') != '1') ||
+                (this.termsaccepted && this.nde && this.ss_nde_incoming)
+            ) {
                 this.ui.add_dewar.hide()
             } else {
                 this.ui.add_dewar.show()
@@ -393,6 +408,12 @@ define(['marionette',
             this.edit.create("ONSITEUSERS", 'text', { placeholder: 'No' });
             this.edit.create("MULTIAXISGONIOMETRY", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
 
+            this.termsaccepted = this.model.get('TERMSACCEPTED') == 1
+            const country = this.model.get('COUNTRY')
+            const fac_country_nde = app.options.get('facility_courier_countries_nde')
+            this.ss_nde_incoming = app.options.get('use_shipping_service_incoming_shipments_nde')
+            this.nde = country && fac_country_nde.includes(country)
+
             this.updateGUI()
             this.listenTo(this.model, "change", this.updateGUI)
 
@@ -406,9 +427,8 @@ define(['marionette',
             })
 
             const externalid = this.model.get('EXTERNALSHIPPINGIDTOSYNCHROTRON')
-            const termsaccepted = this.model.get('TERMSACCEPTED') == 1
             const ss_url = app.options.get("shipping_service_app_url_incoming")
-            if (ss_url && (externalid || termsaccepted)) {
+            if (ss_url && (externalid || this.termsaccepted)) {
                 this.ui.courierfields.hide()
             }
         },

--- a/client/src/js/modules/shipment/views/shipment.js
+++ b/client/src/js/modules/shipment/views/shipment.js
@@ -225,7 +225,12 @@ define(['marionette',
             const sendingId = this.model.get('SENDINGLABCONTACTID')
             if (!sendingId || !this.contacts || !this.contacts.length) return
             const contact = this.contacts.findWhere({ LABCONTACTID: sendingId })
-            if (contact) this.model.set('COUNTRY', contact.get('COUNTRY'))
+            if (contact) {
+                const country = contact.get('COUNTRY')
+                this.model.set('COUNTRY', country)
+                const fac_country_nde = app.options.get('facility_courier_countries_nde')
+                this.nde = country && fac_country_nde.includes(country)
+            }
         },
 
         showButtons: function() {
@@ -409,21 +414,15 @@ define(['marionette',
             this.edit.create("MULTIAXISGONIOMETRY", 'select', { data: {'Yes': 'Yes', 'No': 'No'}})
 
             this.termsaccepted = this.model.get('TERMSACCEPTED') == 1
-            const country = this.model.get('COUNTRY')
-            const fac_country_nde = app.options.get('facility_courier_countries_nde')
             this.ss_nde_incoming = app.options.get('use_shipping_service_incoming_shipments_nde')
-            this.nde = country && fac_country_nde.includes(country)
 
-            this.updateGUI()
             this.listenTo(this.model, "change", this.updateGUI)
 
-            
-            var self = this
             this.contacts = new LabContacts(null, { state: { pageSize: 9999 } })
-            this.contacts.fetch().done(function() {
-                console.log(self.contacts, self.contacts.kv())
-                self.edit.create('SENDINGLABCONTACTID', 'select', { data: self.contacts.kv() })
-                self.edit.create('RETURNLABCONTACTID', 'select', { data: self.contacts.kv() })
+            this.contacts.fetch().done(() => {
+                this.edit.create('SENDINGLABCONTACTID', 'select', { data: this.contacts.kv() })
+                this.edit.create('RETURNLABCONTACTID', 'select', { data: this.contacts.kv() })
+                this.updateGUI()
             })
 
             const externalid = this.model.get('EXTERNALSHIPPINGIDTOSYNCHROTRON')

--- a/client/src/js/modules/shipment/views/shipmentadd.js
+++ b/client/src/js/modules/shipment/views/shipmentadd.js
@@ -130,6 +130,12 @@ define(['marionette', 'views/form',
             this.model.set({ TERMSACCEPTED: 1 })
             this.ui.accountnumber.val('')
             this.ui.couriername.val('')
+            const lc = this.contacts.findWhere({ LABCONTACTID: this.ui.lcout.val() })
+            const nde = app.options.get('facility_courier_countries_nde').indexOf(lc.get('COUNTRY')) > -1
+            const ss_nde_incoming = app.options.get('use_shipping_service_incoming_shipments_nde')
+            if (nde && ss_nde_incoming) {
+                this.setMaxDewarsPerShipment()
+            }
         },
 
         addLC: function(e) {
@@ -326,9 +332,12 @@ define(['marionette', 'views/form',
             const industrial_visit = industrial_codes.includes(app.prop.slice(0,2))
 
             const lc = this.contacts.findWhere({ LABCONTACTID: this.ui.lcout.val() })
-            const countryOk = app.options.get('facility_courier_countries').indexOf(lc.get('COUNTRY')) > -1 || app.options.get('facility_courier_countries_nde').indexOf(lc.get('COUNTRY')) > -1
+            const domestic = app.options.get('facility_courier_countries').indexOf(lc.get('COUNTRY')) > -1
+            const nde = app.options.get('facility_courier_countries_nde').indexOf(lc.get('COUNTRY')) > -1
+            const countryOk = domestic || nde
 
             const usingFacilityAccount = this.model.get('TERMSACCEPTED') === 1
+            const ss_nde_incoming = app.options.get('use_shipping_service_incoming_shipments_nde')
 
             if (countryOk && !industrial_visit && !usingFacilityAccount) {
                 this.ui.facc.show()
@@ -341,6 +350,22 @@ define(['marionette', 'views/form',
                 this.ui.accmsg.text('')
                 this.model.set({ TERMSACCEPTED: 0 })
             }
+
+            if (nde && ss_nde_incoming && usingFacilityAccount) {
+                this.setMaxDewarsPerShipment()
+            } else {
+                this.ui.dewars.prop('disabled', false)
+            }
+
+        },
+
+        setMaxDewarsPerShipment: function() {
+            if (this.ui.dewars.val() > 1) {
+                this.ui.dewars.val(1)
+                this.updateFCodes()
+                app.alert({ message: 'For international shipping we are limited to 1 dewar per shipment'})
+            }
+            this.ui.dewars.prop('disabled', true)
         },
         
         

--- a/client/src/js/templates/shipment/shipmentadd.html
+++ b/client/src/js/templates/shipment/shipmentadd.html
@@ -22,7 +22,7 @@
                 <label>Number of Dewars
                     <span class="small">Number of dewars to automatically create for this shipment</span>
                 </label>
-                <input type="text" name="DEWARS" value="1" data-testid="add-shipment-number" />
+                <input type="number" name="DEWARS" value="1" data-testid="add-shipment-number" />
             </li>
 
             <li class="d clearfix">


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2205](https://jira.diamond.ac.uk/browse/LIMS-2205)

**Summary**:

EU academic users should be able to use the shipping service for incoming dewars, albeit that it will just email James H and request him to make the booking. This should be behind a feature flag as we don't want to turn it on just yet.

**Changes**:
- Add a feature flag to use the shipping service for NDE (non-domestic European) incoming shipments
- If a shipment has only one dewar, and already has an incoming shipment request id, use the same id for outgoing
- Change the message displayed and enable the button to request an AWB on the View Shipment page (if EU and feature flag enabled)
- Limit shipments to 1 dewar if EU and using our courier (so that it always uses the same incoming and outgoing shipment request id)

**To test**:
- Add to the config if not already there
```
$use_shipping_service = True;
$use_shipping_service_nde = True;
$use_shipping_service_incoming_shipments = True;
$shipping_service_app_url = "https://sample-shipping-test.diamond.ac.uk";
$shipping_service_api_user = "synchweb";
$shipping_service_api_password = <redacted>;
# new
$use_shipping_service_incoming_shipments_nde = True;
```
- Go to an mx proposal, create a lab contact with an EU address
- Go to /shipments/add, and start creating a shipment. Choose UDC for the scheduling option as it doesn't ask any more questions.
- Select 2 dewars, choose the EU lab contact, then click "Use Facility Account", check a message appears saying you can only have 1 dewar, and the no of dewars box is now fixed at 1
- Click "Add Shipment", you should be taken to the View Shipment page, check the message says you can now request your shipment, and the "Request DHL Air Waybill" button is active
- Click "Request DHL Air Waybill", tick the box for the dewar, and click Proceed. Check you are taken to the (test) shipping service
- Fill in your address, choosing the same EU country, and a valid postcode and EORI number. Skip the collection required step, this will be removed (ULIMS-1350), click Submit, and then Done.
- You should be taken back to Synchweb, check the dewar status is 'awb requested'
- In a new tab visit https://sample-shipping-test.diamond.ac.uk/shipment-requests/ and check your shipment appears at the top as "Pending" for the incoming shipment
- ask Mark if he got an email asking to book the shipment, and if he can add a tracking number (2815193780 might work), the dewar status should update to "awb created", and the shipping service should describe it as "Booked"
- Back in Synchweb, request the dewar to come home by pressing "Dispatch", and then "Proceed", and go through the shipping service again
- Check the dewar status is back to "awb requested"
- Look again at https://sample-shipping-test.diamond.ac.uk/shipment-requests, check your shipment now has Booked and Pending for incoming and outgoing, but on the same shipment request id

- Set the config to have
```
$use_shipping_service_incoming_shipments_nde = False;
```
- Go to /shipments/add again, create an EU shipment with 2 dewars, now "Use facility account" should let you still use 2 dewars
- Check when you view the shipment it tells you you cannot use international shipping