### PR TITLE
LIMS-2269: Container History doesnt show beamline name

### DIFF
--- a/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
+++ b/client/src/js/modules/types/mx/shipment/views/mx-container-view.vue
@@ -347,7 +347,7 @@ export default {
         {key: 'BLTIMESTAMP', title: 'Date'},
         {key: 'STATUS', title: 'Status'},
         {key: 'LOCATION', title: 'Location'},
-        {key: 'BEAMLINELOCATION', title: 'Beamline'}
+        {key: 'BEAMLINENAME', title: 'Beamline'}
       ],
       containerHistoryTotal: 0,
       displayQueueModal: false,


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2269](https://jira.diamond.ac.uk/browse/LIMS-2269)

**Summary**:

When viewing a container, the history doesn't show the beamline correctly.

**Changes**:
- Rename field from BEAMLINELOCATION to BEAMLINENAME

**To test**:
- View any container, eg /containers/cid/382105
- Check the container history shows the beamline name in the "Beamline" column.
