### PR TITLE
LIMS-2231: Update Dimple filename

### DIFF
--- a/api/src/Downstream/Type/Dimple.php
+++ b/api/src/Downstream/Type/Dimple.php
@@ -43,7 +43,7 @@ class Dimple extends DownstreamPlugin {
             return;
         }
 
-        $lfs = $this->_get_attachments(null, null, 'refmac5_restr.log');
+        $lfs = $this->_get_attachments(null, null, 'refmac%_restr.log');
         if (sizeof($lfs)) {
             $lf = $lfs[0]['FILE'];
         } else {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2231](https://jira.diamond.ac.uk/browse/LIMS-2231)

**Summary**:

Phil has updated the ccp4 version to 9.0.015, which has picked up an update for dimple. Dimple now uses refmacat instead of refmac5 for the jelly and restr refinement, which breaks the SynchWeb display (the graph of R and Rfree vs cycle). SynchWeb gets data from a ##-refmac5_restr.log file, which will no longer be created. The file will instead have a filename in the format: ##-refmacat_restr.log. 

**Changes**:
- Change filename to include wildcard to match old and new style

**To test**:
- Go to /dc/visit/nt44198-1/id/23195581 (this has the new style), click on the Downstream Processing bar, select the Dimple tab. Check there are Initial and Final stats for eg R factor and R free.
- Go to an old data collection, eg /dc/visit/mx23694-161/id/23181413, and do the same check
