### PR TITLE
LIMS-2282: Use the same callback URL for both incoming and outgoing dewars

### DIFF
--- a/api/src/Controllers/AuthenticationController.php
+++ b/api/src/Controllers/AuthenticationController.php
@@ -118,7 +118,7 @@ class AuthenticationController
             ($parts[0] == 'shipment' && $parts[1] == 'containers' && $parts[2] == 'history' && in_array($_SERVER["REMOTE_ADDR"], $bcr)) ||
 
                 # Allow shipping service to update dewar status
-            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && ($parts[2] == 'confirmdispatch' || $parts[2] == 'confirmpickup'))
+            ($parts[0] == 'shipment' && $parts[1] == 'dewars' && $parts[2] == 'confirm')
             )
             {
                 $need_auth = false;

--- a/api/src/Page/Shipment.php
+++ b/api/src/Page/Shipment.php
@@ -155,6 +155,7 @@ class Shipment extends Page
         'PROPOSALTYPE' => '\w+',
         'pickup_confirmation_code' => '\w+',
         'status' => '\w+',
+        'journey_type' => '\w+',
 
         'manifest' => '\d',
         'currentuser' => '\d',
@@ -210,8 +211,7 @@ class Shipment extends Page
 
         array('/dewars/transfer', 'post', '_transfer_dewar'),
         array('/dewars/dispatch', 'post', '_dispatch_dewar'),
-        array('/dewars/confirmdispatch/did/:did/token/:TOKEN', 'post', '_outgoing_shipment_confirmation'),
-        array('/dewars/confirmpickup/sid/:sid/token/:TOKEN', 'post', '_incoming_shipment_confirmation'),
+        array('/dewars/confirm/did/:did/token/:TOKEN', 'post', '_shipment_confirmation'),
 
         array('/dewars/tracking(/:DEWARID)', 'get', '_get_dewar_tracking'),
 
@@ -1109,7 +1109,7 @@ class Shipment extends Page
             array($token, $external_id)
         );
 
-        $callback_url = "/api/shipment/dewars/confirmdispatch/did/{$external_id}/token/{$token}";
+        $callback_url = "/api/shipment/dewars/confirm/did/{$external_id}/token/{$token}";
         $external_shipping_id = $this->_create_dewars_shipment_request($dewars, $proposal, $session_number, $external_id, $shipping_id, $callback_url);
 
         $this->db->pq(
@@ -1403,15 +1403,43 @@ class Shipment extends Page
         }
     }
 
-    function _outgoing_shipment_confirmation()
+    function _shipment_confirmation()
     {
+        if (!$this->has_arg('journey_type'))
+            $this->_error('No journey type specified');
         if (!$this->has_arg('did'))
             $this->_error('No dewar specified');
-        if (!$this->has_arg('TOKEN'))
-            $this->_error('No token specified');
         if (!$this->has_arg('status'))
             $this->_error('No status specified');
 
+        $dew = $this->db->pq(
+            "SELECT d.shippingid,
+                json_unquote(json_extract(d.extra, '$.token')) as token
+                FROM dewar d
+                WHERE d.dewarid=:1",
+            array($this->arg('did'))
+        );
+        if (!sizeof($dew))
+            $this->_error('No such dewar');
+        else
+            $dew = $dew[0];
+
+        if (!$this->has_arg('TOKEN') || $this->arg('TOKEN') !== $dew['TOKEN']) {
+            $this->_error('Incorrect token');
+        }
+
+        if ($this->arg('journey_type') === 'TO_FACILITY') {
+            $this->set_arg('sid', $dew['SHIPPINGID']);
+            $this->_incoming_shipment_confirmation();
+        } else if ($this->arg('journey_type') === 'FROM_FACILITY') {
+            $this->_outgoing_shipment_confirmation();
+        } else {
+            $this->_error('Invalid journey type');
+        }
+    }
+
+    function _outgoing_shipment_confirmation()
+    {
         if ($this->arg('status') === 'CREATED') {
             $this->_cancel_dispatch_dewar_confirmation();
         } else if ($this->arg('status') === 'BOOKED' || $this->arg('status') === 'PENDING') {
@@ -1563,13 +1591,6 @@ class Shipment extends Page
 
     function _incoming_shipment_confirmation()
     {
-        if (!$this->has_arg('sid'))
-            $this->_error('No shipment specified');
-        if (!$this->has_arg('TOKEN'))
-            $this->_error('No token specified');
-        if (!$this->has_arg('status'))
-            $this->_error('No status specified');
-
         if ($this->arg('status') === 'CREATED') {
             $this->_cancel_pickup_dewar_confirmation();
         } else if ($this->arg('status') === 'BOOKED' || $this->arg('status') === 'PENDING') {
@@ -3514,6 +3535,8 @@ class Shipment extends Page
     {
 
         $shipping_id = (int) $shipment['SHIPPINGID'];
+        // Any dewar id is ok for callback as it will be converted back to a shipping id
+        $dewar_id = (int) $dewars[0]['DEWARID'];
 
         $token = Utils::generateRandomMd5(7);
         $this->db->pq(
@@ -3521,7 +3544,7 @@ class Shipment extends Page
             array($token, $shipping_id)
         );
 
-        $callback_url = "/api/shipment/dewars/confirmpickup/sid/{$shipping_id}/token/{$token}";
+        $callback_url = "/api/shipment/dewars/confirm/did/{$dewar_id}/token/{$token}";
 
         $external_shipping_id = $this->_create_dewars_shipment_request(
             $dewars,


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2282](https://jira.diamond.ac.uk/browse/LIMS-2282)

**Summary**:

We currently have 2 separate callback URLs for the shipping service to use for incoming and outgoing shipments. We should combine them into one endpoint, and then figure out what is happening based on the `journey_type` sent in by the shipping service. This is needed so we can use the same shipment request for incoming and outgoing, which is needed for EU shipments.

**Changes**:
- Remove `confirmdispatch` and `confirmpickup` endpoints, add a single `confirm` endpoint, adjust the authentication to match
- Always use the same confirm endpoint, with a dewar id and token (for incoming, any dewar id in the shipment is fine)
- Create a new function to split requests depending on `journey_type`
- Move some of the checks for args into the new function

**To test**:
- Go to an mx proposal, eg mx23694, go to /shipments/add and create a shipment
  - Say it is for a UDC visit
  - Use a UK based Lab Contact
  - use the facility DHL account
- Once created, click "Create DHL Air Waybill" in the top right
- Tick the dewar and click "Proceed"
- Fill in the address in the shipping service, and accept the Ts & Cs, ask for a pick up, and then click "Submit"
- Once back in Synchweb, check the dewar now has status "pickup booked" and there is an incoming tracking number
- Now click "Dispatch" on the right hand side, and go through the shipping service to book the return (outgoing) shipment
- Once back in Synchweb, check the dewar status is "dispatch-booked" and there is an outgoing tracking number
