### PR TITLE
LIMS-2252: Disable 'Request Plate Imaging' button immediately

### DIFF
--- a/client/src/js/modules/shipment/views/containerplate.js
+++ b/client/src/js/modules/shipment/views/containerplate.js
@@ -532,7 +532,8 @@ define(['marionette',
                     INSPECTIONTYPEID: this.ui.ity.val(),
                 },
                 success: function() {
-                    app.alert({ message: 'Adhoc inspection successfully requested for this container' })
+                    app.message({ message: 'Adhoc inspection successfully requested for this container' })
+                    self.model.set('ALLOW_ADHOC', 0)
                     self.updateAdhoc()
                 },
                 error: function() {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2252](https://jira.diamond.ac.uk/browse/LIMS-2252)

**Summary**:

Somehow a user requested 2 adhoc plate imagings. The button disappears if you refresh the page, but we should make it disappear as soon as one is requested.

**Changes**:
- Edit the model before updating the button
- Make the success message be green not red

**To test**:
- Go to any plate with a previous imaging, eg /containers/cid/305691
- Click the small "Request Plate Imaging" button
- Check a green message appears
- Check the "Request Plate Imaging" button disappears, even before a refresh
