### PR TITLE
LIMS-2253: Disable DC parameters immediately after queueing plate

### DIFF
--- a/client/src/js/modules/imaging/views/queuecontainer.js
+++ b/client/src/js/modules/imaging/views/queuecontainer.js
@@ -240,6 +240,7 @@ define(['marionette',
             ExperimentCell.__super__.initialize.call(this,options)
 
             this.listenTo(this.model, 'change:EXPERIMENTKIND', this.render, this)
+            this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.render, this)
             this.listenTo(this.model, 'refresh', this.render, this)
 
             this.preSave = _.debounce(this.preSave, 1000)
@@ -330,6 +331,11 @@ define(['marionette',
             'Point': [{ name: 'Point Collection', type: 'SAD' }, { name: 'Fluorescence', type: 'XFE' }],
             'Region': [{ name: 'Grid Scan', type: 'MESH' }],
             'Line': [{ name: 'Line Scan', type: 'SAD' }],
+        },
+
+        initialize: function(options) {
+            ExperimentKindCell.__super__.initialize.call(this, options)
+            this.listenTo(this.model, 'change:CONTAINERQUEUEID', this.render, this)
         },
 
         render: function() {
@@ -681,11 +687,11 @@ define(['marionette',
                 },
                 success: function() {
                     app.message({ message: 'Container Successfully Unqueued' })
-                    self.ui.unqueuebutton.hide()
-                    self.ui.unqueuesamples.show()
-                    self.ui.queuebutton.show()
-                    self.ui.rpreset.show()
                     self.model.set('CONTAINERQUEUEID', null, { silent: true })
+                    self.typeselector.shadowCollection.each(function(m) {
+                        m.set('CONTAINERQUEUEID', null)
+                    })
+                    self.doOnRender()
                 },
                 error: function() {
                     app.alert({ message: 'Something went wrong unqueuing this container' })
@@ -807,11 +813,12 @@ define(['marionette',
                     },
                     success: function(json) {
                         app.message({ message: 'Container Successfully Queued' })
-                        self.ui.unqueuebutton.show()
-                        self.ui.unqueuesamples.hide()
-                        self.ui.queuebutton.hide()
-                        self.ui.rpreset.hide()
                         self.model.set('CONTAINERQUEUEID', json.CONTAINERQUEUEID, { silent: true })
+                        self.typeselector.shadowCollection.each(function(m) {
+                            m.set('CONTAINERQUEUEID', json.CONTAINERQUEUEID)
+                        })
+                        self.doOnRender()
+
                     },
                     error: function() {
                         app.alert({ message: 'Something went wrong queuing this container' })


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2253](https://jira.diamond.ac.uk/browse/LIMS-2253)

**Summary**:

When a plate is queued, the data collection parameters are not disabled until you refresh the page.

**Changes**:
- Make it so queueing or unqueueing the container re-renders the page, so the correct fields are disabled.

**To test**:
- Go to a plate with subsamples, then click "Prepare for Data Collection", to go to eg /containers/queue/305691
- Click the + button next to a subsample at the top, to add it to the list to be queued at the bottom
- Fill in the DC parameters, or select a preset and click Apply to All
- Click Queue Container at the bottom
- Check the Queue Container button disappears, and the Unqueue button at the top appears
- Check the DC parameters are disabled
- Click the Unqueue button at the top, check the reverse happens